### PR TITLE
Configure pino to create the log file directory if it does not exist.

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -18,6 +18,7 @@ function loggerInit(directory, quiet = false, logLevel = 'info') {
                 target: 'pino-pretty',
                 options: {
                     destination: logFileDestination,
+                    mkdir: true,
                     colorize: false,
                     translateTime: 'yyyy-mm-dd HH:MM:ss',
                     ignore: 'pid,hostname'


### PR DESCRIPTION
Configure pino to create the log file directory if it does not exist by setting mkdir=true. Previously without this flag an error would occur when attempting to write to the log if the directory did not yet exist.