### PR TITLE
Alias edges with same label as a node

### DIFF
--- a/src/graphdb.js
+++ b/src/graphdb.js
@@ -9,7 +9,7 @@ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 */
-import { loggerInfo } from './logger.js';
+import { loggerDebug, loggerInfo } from './logger.js';
 
 let changeCase = true;
 
@@ -19,6 +19,7 @@ function checkForDuplicateNames(schema) {
         let pascalCase = toPascalCase(node.label);
         if (names.includes(pascalCase)) {            
             changeCase = false;
+            loggerDebug(`Node label '${node.label}' was detected as a duplicate. It is recommended to resolve duplicate labels.`, {toConsole: true});
         } else {
             names.push(pascalCase);             
         }
@@ -28,6 +29,7 @@ function checkForDuplicateNames(schema) {
         let pascalCase = toPascalCase(edge.label);
         if (names.includes(pascalCase)) {            
             changeCase = false;
+            loggerDebug(`Edge label '${edge.label}' was detected as a duplicate. It is recommended to resolve duplicate labels.`, {toConsole: true});
         } else {
             names.push(pascalCase);             
         }
@@ -192,10 +194,17 @@ function graphDBInferenceSchema (graphbSchema, addMutations) {
         r += '}\n\n';
     })
 
+    const nodeLabels = new Set(gdbs.nodeStructures.map((n) => n.label));
+
     // edge types
     gdbs.edgeStructures.forEach(edge => {
         // edge type
-        let edgeCase = cleanseLabel(edge.label);
+
+        // resolve potential conflict between the edge label and node label by prefixing with an underscore
+        let edgeCase = nodeLabels.has(edge.label)
+            ? `_${cleanseLabel(edge.label)}`
+            : cleanseLabel(edge.label);
+
         if (changeCase) {
             edgeCase = toPascalCase(edgeCase);
         }

--- a/src/test/graphdb.test.js
+++ b/src/test/graphdb.test.js
@@ -1,5 +1,6 @@
 import { graphDBInferenceSchema } from '../graphdb.js';
 import fs from "fs";
+import { loggerInit } from "../logger.js";
 
 test('node with same property and edge label should add underscore prefix', () => {
     expect(graphDBInferenceSchema(readFile('./src/test/node-edge-same-property-neptune-schema.json'), false)).toContain('_commonName:Commonname');
@@ -44,6 +45,13 @@ test('should output knowledge graph schema', () => {
 test('should output security graph schema', () => {
     const actual = inferGraphQLSchema('./src/test/security-neptune-schema.json');
     const expected = loadGraphQLSchema('./src/test/security.graphql')
+    expect(actual).toBe(expected);
+});
+
+test('should alias edge with same label as node', () => {
+    loggerInit('./src/test/output', false, 'info');
+    const actual = inferGraphQLSchema('./src/test/node-edge-same-label-neptune-schema.json');
+    const expected = loadGraphQLSchema('./src/test/node-edge-same-label.graphql')
     expect(actual).toBe(expected);
 });
 

--- a/src/test/node-edge-same-label-neptune-schema.json
+++ b/src/test/node-edge-same-label-neptune-schema.json
@@ -1,0 +1,40 @@
+{
+  "nodeStructures": [
+    {
+      "label": "post",
+      "properties": [
+        {
+          "name": "text",
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "label": "author",
+      "properties": [
+        {
+          "name": "username",
+          "type": "String"
+        }
+      ]
+    }
+  ],
+  "edgeStructures": [
+    {
+      "label": "author",
+      "properties": [
+        {
+          "name": "date",
+          "type": "Date"
+        }
+      ],
+      "directions": [
+        {
+          "from": "post",
+          "to": "author",
+          "relationship": "ONE-ONE"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/node-edge-same-label.graphql
+++ b/src/test/node-edge-same-label.graphql
@@ -1,0 +1,45 @@
+type post {
+    _id: ID! @id
+    text: String
+    author:author
+}
+
+input postInput {
+    _id: ID @id
+    text: String
+}
+
+type author {
+    _id: ID! @id
+    username: String
+    author:author
+}
+
+input authorInput {
+    _id: ID @id
+    username: String
+}
+
+type _author @alias(property:"author") {
+    _id: ID! @id
+    date: Date
+}
+
+input _authorInput {
+    date: Date
+}
+
+input Options {
+    limit:Int
+}
+
+type Query {
+    getNodepost(filter: postInput): post
+    getNodeposts(filter: postInput, options: Options): [post]
+    getNodeauthor(filter: authorInput): author
+    getNodeauthors(filter: authorInput, options: Options): [author]
+}
+
+schema {
+    query: Query
+}


### PR DESCRIPTION
Detect if there is an edge with the same label as a node and if so, create an alias in the graphQL schema by prefixing the edge label with an underscore. Without adding this alias the request to AWS to publish the graphQL API will fail as the schema will be invalid due to the duplication of types.
