### PR TITLE
Apollo zip from input schema file

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ See CDK end to end example [here](https://github.com/aws/amazon-neptune-for-grap
 # Generate Apollo Server Artifacts
 If you prefer to use Apollo Server instead of AWS App Sync, the utility can generate a ZIP file of Apollo Server artifacts with the CLI option `--create-update-apollo-server` for a standalone server or `--create-update-apollo-server-subgraph` for federated systems.
 
-For example:
+Example of starting with a neptune database with data from which to determine the graphQL schema:
 ```
 neptune-for-graphql \
   --input-graphdb-schema-neptune-endpoint abc.us-west-2.neptune.amazonaws.com:8182 \
@@ -283,7 +283,16 @@ neptune-for-graphql \
   --output-resolver-query-https
 ```
 
-The command above will generate an `apollo-server-<identifier>-<timestamp>.zip` file which can then be deployed locally by following these steps:
+Example of starting with a graphQL schema file:
+```
+neptune-for-graphql \
+  --input-schema-file airports.source.schema.graphql \
+  --create-update-apollo-server-neptune-endpoint abc.us-west-2.neptune.amazonaws.com:8182 \
+  --create-update-apollo-server \
+  --output-resolver-query-https
+```
+
+The example commands above will generate the file `apollo-server-<identifier>-<timestamp>.zip`, which can then be deployed locally by following these steps:
 1. unzip `apollo-server-<identifier>-<timestamp>.zip`
 2. change directory into the unzipped folder
 3. execute `npm install` to install required dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/neptune-for-graphql",
-  "version": "1.1.1",
+  "version": "1.2.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/neptune-for-graphql",
-      "version": "1.1.1",
+      "version": "1.2.0-beta.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/neptune-for-graphql",
-  "version": "1.1.1",
+  "version": "1.2.0-beta.1",
   "description": "CLI utility to create and maintain a GraphQL API for Amazon Neptune",
   "keywords": [
     "Amazon Neptune",

--- a/src/help.js
+++ b/src/help.js
@@ -146,6 +146,8 @@ Parameters
 
 [--create-update-apollo-server                              -asvr]
 [--create-update-apollo-server-subgraph                     -asub]
+[--create-update-apollo-server-neptune-endpoint             -ase ]  default: --input-graphdb-schema-neptune-endpoint if exists
+[ ... more apollo options to come in future roadmap              ]
 
 [--output-aws-pipeline-cdk                                  -c   ]
 [--output-aws-pipeline-cdk-name <value>                     -cn  ]  default: Neptune DB name from --input-graphdb-schema-neptune-endpoint if exists

--- a/src/zipPackage.js
+++ b/src/zipPackage.js
@@ -81,7 +81,7 @@ export async function createApolloDeploymentPackage({zipFilePath, resolverFilePa
         includePaths: [
             {source: path.join(modulePath, '/../templates/ApolloServer')},
             {source: resolverFilePath, target: 'output.resolver.graphql.js'},
-            {source: schemaFilePath, target: 'schema.graphql'},
+            {source: schemaFilePath, target: 'output.schema.graphql'},
             // querying neptune using SDK not yet supported
             {source: path.join(modulePath, '/../templates/queryHttpNeptune.mjs')}
         ],

--- a/templates/ApolloServer/index.mjs
+++ b/templates/ApolloServer/index.mjs
@@ -8,7 +8,7 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-const typeDefs = gql(readFileSync('./schema.graphql', 'utf-8'));
+const typeDefs = gql(readFileSync('./output.schema.graphql', 'utf-8'));
 const queryDefinition = typeDefs.definitions.find(
     definition => definition.kind === 'ObjectTypeDefinition' && definition.name.value === 'Query'
 );

--- a/templates/ApolloServer/package.json
+++ b/templates/ApolloServer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neptune-apollo-server",
-  "version": "1.0.0",
+  "version": "1.2.0-beta.1",
   "description": "",
   "license": "Apache-2.0",
   "author": "",

--- a/templates/JSResolverOCHTTPSTemplate.js
+++ b/templates/JSResolverOCHTTPSTemplate.js
@@ -10,7 +10,7 @@ express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 */
 
-import { astFromValue, buildASTSchema, typeFromAST, GraphQLID } from 'graphql';
+import { astFromValue, buildASTSchema, typeFromAST, GraphQLID, GraphQLInputObjectType } from 'graphql';
 import { gql } from 'graphql-tag'; // GraphQL library to parse the GraphQL query
 
 const useCallSubquery = false;
@@ -36,7 +36,7 @@ export function resolveGraphDBQueryFromAppSyncEvent(event) {
     return resolveGraphDBQueryFromEvent({
         field: event.field,
         arguments: event.arguments,
-        selectionSet: gql`${event.selectionSetGraphQL}`.definitions[0].selectionSet
+        selectionSet: event.selectionSetGraphQL ? gql`${event.selectionSetGraphQL}`.definitions[0].selectionSet : {}
     });
 }
 
@@ -58,15 +58,17 @@ export function resolveGraphDBQueryFromEvent(event) {
         if (value) {
             const inputType = typeFromAST(schema, inputDef.type);
             const astValue = astFromValue(value, inputType);
-            // retrieve an ID field which may not necessarily be named 'id'
-            const idField = Object.values(inputType.getFields()).find(field => field.type.name === GraphQLID.name);
-            if (idField) {
-                // check if id was an input arg
-                const idValue = astValue.fields.find(f => f.name.value === idField.name);
-                if (idValue?.value?.kind === 'IntValue') {
-                    // graphql astFromValue function can convert ID integer strings into integer type
-                    // if input args contain an id and the graphql library has interpreted the value as an int, change it to treat the value as a string
-                    idValue.value.kind = 'StringValue';
+            if (inputType instanceof GraphQLInputObjectType) {
+                // retrieve an ID field which may not necessarily be named 'id'
+                const idField = Object.values(inputType.getFields()).find(field => field.type.name === GraphQLID.name);
+                if (idField) {
+                    // check if id was an input arg
+                    const idValue = astValue.fields.find(f => f.name.value === idField.name);
+                    if (idValue?.value?.kind === 'IntValue') {
+                        // graphql astFromValue function can convert ID integer strings into integer type
+                        // if input args contain an id and the graphql library has interpreted the value as an int, change it to treat the value as a string
+                        idValue.value.kind = 'StringValue';
+                    }
                 }
             }
             args.push({

--- a/templates/Lambda4AppSyncGraphSDK/package-lock.json
+++ b/templates/Lambda4AppSyncGraphSDK/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lambda4appsyncgraphsdk",
-  "version": "1.1.1",
+  "version": "1.2.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lambda4appsyncgraphsdk",
-      "version": "1.1.1",
+      "version": "1.2.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-neptune-graph": "3.662.0",

--- a/templates/Lambda4AppSyncGraphSDK/package.json
+++ b/templates/Lambda4AppSyncGraphSDK/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda4appsyncgraphsdk",
-  "version": "1.1.1",
+  "version": "1.2.0-beta.1",
   "description": "AWS Lambda function to bridge AppSync to Neptune Analytics",
   "main": "index.mjs",
   "type": "module",

--- a/templates/Lambda4AppSyncHTTP/package-lock.json
+++ b/templates/Lambda4AppSyncHTTP/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lambda4appsynchttp",
-  "version": "1.1.1",
+  "version": "1.2.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lambda4appsynchttp",
-      "version": "1.1.1",
+      "version": "1.2.0-beta.1",
       "license": "ISC",
       "dependencies": {
         "aws4-axios": "3.3.0",

--- a/templates/Lambda4AppSyncHTTP/package.json
+++ b/templates/Lambda4AppSyncHTTP/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda4appsynchttp",
-  "version": "1.1.1",
+  "version": "1.2.0-beta.1",
   "description": "AWS Lambda function to bridge AppSync to Neptune or Neptune Analytics",
   "main": "index.mjs",
   "type": "module",

--- a/templates/Lambda4AppSyncSDK/package-lock.json
+++ b/templates/Lambda4AppSyncSDK/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lambda4appsyncsdk",
-  "version": "1.1.1",
+  "version": "1.2.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lambda4appsyncsdk",
-      "version": "1.1.1",
+      "version": "1.2.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-neptunedata": "3.403.0",

--- a/templates/Lambda4AppSyncSDK/package.json
+++ b/templates/Lambda4AppSyncSDK/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda4appsyncsdk",
-  "version": "1.1.1",
+  "version": "1.2.0-beta.1",
   "description": "AWS Lambda function to bridge AppSync to Neptune",
   "main": "index.mjs",
   "type": "module",

--- a/test/TestCases/Case01/Case01.05.test.js
+++ b/test/TestCases/Case01/Case01.05.test.js
@@ -105,6 +105,36 @@ describe('AppSync resolver', () => {
         });
     });
 
+    test('should resolve gremlin query with argument', () => {
+        const result = resolve({
+            field: 'getAirportWithGremlin',
+            arguments: { code: 'YVR' },
+            selectionSetGraphQL: '{ city }'
+        });
+
+        expect(result).toMatchObject({
+            query: "g.V().has('airport', 'code', 'YVR').elementMap()",
+            parameters: {},
+            language: 'gremlin',
+            refactorOutput: null
+        });
+    });
+
+    test('should resolve gremlin query without arguments or selection set', () => {
+        const result = resolve({
+            field: 'getCountriesCount',
+            arguments: { },
+            selectionSetGraphQL: ''
+        });
+
+        expect(result).toMatchObject({
+            query: "g.V().hasLabel('country').count()",
+            parameters: {},
+            language: 'gremlin',
+            refactorOutput: null
+        });
+    });
+
     function resolve(event) {
         return resolverModule.resolveGraphDBQueryFromAppSyncEvent(event);
     }

--- a/test/TestCases/Case01/input/changesAirport.json
+++ b/test/TestCases/Case01/input/changesAirport.json
@@ -1,5 +1,7 @@
 [
     { "type": "Airport", "field": "outboundRoutesCountAdd", "action": "add", "value":"outboundRoutesCountAdd: Int @graphQuery(statement: \"MATCH (this)-[r:route]->(a) RETURN count(r)\")"},    
     { "type": "Mutation", "field": "deleteNodeVersion", "action": "remove", "value": "" },
-    { "type": "Mutation", "field": "createNodeVersion", "action": "remove", "value": "" }
+    { "type": "Mutation", "field": "createNodeVersion", "action": "remove", "value": "" },
+    { "type": "Query", "field": "getAirportWithGremlin", "action": "add", "value":"getAirportWithGremlin(code:String): Airport @graphQuery(statement: \"g.V().has('airport', 'code', '$code').elementMap()\")"},
+    { "type": "Query", "field": "getCountriesCount", "action": "add", "value":"getCountriesCount: Int @graphQuery(statement: \"g.V().hasLabel('country').count()\")"}
 ]

--- a/test/TestCases/Case01/outputReference/output.jsresolver.graphql.js
+++ b/test/TestCases/Case01/outputReference/output.jsresolver.graphql.js
@@ -10,12 +10,12 @@ express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 */
 
-import { astFromValue, buildASTSchema, typeFromAST, GraphQLID } from 'graphql';
+import { astFromValue, buildASTSchema, typeFromAST, GraphQLID, GraphQLInputObjectType } from 'graphql';
 import { gql } from 'graphql-tag'; // GraphQL library to parse the GraphQL query
 
 const useCallSubquery = false;
 
-// 2025-02-19T23:41:22.685Z
+// 2025-02-21T06:31:13.132Z
 
 const schemaDataModelJSON = `{
   "kind": "Document",
@@ -2469,6 +2469,98 @@ const schemaDataModelJSON = `{
             }
           },
           "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "getAirportWithGremlin"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "code"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              },
+              "directives": []
+            }
+          ],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Airport"
+            }
+          },
+          "directives": [
+            {
+              "kind": "Directive",
+              "name": {
+                "kind": "Name",
+                "value": "graphQuery"
+              },
+              "arguments": [
+                {
+                  "kind": "Argument",
+                  "name": {
+                    "kind": "Name",
+                    "value": "statement"
+                  },
+                  "value": {
+                    "kind": "StringValue",
+                    "value": "g.V().has('airport', 'code', '$code').elementMap()",
+                    "block": false
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "getCountriesCount"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Int"
+            }
+          },
+          "directives": [
+            {
+              "kind": "Directive",
+              "name": {
+                "kind": "Name",
+                "value": "graphQuery"
+              },
+              "arguments": [
+                {
+                  "kind": "Argument",
+                  "name": {
+                    "kind": "Name",
+                    "value": "statement"
+                  },
+                  "value": {
+                    "kind": "StringValue",
+                    "value": "g.V().hasLabel('country').count()",
+                    "block": false
+                  }
+                }
+              ]
+            }
+          ]
         }
       ]
     },
@@ -3466,7 +3558,7 @@ const schemaDataModelJSON = `{
   ],
   "loc": {
     "start": 0,
-    "end": 4698
+    "end": 4902
   }
 }`;
     
@@ -3487,7 +3579,7 @@ export function resolveGraphDBQueryFromAppSyncEvent(event) {
     return resolveGraphDBQueryFromEvent({
         field: event.field,
         arguments: event.arguments,
-        selectionSet: gql`${event.selectionSetGraphQL}`.definitions[0].selectionSet
+        selectionSet: event.selectionSetGraphQL ? gql`${event.selectionSetGraphQL}`.definitions[0].selectionSet : {}
     });
 }
 
@@ -3509,15 +3601,17 @@ export function resolveGraphDBQueryFromEvent(event) {
         if (value) {
             const inputType = typeFromAST(schema, inputDef.type);
             const astValue = astFromValue(value, inputType);
-            // retrieve an ID field which may not necessarily be named 'id'
-            const idField = Object.values(inputType.getFields()).find(field => field.type.name === GraphQLID.name);
-            if (idField) {
-                // check if id was an input arg
-                const idValue = astValue.fields.find(f => f.name.value === idField.name);
-                if (idValue?.value?.kind === 'IntValue') {
-                    // graphql astFromValue function can convert ID integer strings into integer type
-                    // if input args contain an id and the graphql library has interpreted the value as an int, change it to treat the value as a string
-                    idValue.value.kind = 'StringValue';
+            if (inputType instanceof GraphQLInputObjectType) {
+                // retrieve an ID field which may not necessarily be named 'id'
+                const idField = Object.values(inputType.getFields()).find(field => field.type.name === GraphQLID.name);
+                if (idField) {
+                    // check if id was an input arg
+                    const idValue = astValue.fields.find(f => f.name.value === idField.name);
+                    if (idValue?.value?.kind === 'IntValue') {
+                        // graphql astFromValue function can convert ID integer strings into integer type
+                        // if input args contain an id and the graphql library has interpreted the value as an int, change it to treat the value as a string
+                        idValue.value.kind = 'StringValue';
+                    }
                 }
             }
             args.push({

--- a/test/TestCases/Case01/outputReference/output.resolver.graphql.js
+++ b/test/TestCases/Case01/outputReference/output.resolver.graphql.js
@@ -10,12 +10,12 @@ express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 */
 
-import { astFromValue, buildASTSchema, typeFromAST, GraphQLID } from 'graphql';
+import { astFromValue, buildASTSchema, typeFromAST, GraphQLID, GraphQLInputObjectType } from 'graphql';
 import { gql } from 'graphql-tag'; // GraphQL library to parse the GraphQL query
 
 const useCallSubquery = false;
 
-// 2025-02-19T23:41:22.685Z
+// 2025-02-21T06:31:13.132Z
 
 const schemaDataModelJSON = `{
   "kind": "Document",
@@ -2469,6 +2469,98 @@ const schemaDataModelJSON = `{
             }
           },
           "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "getAirportWithGremlin"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "code"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              },
+              "directives": []
+            }
+          ],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Airport"
+            }
+          },
+          "directives": [
+            {
+              "kind": "Directive",
+              "name": {
+                "kind": "Name",
+                "value": "graphQuery"
+              },
+              "arguments": [
+                {
+                  "kind": "Argument",
+                  "name": {
+                    "kind": "Name",
+                    "value": "statement"
+                  },
+                  "value": {
+                    "kind": "StringValue",
+                    "value": "g.V().has('airport', 'code', '$code').elementMap()",
+                    "block": false
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "getCountriesCount"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Int"
+            }
+          },
+          "directives": [
+            {
+              "kind": "Directive",
+              "name": {
+                "kind": "Name",
+                "value": "graphQuery"
+              },
+              "arguments": [
+                {
+                  "kind": "Argument",
+                  "name": {
+                    "kind": "Name",
+                    "value": "statement"
+                  },
+                  "value": {
+                    "kind": "StringValue",
+                    "value": "g.V().hasLabel('country').count()",
+                    "block": false
+                  }
+                }
+              ]
+            }
+          ]
         }
       ]
     },
@@ -3466,7 +3558,7 @@ const schemaDataModelJSON = `{
   ],
   "loc": {
     "start": 0,
-    "end": 4698
+    "end": 4902
   }
 }`;
     
@@ -3487,7 +3579,7 @@ export function resolveGraphDBQueryFromAppSyncEvent(event) {
     return resolveGraphDBQueryFromEvent({
         field: event.field,
         arguments: event.arguments,
-        selectionSet: gql`${event.selectionSetGraphQL}`.definitions[0].selectionSet
+        selectionSet: event.selectionSetGraphQL ? gql`${event.selectionSetGraphQL}`.definitions[0].selectionSet : {}
     });
 }
 
@@ -3509,15 +3601,17 @@ export function resolveGraphDBQueryFromEvent(event) {
         if (value) {
             const inputType = typeFromAST(schema, inputDef.type);
             const astValue = astFromValue(value, inputType);
-            // retrieve an ID field which may not necessarily be named 'id'
-            const idField = Object.values(inputType.getFields()).find(field => field.type.name === GraphQLID.name);
-            if (idField) {
-                // check if id was an input arg
-                const idValue = astValue.fields.find(f => f.name.value === idField.name);
-                if (idValue?.value?.kind === 'IntValue') {
-                    // graphql astFromValue function can convert ID integer strings into integer type
-                    // if input args contain an id and the graphql library has interpreted the value as an int, change it to treat the value as a string
-                    idValue.value.kind = 'StringValue';
+            if (inputType instanceof GraphQLInputObjectType) {
+                // retrieve an ID field which may not necessarily be named 'id'
+                const idField = Object.values(inputType.getFields()).find(field => field.type.name === GraphQLID.name);
+                if (idField) {
+                    // check if id was an input arg
+                    const idValue = astValue.fields.find(f => f.name.value === idField.name);
+                    if (idValue?.value?.kind === 'IntValue') {
+                        // graphql astFromValue function can convert ID integer strings into integer type
+                        // if input args contain an id and the graphql library has interpreted the value as an int, change it to treat the value as a string
+                        idValue.value.kind = 'StringValue';
+                    }
                 }
             }
             args.push({

--- a/test/TestCases/Case01/outputReference/output.schema.graphql
+++ b/test/TestCases/Case01/outputReference/output.schema.graphql
@@ -119,6 +119,8 @@ type Query {
   getNodeVersions(filter: VersionInput, options: Options): [Version]
   getNodeAirport(filter: AirportInput): Airport
   getNodeAirports(filter: AirportInput, options: Options): [Airport]
+  getAirportWithGremlin(code: String): Airport
+  getCountriesCount: Int
 }
 
 type Mutation {

--- a/test/TestCases/Case01/outputReference/output.source.schema.graphql
+++ b/test/TestCases/Case01/outputReference/output.source.schema.graphql
@@ -119,6 +119,8 @@ type Query {
   getNodeVersions(filter: VersionInput, options: Options): [Version]
   getNodeAirport(filter: AirportInput): Airport
   getNodeAirports(filter: AirportInput, options: Options): [Airport]
+  getAirportWithGremlin(code: String): Airport @graphQuery(statement: "g.V().has('airport', 'code', '$code').elementMap()")
+  getCountriesCount: Int @graphQuery(statement: "g.V().hasLabel('country').count()")
 }
 
 type Mutation {

--- a/test/TestCases/Case08/Case08.02.test.js
+++ b/test/TestCases/Case08/Case08.02.test.js
@@ -1,47 +1,15 @@
-import {readJSONFile, unzipAndGetContents} from '../../testLib';
+import {readJSONFile, testApolloArtifacts} from '../../testLib';
 import fs from "fs";
 import {parseNeptuneEndpoint} from "../../../src/util.js";
 
 const testCase = readJSONFile('./test/TestCases/Case08/case01.json');
 const testDbInfo = parseNeptuneEndpoint(testCase.host + ':' + testCase.port);
+const outputFolderPath = './test/TestCases/Case08/case08-01-output';
 
 describe('Validate Apollo Server output artifacts', () => {
-
     afterAll(async () => {
-        fs.rmSync('./test/TestCases/Case08/case08-01-output', {recursive: true});
+        fs.rmSync(outputFolderPath, {recursive: true});
     });
 
-    test('Validate zip contents', () => {
-        const expectedFiles = [
-            '.env',
-            'index.mjs',
-            'output.resolver.graphql.js',
-            'package.json',
-            'package-lock.json',
-            'schema.graphql',
-            'neptune.mjs',
-            'queryHttpNeptune.mjs'
-        ];
-
-        const files = fs.readdirSync('./test/TestCases/Case08/case08-01-output');
-        const apolloZips = files.filter(file => file.startsWith(`apollo-server-${testDbInfo.graphName}-`) && file.endsWith('.zip'));
-        expect(apolloZips.length).toEqual(1);
-
-        const actualFiles = unzipAndGetContents('./test/TestCases/Case08/case08-01-output/unzipped', `./test/TestCases/Case08/case08-01-output/${apolloZips[0]}`);
-        expect(actualFiles.toSorted()).toEqual(expectedFiles.toSorted());
-    });
-
-    test('Validate .env values', () => {
-        const expectedContent = [
-            `NEPTUNE_TYPE=${testDbInfo.neptuneType}`,
-            `NEPTUNE_HOST=${testCase.host}`,
-            `NEPTUNE_PORT=${testCase.port}`,
-            `AWS_REGION=${testDbInfo.region}`,
-            'LOGGING_ENABLED=false',
-            'SUBGRAPH=false'
-        ];
-        const actualContent = fs.readFileSync('./test/TestCases/Case08/case08-01-output/unzipped/.env', 'utf8');
-        expect(actualContent).toEqual(expectedContent.join('\n'));
-    });
-
+    testApolloArtifacts(outputFolderPath, testDbInfo, false);
 });

--- a/test/TestCases/Case08/Case08.05.test.js
+++ b/test/TestCases/Case08/Case08.05.test.js
@@ -1,0 +1,15 @@
+import {readJSONFile} from '../../testLib';
+import {main} from "../../../src/main";
+
+const casetest = readJSONFile('./test/TestCases/Case08/case03.json');
+
+async function executeUtility() {
+    process.argv = casetest.argv;
+    await main();
+}
+
+describe('Create Apollo Server output artifacts from input schema file', () => {
+    test('Execute utility: ' + casetest.argv.join(' '), async () => {
+        expect(await executeUtility()).not.toBe(null);
+    }, 600000);
+});

--- a/test/TestCases/Case08/Case08.06.test.js
+++ b/test/TestCases/Case08/Case08.06.test.js
@@ -2,14 +2,14 @@ import {readJSONFile, testApolloArtifacts} from '../../testLib';
 import fs from "fs";
 import {parseNeptuneEndpoint} from "../../../src/util.js";
 
-const testCase = readJSONFile('./test/TestCases/Case08/case02.json');
+const testCase = readJSONFile('./test/TestCases/Case08/case03.json');
 const testDbInfo = parseNeptuneEndpoint(testCase.host + ':' + testCase.port);
-const outputFolderPath = './test/TestCases/Case08/case08-02-output';
+const outputFolderPath = './test/TestCases/Case08/case08-03-output';
 
-describe('Validate Apollo Server output artifacts are created when using customized output arguments', () => {
+describe('Validate Apollo Server output artifacts are created when using an input schema file', () => {
     afterAll(async () => {
         fs.rmSync(outputFolderPath, {recursive: true});
     });
-
+    
     testApolloArtifacts(outputFolderPath, testDbInfo, false);
 });

--- a/test/TestCases/Case08/case03.json
+++ b/test/TestCases/Case08/case03.json
@@ -1,0 +1,12 @@
+{
+    "name": "Create Apollo Server ZIP from input schema file",
+    "description":"Test creation of Apollo Server ZIP using an input schema file",
+    "argv":["--quiet",
+            "--input-schema-file", "./test/TestCases/airports.source.schema.graphql",
+            "--create-update-apollo-server-neptune-endpoint", "<AIR_ROUTES_DB_HOST>:<AIR_ROUTES_DB_PORT>",
+            "--output-folder-path", "./test/TestCases/Case08/case08-03-output",
+            "--create-update-apollo-server",
+            "--output-resolver-query-https"],
+    "host": "<AIR_ROUTES_DB_HOST>",
+    "port": "<AIR_ROUTES_DB_PORT>"
+}

--- a/test/TestCases/Case09/Case09.02.test.js
+++ b/test/TestCases/Case09/Case09.02.test.js
@@ -1,47 +1,15 @@
-import {readJSONFile, unzipAndGetContents} from '../../testLib';
+import {readJSONFile, testApolloArtifacts} from '../../testLib';
 import fs from "fs";
 import {parseNeptuneEndpoint} from "../../../src/util.js";
 
 const testCase = readJSONFile('./test/TestCases/Case09/case01.json');
 const testDbInfo = parseNeptuneEndpoint(testCase.host + ':' + testCase.port);
 
+const outputFolderPath = './test/TestCases/Case09/output';
 describe('Validate Apollo Server Subgraph output artifacts', () => {
-
     afterAll(async () => {
-        fs.rmSync('./test/TestCases/Case09/output', {recursive: true});
+        fs.rmSync(outputFolderPath, {recursive: true});
     });
 
-    test('Validate zip contents', () => {
-        const expectedFiles = [
-            '.env',
-            'index.mjs',
-            'output.resolver.graphql.js',
-            'package.json',
-            'package-lock.json',
-            'schema.graphql',
-            'neptune.mjs',
-            'queryHttpNeptune.mjs'
-        ];
-
-        const files = fs.readdirSync('./test/TestCases/Case09/output');
-        const apolloZips = files.filter(file => file.startsWith(`apollo-server-${testDbInfo.graphName}-`) && file.endsWith('.zip'));
-        expect(apolloZips.length).toEqual(1);
-
-        const actualFiles = unzipAndGetContents('./test/TestCases/Case09/output/unzipped', `./test/TestCases/Case09/output/${apolloZips[0]}`);
-        expect(actualFiles.toSorted()).toEqual(expectedFiles.toSorted());
-    });
-
-    test('Validate .env values', () => {
-        const expectedContent = [
-            `NEPTUNE_TYPE=${testDbInfo.neptuneType}`,
-            `NEPTUNE_HOST=${testCase.host}`,
-            `NEPTUNE_PORT=${testCase.port}`,
-            `AWS_REGION=${testDbInfo.region}`,
-            `LOGGING_ENABLED=false`,
-            `SUBGRAPH=true`
-        ];
-        const actualContent = fs.readFileSync('./test/TestCases/Case09/output/unzipped/.env', 'utf8');
-        expect(actualContent).toEqual(expectedContent.join('\n'));
-    });
-
+    testApolloArtifacts(outputFolderPath, testDbInfo, true);
 });

--- a/test/TestCases/Case09/Case09.03.test.js
+++ b/test/TestCases/Case09/Case09.03.test.js
@@ -1,0 +1,15 @@
+import {readJSONFile} from '../../testLib';
+import {main} from "../../../src/main";
+
+const casetest = readJSONFile('./test/TestCases/Case09/case02.json');
+
+async function executeUtility() {
+    process.argv = casetest.argv;
+    await main();
+}
+
+describe('Create Apollo Server Subgraph output artifacts from input schema file', () => {
+    test('Execute utility: ' + casetest.argv.join(' '), async () => {
+        expect(await executeUtility()).not.toBe(null);
+    }, 600000);
+});

--- a/test/TestCases/Case09/Case09.04.test.js
+++ b/test/TestCases/Case09/Case09.04.test.js
@@ -2,14 +2,14 @@ import {readJSONFile, testApolloArtifacts} from '../../testLib';
 import fs from "fs";
 import {parseNeptuneEndpoint} from "../../../src/util.js";
 
-const testCase = readJSONFile('./test/TestCases/Case08/case02.json');
+const testCase = readJSONFile('./test/TestCases/Case09/case02.json');
 const testDbInfo = parseNeptuneEndpoint(testCase.host + ':' + testCase.port);
-const outputFolderPath = './test/TestCases/Case08/case08-02-output';
+const outputFolderPath = './test/TestCases/Case09/case09-02-output';
 
-describe('Validate Apollo Server output artifacts are created when using customized output arguments', () => {
+describe('Validate Apollo Server Subgraph output artifacts are created when using an input schema file', () => {
     afterAll(async () => {
         fs.rmSync(outputFolderPath, {recursive: true});
     });
-
-    testApolloArtifacts(outputFolderPath, testDbInfo, false);
+    
+    testApolloArtifacts(outputFolderPath, testDbInfo, true);
 });

--- a/test/TestCases/Case09/case02.json
+++ b/test/TestCases/Case09/case02.json
@@ -1,0 +1,12 @@
+{
+    "name": "Create Apollo Server Subgraph ZIP from input schema file",
+    "description":"Test creation of Apollo Server Subgraph ZIP using an input schema file",
+    "argv":["--quiet",
+            "--input-schema-file", "./test/TestCases/airports.source.schema.graphql",
+            "--create-update-apollo-server-neptune-endpoint", "<AIR_ROUTES_DB_HOST>:<AIR_ROUTES_DB_PORT>",
+            "--output-folder-path", "./test/TestCases/Case09/case09-02-output",
+            "--create-update-apollo-server-subgraph",
+            "--output-resolver-query-https"],
+    "host": "<AIR_ROUTES_DB_HOST>",
+    "port": "<AIR_ROUTES_DB_PORT>"
+}


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-neptune-for-graphql/issues/67

*Description of changes:*
Added ability to create Apollo zip using an input graphQL schema file instead of discovering the schema by querying neptune. For consistency with App Sync pipeline and CDK workflows, this workflow requires setting a new endpoint argument `--create-update-apollo-server-neptune-endpoint` in addition to the existing `--input-schema-file` argument.

Other changes:
* fixed bugs resolving gremlin queries and added resolver tests for these scenarios
* changed schema file in zip to have `output.` prefix for consistency with the resolver file
* bumped the version from 1.1.1 to 1.2.0-beta.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
