### PR TITLE
Added apollo args to help menu and fixed bug with ID argument type conversion

### DIFF
--- a/src/help.js
+++ b/src/help.js
@@ -140,6 +140,9 @@ Parameters
 [--create-update-aws-pipeline-neptune-IAM                   -pi  ]  default: is Neptune VPC
 [--remove-aws-pipeline-name <value>                         -rp  ]  
 
+[--create-update-apollo-server                              -asvr]
+[--create-update-apollo-server-subgraph                     -asub]
+
 [--output-aws-pipeline-cdk                                  -c   ]
 [--output-aws-pipeline-cdk-name <value>                     -cn  ]  default: Neptune DB name from --input-graphdb-schema-neptune-endpoint if exists
 [--output-aws-pipeline-cdk-neptune-endpoint <value>         -ce  ]  default: --input-graphdb-schema-neptune-endpoint if exists

--- a/src/main.js
+++ b/src/main.js
@@ -183,14 +183,14 @@ function processArgs() {
             case '--output-resolver-query-sdk':
                 queryClient = 'sdk';
             break;
-            case 'asvr':
+            case '-asvr':
             case '--create-update-apollo-server':
                 createUpdateApolloServer = true;
                 createLambdaZip = false;
                 createUpdatePipeline = false;
                 inputCDKpipeline = false;
             break;
-            case 'asub':
+            case '-asub':
             case '--create-update-apollo-server-subgraph':
                 createUpdateApolloServerSubgraph = true;
                 createLambdaZip = false;

--- a/templates/JSResolverOCHTTPSTemplate.js
+++ b/templates/JSResolverOCHTTPSTemplate.js
@@ -10,7 +10,7 @@ express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 */
 
-import { astFromValue, buildASTSchema, typeFromAST } from 'graphql';
+import { astFromValue, buildASTSchema, typeFromAST, GraphQLID } from 'graphql';
 import { gql } from 'graphql-tag'; // GraphQL library to parse the GraphQL query
 
 const useCallSubquery = false;
@@ -57,10 +57,22 @@ export function resolveGraphDBQueryFromEvent(event) {
 
         if (value) {
             const inputType = typeFromAST(schema, inputDef.type);
+            const astValue = astFromValue(value, inputType);
+            // retrieve an ID field which may not necessarily be named 'id'
+            const idField = Object.values(inputType.getFields()).find(field => field.type.name === GraphQLID.name);
+            if (idField) {
+                // check if id was an input arg
+                const idValue = astValue.fields.find(f => f.name.value === idField.name);
+                if (idValue?.value?.kind === 'IntValue') {
+                    // graphql astFromValue function can convert ID integer strings into integer type
+                    // if input args contain an id and the graphql library has interpreted the value as an int, change it to treat the value as a string
+                    idValue.value.kind = 'StringValue';
+                }
+            }
             args.push({
                 kind: 'Argument',
                 name: { kind: 'Name', value: inputDef.name.value },
-                value: astFromValue(value, inputType)
+                value: astValue
             });
         }
     }

--- a/test/TestCases/Case01/Case01.05.test.js
+++ b/test/TestCases/Case01/Case01.05.test.js
@@ -73,6 +73,38 @@ describe('AppSync resolver', () => {
         });
     });
 
+    test('should resolve queries with a string id filter', () => {
+        const result = resolve({
+            field: 'getNodeAirport',
+            arguments: { filter: { _id: '22' } },
+            selectionSetGraphQL: '{ city }'
+        });
+
+        expect(result).toEqual({
+            query: 'MATCH (getNodeAirport_Airport:`airport`) WHERE ID(getNodeAirport_Airport) = $getNodeAirport_Airport_whereId\n' +
+                'RETURN {city: getNodeAirport_Airport.`city`} LIMIT 1',
+            parameters: { getNodeAirport_Airport_whereId: '22'},
+            language: 'opencypher',
+            refactorOutput: null
+        });
+    });
+
+    test('should resolve queries with an integer id filter', () => {
+        const result = resolve({
+            field: 'getNodeAirport',
+            arguments: { filter: { _id: 22 } },
+            selectionSetGraphQL: '{ city }'
+        });
+
+        expect(result).toEqual({
+            query: 'MATCH (getNodeAirport_Airport:`airport`) WHERE ID(getNodeAirport_Airport) = $getNodeAirport_Airport_whereId\n' +
+                'RETURN {city: getNodeAirport_Airport.`city`} LIMIT 1',
+            parameters: { getNodeAirport_Airport_whereId: '22'},
+            language: 'opencypher',
+            refactorOutput: null
+        });
+    });
+
     function resolve(event) {
         return resolverModule.resolveGraphDBQueryFromAppSyncEvent(event);
     }

--- a/test/TestCases/Case07/outputReference/output.resolver.graphql.js
+++ b/test/TestCases/Case07/outputReference/output.resolver.graphql.js
@@ -10,12 +10,12 @@ express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 */
 
-import { astFromValue, buildASTSchema, typeFromAST } from 'graphql';
+import { astFromValue, buildASTSchema, typeFromAST, GraphQLID } from 'graphql';
 import { gql } from 'graphql-tag'; // GraphQL library to parse the GraphQL query
 
 const useCallSubquery = false;
 
-// 2025-02-11T06:24:58.419Z
+// 2025-02-19T23:44:32.919Z
 
 const schemaDataModelJSON = `{
   "kind": "Document",
@@ -3540,10 +3540,22 @@ export function resolveGraphDBQueryFromEvent(event) {
 
         if (value) {
             const inputType = typeFromAST(schema, inputDef.type);
+            const astValue = astFromValue(value, inputType);
+            // retrieve an ID field which may not necessarily be named 'id'
+            const idField = Object.values(inputType.getFields()).find(field => field.type.name === GraphQLID.name);
+            if (idField) {
+                // check if id was an input arg
+                const idValue = astValue.fields.find(f => f.name.value === idField.name);
+                if (idValue?.value?.kind === 'IntValue') {
+                    // graphql astFromValue function can convert ID integer strings into integer type
+                    // if input args contain an id and the graphql library has interpreted the value as an int, change it to treat the value as a string
+                    idValue.value.kind = 'StringValue';
+                }
+            }
             args.push({
                 kind: 'Argument',
                 name: { kind: 'Name', value: inputDef.name.value },
-                value: astFromValue(value, inputType)
+                value: astValue
             });
         }
     }


### PR DESCRIPTION
*Description of changes:*
Added apollo args to help menu. Fixed bug with graphQL ID input argument values like '22' being converted into integer open cypher parameters by adding a workaround for the `graphql` library `astFromValue` function which is causing the conversion.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
