### PR TITLE
Fix for file logging errors in windows environments

### DIFF
--- a/src/pipelineResources.js
+++ b/src/pipelineResources.js
@@ -169,7 +169,8 @@ async function checkPipeline() {
     startSpinner('Checking for API...');
     const notFound = 'API not found';
     try {
-        const command = new ListGraphqlApisCommand({apiType: "GRAPHQL"});
+        // set maxResults to max allowed value as workaround until https://github.com/aws/amazon-neptune-for-graphql/issues/39 is addressed
+        const command = new ListGraphqlApisCommand({apiType: "GRAPHQL", maxResults: 25});
         const response = await appSyncClient.send(command);
         response.graphqlApis.forEach(element => {
             if (element.name == NAME + 'API') {


### PR DESCRIPTION
Fixes for file logging related errors in windows environments:
* replaced `:` and `.` characters in log file name with `-` as windows does not allow these characters in file names
* replaced usage of `pino.transport` with `pino.multistream` which resolved issue of log file being created with no content
