### PR TITLE
Fix CDK deployment

### DIFF
--- a/src/CDKPipelineApp.js
+++ b/src/CDKPipelineApp.js
@@ -167,6 +167,10 @@ async function createAWSpipelineCDK({
     CDKFile = CDKFile.replace( "const NEPTUNE_DB_NAME = '';",                `const NEPTUNE_DB_NAME = '${NEPTUNE_DB_NAME}';` );
     CDKFile = CDKFile.replace( "const NEPTUNE_TYPE = '';",                   `const NEPTUNE_TYPE = '${NEPTUNE_TYPE}';` );
     CDKFile = CDKFile.replace( "const NEPTUNE_DBSubnetGroup = null;",        `const NEPTUNE_DBSubnetGroup = '${NEPTUNE_DBSubnetGroup}';` );
+    if (neptuneClusterInfo) {
+        CDKFile = CDKFile.replace("const NEPTUNE_DBSubnetIds = null;",       `const NEPTUNE_DBSubnetIds = '${neptuneClusterInfo.dbSubnetIds}';`);
+        CDKFile = CDKFile.replace("const NEPTUNE_VpcSecurityGroupId = null;",`const NEPTUNE_VpcSecurityGroupId = '${neptuneClusterInfo.vpcSecurityGroupId}';`);
+    }
     CDKFile = CDKFile.replace( "const NEPTUNE_IAM_AUTH = false;",            `const NEPTUNE_IAM_AUTH = ${isNeptuneIAMAuth};` );    
     CDKFile = CDKFile.replace( "const NEPTUNE_IAM_POLICY_RESOURCE = '*';",   `const NEPTUNE_IAM_POLICY_RESOURCE = '${NEPTUNE_IAM_POLICY_RESOURCE}';` );
 

--- a/src/NeptuneSchema.js
+++ b/src/NeptuneSchema.js
@@ -15,7 +15,6 @@ import { aws4Interceptor } from "aws4-axios";
 import { fromNodeProviderChain  } from "@aws-sdk/credential-providers";
 import { NeptunedataClient, ExecuteOpenCypherQueryCommand } from "@aws-sdk/client-neptunedata";
 import { loggerDebug, loggerError, loggerInfo, yellow } from "./logger.js";
-import { parseNeptuneDomainFromHost, parseNeptuneGraphName } from "./util.js";
 import { ExecuteQueryCommand, GetGraphSummaryCommand, NeptuneGraphClient } from "@aws-sdk/client-neptune-graph";
 
 const NEPTUNE_DB = 'neptune-db';
@@ -25,7 +24,8 @@ const HTTP_LANGUAGE = 'openCypher';
 const NEPTUNE_GRAPH_LANGUAGE = 'OPEN_CYPHER';
 let HOST = '';
 let PORT = 8182;
-let REGION = ''
+let REGION = '';
+let DOMAIN = '';
 let SAMPLE = 5000;
 let NEPTUNE_TYPE = NEPTUNE_DB;
 let NAME = '';
@@ -331,12 +331,13 @@ async function getEdgesDirectionsCardinality() {
 }
 
 
-function setGetNeptuneSchemaParameters(host, port, region, neptuneType) {
-    HOST = host;
-    PORT = port;
-    REGION = region;
-    NEPTUNE_TYPE = neptuneType;
-    NAME = parseNeptuneGraphName(host);
+function setGetNeptuneSchemaParameters(neptuneInfo) {
+    HOST = neptuneInfo.host;
+    PORT = neptuneInfo.port;
+    REGION = neptuneInfo.region;
+    NEPTUNE_TYPE = neptuneInfo.neptuneType;
+    NAME = neptuneInfo.graphName;
+    DOMAIN = neptuneInfo.domain;
 }
 
 function getNeptunedataClient() {
@@ -354,7 +355,7 @@ function getNeptuneGraphClient() {
         loggerInfo('Instantiating NeptuneGraphClient')
         neptuneGraphClient = new NeptuneGraphClient({
             port: PORT,
-            host: parseNeptuneDomainFromHost(HOST),
+            host: DOMAIN,
             region: REGION,
             protocol: NEPTUNE_GRAPH_PROTOCOL,
         });

--- a/src/pipelineResources.js
+++ b/src/pipelineResources.js
@@ -330,19 +330,6 @@ async function createLambdaRole() {
 
 
     if (NEPTUNE_IAM_AUTH) {
-
-        let action = [];
-        if (NEPTUNE_TYPE === NEPTUNE_DB) {
-            action = [
-                "neptune-db:DeleteDataViaQuery",
-                "neptune-db:connect",
-                "neptune-db:ReadDataViaQuery",
-                "neptune-db:WriteDataViaQuery"
-            ];
-        } else {
-            action = ["neptune-graph:*"]
-        }
-
         // Create Neptune query policy
         startSpinner('Creating policy for Neptune queries', true);
         let policyName = NAME+"NeptuneQueryPolicy";
@@ -352,7 +339,12 @@ async function createLambdaRole() {
             Statement: [
                 {
                     Effect: "Allow",
-                    Action: action,
+                    Action: [
+                        NEPTUNE_TYPE + ':connect',
+                        NEPTUNE_TYPE + ':DeleteDataViaQuery',
+                        NEPTUNE_TYPE + ':ReadDataViaQuery',
+                        NEPTUNE_TYPE + ':WriteDataViaQuery'
+                    ],
                     Resource: NEPTUNE_IAM_POLICY_RESOURCE            
                 },
             ],

--- a/src/test/util.test.js
+++ b/src/test/util.test.js
@@ -1,37 +1,46 @@
-import {parseNeptuneDomainFromEndpoint, parseNeptuneDomainFromHost, parseNeptuneGraphName} from '../util.js';
+import {parseNeptuneDomainFromHost, parseNeptuneEndpoint} from '../util.js';
 
 test('parse domain from neptune cluster host', () => {
-    expect(parseNeptuneDomainFromHost('db-neptune-abc-def.cluster-xyz.us-west-2.neptune.amazonaws.com')).toBe('neptune.amazonaws.com');
+    expect(parseNeptuneDomainFromHost('db-neptune-abc-def.cluster-xyz.us-west-2.neptune.amazonaws.com'))
+        .toBe('neptune.amazonaws.com');
 });
 
 test('parse domain from neptune analytics host', () => {
-    expect(parseNeptuneDomainFromHost('g-abcdef.us-west-2.neptune-graph.amazonaws.com')).toBe('neptune-graph.amazonaws.com');
+    expect(parseNeptuneDomainFromHost('g-abcdef.us-west-2.neptune-graph.amazonaws.com'))
+        .toBe('neptune-graph.amazonaws.com');
 });
 
 test('parse domain from host without enough parts throws error', () => {
-    expect(() => parseNeptuneDomainFromHost('invalid.com')).toThrow('Cannot parse neptune host invalid.com because it has 2 part(s) delimited by . but expected at least 5');
+    expect(() => parseNeptuneDomainFromHost('invalid.com'))
+        .toThrow('Cannot parse neptune host invalid.com because it has 2 part(s) delimited by . but expected at least 5');
 });
 
-test('parse domain from neptune cluster endpoint', () => {
-    expect(parseNeptuneDomainFromEndpoint('db-neptune-abc-def.cluster-xyz.us-west-2.neptune.amazonaws.com:8182')).toBe('neptune.amazonaws.com');
+test('parse neptune db endpoint', () => {
+    let neptuneInfo = parseNeptuneEndpoint('db-neptune-abc-def.cluster-xyz.us-west-2.neptune.amazonaws.com:8182');
+    expect(neptuneInfo).toHaveProperty('port', '8182');
+    expect(neptuneInfo).toHaveProperty('host', 'db-neptune-abc-def.cluster-xyz.us-west-2.neptune.amazonaws.com');
+    expect(neptuneInfo).toHaveProperty('domain', 'neptune.amazonaws.com');
+    expect(neptuneInfo).toHaveProperty('region', 'us-west-2');
+    expect(neptuneInfo).toHaveProperty('graphName', 'db-neptune-abc-def');
+    expect(neptuneInfo).toHaveProperty('neptuneType', 'neptune-db');
 });
 
-test('parse domain from neptune analytics endpoint', () => {
-    expect(parseNeptuneDomainFromEndpoint('g-abcdef.us-west-2.neptune-graph.amazonaws.com:8182')).toBe('neptune-graph.amazonaws.com');
+test('parse neptune analytics endpoint', () => {
+    let neptuneInfo = parseNeptuneEndpoint('g-abcdef.us-east-1.neptune-graph.amazonaws.com:8183');
+    expect(neptuneInfo).toHaveProperty('port', '8183');
+    expect(neptuneInfo).toHaveProperty('host', 'g-abcdef.us-east-1.neptune-graph.amazonaws.com');
+    expect(neptuneInfo).toHaveProperty('domain', 'neptune-graph.amazonaws.com');
+    expect(neptuneInfo).toHaveProperty('region', 'us-east-1');
+    expect(neptuneInfo).toHaveProperty('graphName', 'g-abcdef');
+    expect(neptuneInfo).toHaveProperty('neptuneType', 'neptune-graph');
 });
 
-test('parse domain from endpoint without enough parts throws error', () => {
-    expect(() => parseNeptuneDomainFromEndpoint('g-abcdef.us-west-2.neptune-graph.amazonaws.com')).toThrow('Cannot parse domain from neptune endpoint g-abcdef.us-west-2.neptune-graph.amazonaws.com because it has 1 part(s) delimited by : but expected 2');
+test('parse neptune endpoint without port throws error', () => {
+    expect(() => parseNeptuneEndpoint('db-neptune-abc-def.cluster-xyz.us-west-2.neptune.amazonaws.com'))
+        .toThrow('Cannot parse neptune endpoint db-neptune-abc-def.cluster-xyz.us-west-2.neptune.amazonaws.com because it is not in expected format of host:port');
 });
 
-test('parse name from neptune cluster host', () => {
-    expect(parseNeptuneGraphName('db-neptune-abc-def.cluster-xyz.us-west-2.neptune.amazonaws.com')).toBe('db-neptune-abc-def');
-});
-
-test('parse name from neptune analytics host', () => {
-    expect(parseNeptuneGraphName('g-abcdef.us-west-2.neptune-graph.amazonaws.com')).toBe('g-abcdef');
-});
-
-test('parse name from host without enough parts throws error', () => {
-    expect(() => parseNeptuneGraphName('invalid.com')).toThrow('Cannot parse neptune host invalid.com because it has 2 part(s) delimited by . but expected at least 5');
+test('parse neptune endpoint not enough parts in domain throws error', () => {
+    expect(() => parseNeptuneEndpoint('invalid.com:1234'))
+        .toThrow('Cannot parse neptune host invalid.com because it has 2 part(s) delimited by . but expected at least 5');
 });

--- a/test/TestCases/Case06/Case06.02.test.js
+++ b/test/TestCases/Case06/Case06.02.test.js
@@ -1,0 +1,15 @@
+import {checkFileContains, readJSONFile} from '../../testLib';
+
+const casetest = readJSONFile('./test/TestCases/Case06/case.json');
+let neptuneType = 'neptune-db';
+if (casetest.host.includes('neptune-graph')) {
+    neptuneType = 'neptune-graph';
+}
+checkFileContains('./test/TestCases/Case06/output/AirportCDKTestJest-cdk.js', [
+    'const NAME = \'AirportCDKTestJest\';',
+    'const NEPTUNE_HOST = \'' + casetest.host + '\';',
+    'const NEPTUNE_PORT = \'' + casetest.port + '\';',
+    'const NEPTUNE_TYPE = \'' + neptuneType + '\';',
+    'vpcSubnets',
+    'securityGroups'
+]);

--- a/test/testLib.js
+++ b/test/testLib.js
@@ -34,7 +34,7 @@ function replacePlaceholderWithEnvironmentVariable(text, placeholder) {
         // remove angle brackets
         let envVarName = placeholder.replace(/[<>]/g, '');
         if (process.env[envVarName]) {
-            return text.replace(placeholder, process.env[envVarName]);
+            return text.replaceAll(placeholder, process.env[envVarName]);
         }
         throw new Error('Expected environment variable ' + envVarName + ' is not set');
     }
@@ -83,6 +83,15 @@ function checkOutputZipLambdaUsesSdk(outputFolder, zipFile) {
     test('Lambda uses SDK: ' + lambdaFile, async () => {
         expect(lambdaContent).toContain('@aws-sdk/client-neptune')
     });
+}
+
+function checkFileContains(outputFile, expectedContent = []) {
+    const fileContent = fs.readFileSync(outputFile, 'utf8');
+    expectedContent.forEach(expected => {
+        test(outputFile + ' contains text ' + expected, async () => {
+            expect(fileContent).toContain(expected);
+        });
+    })
 }
 
 async function loadResolver(file) {
@@ -140,4 +149,4 @@ async function testResolverQueriesResults(resolverFile, queriesReferenceFolder, 
 }
 
 
-export { readJSONFile, checkOutputFilesSize, checkOutputFilesContent, testResolverQueries, testResolverQueriesResults, checkOutputZipLambdaUsesSdk };
+export { readJSONFile, checkFileContains, checkOutputFilesSize, checkOutputFilesContent, testResolverQueries, testResolverQueriesResults, checkOutputZipLambdaUsesSdk };


### PR DESCRIPTION
Fixed CDK lambda function bugs which were causing timeout and unauthorized errors when using the deployed GraphQL API app:
- VPC config now has the appropriate subnets and security group configured
- policy actions now reference the correct aws service depending on the neptune type
- environment now references the correct region when the neptune type is neptune-graph
- refactored endpoint parsing to use new util function so that the logic is contained in place and parsing is done in one function call instead of sprinkled throughout the code
- added unit tests for endpoint parsing
- added integration test verification for CDK deployment to check that the generated CDK js file contains some expected content
