### PR TITLE
Honour `@id` directive on type fields

### DIFF
--- a/src/schemaModelValidator.js
+++ b/src/schemaModelValidator.js
@@ -139,8 +139,7 @@ function addNode(def) {
     const idField = getIdField(def);
 
     // Create Input type
-    const inputFields = [idField, ...getInputFields(def)];
-    typesToAdd.push(`input ${name}Input {\n${print(inputFields)}\n}`);    
+    typesToAdd.push(`input ${name}Input {\n${print(getInputFields(def))}\n}`);    
 
     // Create query
     queriesToAdd.push(`getNode${name}(filter: ${name}Input, options: Options): ${name}\n`);
@@ -239,11 +238,18 @@ function idFieldToInputValue({ name, type }) {
 
 
 function getInputFields(objTypeDef) {
-    const inputFieldTypes = ['String', 'Int', 'Float', 'Boolean'];
-    return objTypeDef.fields.filter(
-        field =>
-            field.type.kind === 'NamedType' && inputFieldTypes.includes(field.type.name.value)
-    );
+    return objTypeDef.fields.filter(field => isScalar(nullable(field.type)));
+}
+
+
+function nullable(type) {
+    return type.kind === 'NonNullType' ? type.type : type;
+}
+
+
+function isScalar(type) {
+    const scalarTypes = ['String', 'Int', 'Float', 'Boolean', 'ID'];
+    return type.kind === 'NamedType' && scalarTypes.includes(type.name.value);
 }
 
 

--- a/src/test/directive-id.graphql
+++ b/src/test/directive-id.graphql
@@ -1,0 +1,9 @@
+type User {
+    userId: ID! @id
+    firstName: String
+    lastName: String
+}
+
+type Group {
+    name: String
+}

--- a/src/test/schemaModelValidator.test.js
+++ b/src/test/schemaModelValidator.test.js
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import { loggerInit } from '../logger.js';
+import { validatedSchemaModel } from '../schemaModelValidator.js';
+import { schemaParser } from '../schemaParser.js';
+
+describe('validatedSchemaModel', () => {
+    let model;
+
+    beforeAll(() => {
+        loggerInit('./output', false, 'silent');
+
+        const schema = readFileSync('./src/test/directive-id.graphql');
+        model = validatedSchemaModel(schemaParser(schema));
+    });
+
+    test('should only add _id field to object types without ID fields', () => {
+        const objTypeDefs = model.definitions.filter(def => def.kind === 'ObjectTypeDefinition');
+        const userType = objTypeDefs.find(def => def.name.value === 'User');
+        const groupType = objTypeDefs.find(def => def.name.value === 'Group');
+
+        const userIdFields = getIdFields(userType);
+        const groupIdFields = getIdFields(groupType);
+
+        expect(userIdFields).toHaveLength(1);
+        expect(groupIdFields).toHaveLength(1);
+        expect(userIdFields[0].name.value).toEqual('userId');
+        expect(groupIdFields[0].name.value).toEqual('_id');
+    });
+
+    test('should define the same ID fields on a type and its input type', () => {
+        const userType = model.definitions.find(
+            def =>
+                def.kind === 'ObjectTypeDefinition' && def.name.value === 'User'
+        );
+        const userInputType = model.definitions.find(
+            def =>
+                def.kind === 'InputObjectTypeDefinition' && def.name.value === 'UserInput'
+        );
+
+        const userIdFields = getIdFields(userType);
+        const userInputIdFields = getIdFields(userInputType);
+
+        expect(userIdFields).toHaveLength(1);
+        expect(userInputIdFields).toHaveLength(1);
+        expect(userIdFields[0].name.value).toEqual(userInputIdFields[0].name.value);
+    });
+
+    function getIdFields(objTypeDef) {
+        return objTypeDef.fields.filter(
+            field =>
+                field.directives.some(directive => directive.name.value === 'id')
+        );
+    }
+});

--- a/src/test/schemaModelValidator.test.js
+++ b/src/test/schemaModelValidator.test.js
@@ -28,21 +28,25 @@ describe('validatedSchemaModel', () => {
     });
 
     test('should define the same ID fields on a type and its input type', () => {
-        const userType = model.definitions.find(
-            def =>
-                def.kind === 'ObjectTypeDefinition' && def.name.value === 'User'
-        );
-        const userInputType = model.definitions.find(
-            def =>
-                def.kind === 'InputObjectTypeDefinition' && def.name.value === 'UserInput'
-        );
+        const typeNames = ['User', 'Group'];
 
-        const userIdFields = getIdFields(userType);
-        const userInputIdFields = getIdFields(userInputType);
+        typeNames.forEach(typeName => {
+            const type = model.definitions.find(
+                def =>
+                    def.kind === 'ObjectTypeDefinition' && def.name.value === typeName
+            );
+            const inputType = model.definitions.find(
+                def =>
+                    def.kind === 'InputObjectTypeDefinition' && def.name.value === `${typeName}Input`
+            );
 
-        expect(userIdFields).toHaveLength(1);
-        expect(userInputIdFields).toHaveLength(1);
-        expect(userIdFields[0].name.value).toEqual(userInputIdFields[0].name.value);
+            const idFields = getIdFields(type);
+            const inputIdFields = getIdFields(inputType);
+
+            expect(idFields).toHaveLength(1);
+            expect(inputIdFields).toHaveLength(1);
+            expect(idFields[0].name.value).toEqual(inputIdFields[0].name.value);
+        });
     });
 
     function getIdFields(objTypeDef) {


### PR DESCRIPTION
*Issue #, if available:* #59

*Description of changes:*

When the `@id` directive was specified on a field, it was ignored by `schemaModelValidator` which added a new ID field, resulting in 2 ID fields.

Now, the directive inference checks for the existence of an ID field before adding the default one.

- break out logic around ID/input fields into dedicated functions
- better inlining of input fields and values

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
