### PR TITLE
Add assertions and type safety after #61

### DIFF
--- a/templates/JSResolverOCHTTPSTemplate.js
+++ b/templates/JSResolverOCHTTPSTemplate.js
@@ -10,7 +10,8 @@ express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 */
 
-import { astFromValue, buildASTSchema, typeFromAST } from 'graphql';
+import assert from 'node:assert';
+import { astFromValue, buildASTSchema, isInputType, typeFromAST } from 'graphql';
 import { gql } from 'graphql-tag'; // GraphQL library to parse the GraphQL query
 
 const useCallSubquery = false;
@@ -27,12 +28,17 @@ const schema = buildASTSchema(schemaDataModel, { assumeValidSDL: true });
 export function resolveGraphDBQueryFromAppSyncEvent(event) {
     const fieldDef = getFieldDef(event.field);
 
+    assert(fieldDef);
+
     const args = [];
-    for (const inputDef of fieldDef.arguments) {
+    for (const inputDef of fieldDef.arguments ?? []) {
         const value = event.arguments[inputDef.name.value];
 
         if (value) {
             const inputType = typeFromAST(schema, inputDef.type);
+
+            assert(isInputType(inputType));
+
             args.push({
                 kind: 'Argument',
                 name: { kind: 'Name', value: inputDef.name.value },
@@ -99,8 +105,8 @@ function getTypeDefs(typeNameOrNames) {
 function getFieldDef(fieldName) {
     const rootTypeDefs = getRootTypeDefs();
 
-    for (const rootDef of rootTypeDefs) {
-        const fieldDef = rootDef.fields.find(def => def.name.value === fieldName);
+    for (const rootTypeDef of rootTypeDefs) {
+        const fieldDef = rootTypeDef.fields?.find(def => def.name.value === fieldName);
 
         if (fieldDef) {
             return fieldDef;
@@ -1080,7 +1086,7 @@ function parseQueryInput(queryObjOrStr) {
  * Accepts a GraphQL document or query string and outputs the graphDB query.
  *
  * @param {(Object|string)} queryObjOrStr the GraphQL document containing an operation to resolve
- * @returns {string}
+ * @returns {Object}
  */
 export function resolveGraphDBQuery(queryObjOrStr) {
     let executeQuery =  { query:'', parameters: {}, language: 'opencypher', refactorOutput: null };

--- a/test/TestCases/Case01/outputReference/output.jsresolver.graphql.js
+++ b/test/TestCases/Case01/outputReference/output.jsresolver.graphql.js
@@ -10,12 +10,13 @@ express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 */
 
-import { astFromValue, buildASTSchema, typeFromAST } from 'graphql';
+import assert from 'node:assert';
+import { astFromValue, buildASTSchema, isInputType, typeFromAST } from 'graphql';
 import { gql } from 'graphql-tag'; // GraphQL library to parse the GraphQL query
 
 const useCallSubquery = false;
 
-// 2025-02-05T01:35:32.969Z
+// 2025-02-09T22:45:48.901Z
 
 const schemaDataModelJSON = `{
   "kind": "Document",
@@ -3478,12 +3479,17 @@ const schema = buildASTSchema(schemaDataModel, { assumeValidSDL: true });
 export function resolveGraphDBQueryFromAppSyncEvent(event) {
     const fieldDef = getFieldDef(event.field);
 
+    assert(fieldDef);
+
     const args = [];
-    for (const inputDef of fieldDef.arguments) {
+    for (const inputDef of fieldDef.arguments ?? []) {
         const value = event.arguments[inputDef.name.value];
 
         if (value) {
             const inputType = typeFromAST(schema, inputDef.type);
+
+            assert(isInputType(inputType));
+
             args.push({
                 kind: 'Argument',
                 name: { kind: 'Name', value: inputDef.name.value },
@@ -3550,8 +3556,8 @@ function getTypeDefs(typeNameOrNames) {
 function getFieldDef(fieldName) {
     const rootTypeDefs = getRootTypeDefs();
 
-    for (const rootDef of rootTypeDefs) {
-        const fieldDef = rootDef.fields.find(def => def.name.value === fieldName);
+    for (const rootTypeDef of rootTypeDefs) {
+        const fieldDef = rootTypeDef.fields?.find(def => def.name.value === fieldName);
 
         if (fieldDef) {
             return fieldDef;
@@ -4531,7 +4537,7 @@ function parseQueryInput(queryObjOrStr) {
  * Accepts a GraphQL document or query string and outputs the graphDB query.
  *
  * @param {(Object|string)} queryObjOrStr the GraphQL document containing an operation to resolve
- * @returns {string}
+ * @returns {Object}
  */
 export function resolveGraphDBQuery(queryObjOrStr) {
     let executeQuery =  { query:'', parameters: {}, language: 'opencypher', refactorOutput: null };

--- a/test/TestCases/Case01/outputReference/output.resolver.graphql.js
+++ b/test/TestCases/Case01/outputReference/output.resolver.graphql.js
@@ -10,12 +10,13 @@ express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 */
 
-import { astFromValue, buildASTSchema, typeFromAST } from 'graphql';
+import assert from 'node:assert';
+import { astFromValue, buildASTSchema, isInputType, typeFromAST } from 'graphql';
 import { gql } from 'graphql-tag'; // GraphQL library to parse the GraphQL query
 
 const useCallSubquery = false;
 
-// 2025-02-05T01:35:32.969Z
+// 2025-02-09T22:45:48.901Z
 
 const schemaDataModelJSON = `{
   "kind": "Document",
@@ -3478,12 +3479,17 @@ const schema = buildASTSchema(schemaDataModel, { assumeValidSDL: true });
 export function resolveGraphDBQueryFromAppSyncEvent(event) {
     const fieldDef = getFieldDef(event.field);
 
+    assert(fieldDef);
+
     const args = [];
-    for (const inputDef of fieldDef.arguments) {
+    for (const inputDef of fieldDef.arguments ?? []) {
         const value = event.arguments[inputDef.name.value];
 
         if (value) {
             const inputType = typeFromAST(schema, inputDef.type);
+
+            assert(isInputType(inputType));
+
             args.push({
                 kind: 'Argument',
                 name: { kind: 'Name', value: inputDef.name.value },
@@ -3550,8 +3556,8 @@ function getTypeDefs(typeNameOrNames) {
 function getFieldDef(fieldName) {
     const rootTypeDefs = getRootTypeDefs();
 
-    for (const rootDef of rootTypeDefs) {
-        const fieldDef = rootDef.fields.find(def => def.name.value === fieldName);
+    for (const rootTypeDef of rootTypeDefs) {
+        const fieldDef = rootTypeDef.fields?.find(def => def.name.value === fieldName);
 
         if (fieldDef) {
             return fieldDef;
@@ -4531,7 +4537,7 @@ function parseQueryInput(queryObjOrStr) {
  * Accepts a GraphQL document or query string and outputs the graphDB query.
  *
  * @param {(Object|string)} queryObjOrStr the GraphQL document containing an operation to resolve
- * @returns {string}
+ * @returns {Object}
  */
 export function resolveGraphDBQuery(queryObjOrStr) {
     let executeQuery =  { query:'', parameters: {}, language: 'opencypher', refactorOutput: null };

--- a/test/TestCases/Case02/case.json
+++ b/test/TestCases/Case02/case.json
@@ -3,11 +3,8 @@
     "description":"Start from graph db json, from Air Routes db",
     "argv":[ "--quiet",
             "--input-graphdb-schema-file", "./test/TestCases/Case02/input/airports.graphdb.json",
-            "--output-js-resolver-file", "./test/TestCases/Case02/output/output.jsresolver.graphql.js",
             "--output-folder-path", "./test/TestCases/Case02/output",
             "--output-no-lambda-zip"],
     "host": "<AIR_ROUTES_DB_HOST>",
-    "port": "<AIR_ROUTES_DB_PORT>",
-    "testOutputFilesSize": ["output.lambda.zip", "output.resolver.graphql.js", "output.schema.graphql", "output.source.schema.graphql"],
-    "testOutputFilesContent": ["output.schema.graphql", "output.source.schema.graphql"]
+    "port": "<AIR_ROUTES_DB_PORT>"
 }

--- a/test/TestCases/Case05/case01.json
+++ b/test/TestCases/Case05/case01.json
@@ -9,7 +9,5 @@
             "--create-update-aws-pipeline-neptune-endpoint", "<AIR_ROUTES_DB_HOST>:<AIR_ROUTES_DB_PORT>",
             "--output-resolver-query-https"],
     "host": "<AIR_ROUTES_DB_HOST>",
-    "port": "<AIR_ROUTES_DB_PORT>",
-    "testOutputFilesSize": ["output.resolver.graphql.js", "output.schema.graphql", "output.source.schema.graphql"],
-    "testOutputFilesContent": ["output.schema.graphql", "output.source.schema.graphql"]
+    "port": "<AIR_ROUTES_DB_PORT>"
 }

--- a/test/TestCases/Case05/case02.json
+++ b/test/TestCases/Case05/case02.json
@@ -5,7 +5,5 @@
     "--remove-aws-pipeline-name", "AirportsJestTest",
     "--output-folder-path", "./test/TestCases/Case05/output"],
   "host": "<AIR_ROUTES_DB_HOST>",
-  "port": "<AIR_ROUTES_DB_HOST>",
-  "testOutputFilesSize": ["output.resolver.graphql.js", "output.schema.graphql", "output.source.schema.graphql"],
-  "testOutputFilesContent": ["output.schema.graphql", "output.source.schema.graphql"]
+  "port": "<AIR_ROUTES_DB_HOST>"
 }

--- a/test/TestCases/Case06/case.json
+++ b/test/TestCases/Case06/case.json
@@ -11,7 +11,5 @@
             "--output-aws-pipeline-cdk-neptune-endpoint", "<AIR_ROUTES_DB_HOST>:<AIR_ROUTES_DB_PORT>",
             "--output-resolver-query-https"],
     "host": "<AIR_ROUTES_DB_HOST>",
-    "port": "<AIR_ROUTES_DB_PORT>",
-    "testOutputFilesSize": ["output.resolver.graphql.js", "output.schema.graphql", "output.source.schema.graphql"],
-    "testOutputFilesContent": ["output.schema.graphql", "output.source.schema.graphql"]
+    "port": "<AIR_ROUTES_DB_PORT>"
 }


### PR DESCRIPTION
*Issue #, if available:* relates to #61 (see https://github.com/aws/amazon-neptune-for-graphql/pull/61#discussion_r1937773379)

*Description of changes:*

Also fix mistyped return annotation on `resolveGraphDBQuery`, my bad

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
