### PR TITLE
Retain numeric parameter value type when creating open cypher query 

### DIFF
--- a/templates/JSResolverOCHTTPSTemplate.js
+++ b/templates/JSResolverOCHTTPSTemplate.js
@@ -24,7 +24,7 @@ const schemaDataModel = JSON.parse(schemaDataModelJSON);
 const schema = buildASTSchema(schemaDataModel, { assumeValidSDL: true });
 
 
-function resolveGraphDBQueryFromAppSyncEvent(event) {        
+function resolveGraphDBQueryFromAppSyncEvent(event) {
     const fieldDef = getFieldDef(event.field);
 
     const args = [];
@@ -67,8 +67,8 @@ function resolveGraphDBQueryFromAppSyncEvent(event) {
     const graphQuery = resolveGraphDBQuery(obj);
     return graphQuery;
 }
-  
-  
+
+
 function resolveGraphDBQueryFromApolloQueryEvent(event) {
   // TODO
 }
@@ -749,6 +749,9 @@ function transformFunctionInputParameters(fields, schemaInfo) {
         fields.forEach(field => {
             if (field.name.value === arg.name) {
                 let value = field.value.value;
+                if (field.value.kind === 'IntValue' || field.value.kind === 'FloatValue') {
+                    value = Number(value);
+                }
                 if (arg.name === schemaInfo.graphDBIdArgName) {
                     r.graphIdValue = value
                 } else if (arg.alias != null) {

--- a/test/TestCases/Case01/Case01.05.test.js
+++ b/test/TestCases/Case01/Case01.05.test.js
@@ -57,6 +57,22 @@ describe('AppSync resolver', () => {
         });
     });
 
+    test('should resolve queries with a filter that contains numeric and string values', () => {
+        const result = resolve({
+            field: 'getNodeAirports',
+            arguments: { filter: { country: 'US', runways: 3 } },
+            selectionSetGraphQL: '{ city }'
+        });
+
+        expect(result).toEqual({
+            query: 'MATCH (getNodeAirports_Airport:`airport`{country: $getNodeAirports_Airport_country, runways: $getNodeAirports_Airport_runways})\n' +
+                'RETURN collect({city: getNodeAirports_Airport.`city`})',
+            parameters: { getNodeAirports_Airport_country: 'US',  getNodeAirports_Airport_runways: 3},
+            language: 'opencypher',
+            refactorOutput: null
+        });
+    });
+
     function resolve(event) {
         return resolverModule.resolveGraphDBQueryFromAppSyncEvent(event);
     }

--- a/test/TestCases/Case01/outputReference/output.resolver.graphql.cjs
+++ b/test/TestCases/Case01/outputReference/output.resolver.graphql.cjs
@@ -15,7 +15,7 @@ const gql = require('graphql-tag'); // GraphQL library to parse the GraphQL quer
 
 const useCallSubquery = false;
 
-// 2025-01-31T06:40:58.761Z
+// 2025-02-04T20:17:38.303Z
 
 const schemaDataModelJSON = `{
   "kind": "Document",
@@ -3475,7 +3475,7 @@ const schemaDataModel = JSON.parse(schemaDataModelJSON);
 const schema = buildASTSchema(schemaDataModel, { assumeValidSDL: true });
 
 
-function resolveGraphDBQueryFromAppSyncEvent(event) {        
+function resolveGraphDBQueryFromAppSyncEvent(event) {
     const fieldDef = getFieldDef(event.field);
 
     const args = [];
@@ -3518,8 +3518,8 @@ function resolveGraphDBQueryFromAppSyncEvent(event) {
     const graphQuery = resolveGraphDBQuery(obj);
     return graphQuery;
 }
-  
-  
+
+
 function resolveGraphDBQueryFromApolloQueryEvent(event) {
   // TODO
 }
@@ -4200,6 +4200,9 @@ function transformFunctionInputParameters(fields, schemaInfo) {
         fields.forEach(field => {
             if (field.name.value === arg.name) {
                 let value = field.value.value;
+                if (field.value.kind === 'IntValue' || field.value.kind === 'FloatValue') {
+                    value = Number(value);
+                }
                 if (arg.name === schemaInfo.graphDBIdArgName) {
                     r.graphIdValue = value
                 } else if (arg.alias != null) {

--- a/test/TestCases/Case01/outputReference/output.resolver.graphql.js
+++ b/test/TestCases/Case01/outputReference/output.resolver.graphql.js
@@ -15,7 +15,7 @@ const gql = require('graphql-tag'); // GraphQL library to parse the GraphQL quer
 
 const useCallSubquery = false;
 
-// 2025-01-31T06:40:58.760Z
+// 2025-02-04T20:17:38.302Z
 
 const schemaDataModelJSON = `{
   "kind": "Document",
@@ -3475,7 +3475,7 @@ const schemaDataModel = JSON.parse(schemaDataModelJSON);
 const schema = buildASTSchema(schemaDataModel, { assumeValidSDL: true });
 
 
-function resolveGraphDBQueryFromAppSyncEvent(event) {        
+function resolveGraphDBQueryFromAppSyncEvent(event) {
     const fieldDef = getFieldDef(event.field);
 
     const args = [];
@@ -3518,8 +3518,8 @@ function resolveGraphDBQueryFromAppSyncEvent(event) {
     const graphQuery = resolveGraphDBQuery(obj);
     return graphQuery;
 }
-  
-  
+
+
 function resolveGraphDBQueryFromApolloQueryEvent(event) {
   // TODO
 }
@@ -4200,6 +4200,9 @@ function transformFunctionInputParameters(fields, schemaInfo) {
         fields.forEach(field => {
             if (field.name.value === arg.name) {
                 let value = field.value.value;
+                if (field.value.kind === 'IntValue' || field.value.kind === 'FloatValue') {
+                    value = Number(value);
+                }
                 if (arg.name === schemaInfo.graphDBIdArgName) {
                     r.graphIdValue = value
                 } else if (arg.alias != null) {

--- a/test/TestCases/Case01/queries/Query0020.json
+++ b/test/TestCases/Case01/queries/Query0020.json
@@ -1,0 +1,18 @@
+{
+  "name": "Filter by parameter with numeric value and return mix of numeric value types",
+  "description": "",
+  "graphql": "query MyQuery {\n getNodeAirports(filter: { city: \"Seattle\", runways: 3 }) {\n code\n lat\n lon\n elev\n}\n }",
+  "parameters": {
+    "getNodeAirports_Airport_city": "Seattle",
+    "getNodeAirports_Airport_runways": 3
+  },
+  "resolved": "MATCH (getNodeAirports_Airport:`airport`{city: $getNodeAirports_Airport_city, runways: $getNodeAirports_Airport_runways})\nRETURN collect({code: getNodeAirports_Airport.`code`, lat: getNodeAirports_Airport.`lat`, lon: getNodeAirports_Airport.`lon`, elev: getNodeAirports_Airport.`elev`})",
+  "result": [
+    {
+      "code": "SEA",
+      "elev": 432,
+      "lon": -122.30899810791,
+      "lat": 47.4490013122559
+    }
+  ]
+}

--- a/test/TestCases/Case07/outputReference/output.resolver.graphql.js
+++ b/test/TestCases/Case07/outputReference/output.resolver.graphql.js
@@ -15,7 +15,7 @@ const gql = require('graphql-tag'); // GraphQL library to parse the GraphQL quer
 
 const useCallSubquery = false;
 
-// 2025-01-31T06:47:04.494Z
+// 2025-02-04T20:38:45.966Z
 
 const schemaDataModelJSON = `{
   "kind": "Document",
@@ -3507,7 +3507,7 @@ const schemaDataModel = JSON.parse(schemaDataModelJSON);
 const schema = buildASTSchema(schemaDataModel, { assumeValidSDL: true });
 
 
-function resolveGraphDBQueryFromAppSyncEvent(event) {        
+function resolveGraphDBQueryFromAppSyncEvent(event) {
     const fieldDef = getFieldDef(event.field);
 
     const args = [];
@@ -3550,8 +3550,8 @@ function resolveGraphDBQueryFromAppSyncEvent(event) {
     const graphQuery = resolveGraphDBQuery(obj);
     return graphQuery;
 }
-  
-  
+
+
 function resolveGraphDBQueryFromApolloQueryEvent(event) {
   // TODO
 }
@@ -4232,6 +4232,9 @@ function transformFunctionInputParameters(fields, schemaInfo) {
         fields.forEach(field => {
             if (field.name.value === arg.name) {
                 let value = field.value.value;
+                if (field.value.kind === 'IntValue' || field.value.kind === 'FloatValue') {
+                    value = Number(value);
+                }
                 if (arg.name === schemaInfo.graphDBIdArgName) {
                     r.graphIdValue = value
                 } else if (arg.alias != null) {


### PR DESCRIPTION
*Issue #:* https://github.com/aws/amazon-neptune-for-graphql/issues/64
*Description of changes:*

Numeric graphQL query parameter values were inadvertently being set as strings upon conversion to the equivalent open cypher query. Fixed `transformFunctionInputParameters` which converts the graphQL request fields into a parameters object by converting the field value to a `Number` if the type is `IntValue` or `FloatValue`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
