### PR TITLE
Upgrade axios and babel versions to fix security warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/neptune-for-graphql",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/neptune-for-graphql",
-      "version": "1.2.0-beta.1",
+      "version": "1.2.0-beta.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -19,7 +19,7 @@
         "@aws-sdk/credential-providers": "3.414.0",
         "archiver": "7.0.1",
         "aws4-axios": "3.3.0",
-        "axios": "1.7.9",
+        "axios": "^1.9.0",
         "graphql": "^16.8.1",
         "graphql-tag": "2.12.6",
         "ora": "7.0.1",
@@ -4003,14 +4003,15 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.24.7",
-        "picocolors": "^1.0.0"
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -4168,9 +4169,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
-      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4178,9 +4179,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4198,121 +4199,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.25.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.6.tgz",
-      "integrity": "sha512-Xg0tn4HcfTijTwfDwYlvVCl43V6h4KyVVX2aEm4qdO/PC6L2YvzLHFdmxhoeSA3eslcE6+ZVXHgWwopXYLNq4Q==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.1.tgz",
+      "integrity": "sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.6"
+        "@babel/template": "^7.27.1",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
-      "integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.1.tgz",
+      "integrity": "sha512-I0dZ3ZpCrJ1c04OqlNsQcKiZlsrXf/kkE4FXzID9rIOYICsAbA8mMDzhW/luRNAHdCNt7os/u8wenklZDlUVUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.6"
+        "@babel/types": "^7.27.1"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -4561,15 +4468,15 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
-      "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.1.tgz",
+      "integrity": "sha512-Fyo3ghWMqkHHpHQCoBs2VnYjR4iWFFjguTDEqA5WgZDOrFesVjMhMM2FSqTKSoUSDO1VQtavj8NFpdRBEvJTtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/parser": "^7.25.0",
-        "@babel/types": "^7.25.0"
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.1",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -4605,15 +4512,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
-      "integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.1.tgz",
+      "integrity": "sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -6886,9 +6792,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -9905,9 +9811,9 @@
       "license": "ISC"
     },
     "node_modules/picocolors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
     },
@@ -10887,16 +10793,6 @@
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/neptune-for-graphql",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "description": "CLI utility to create and maintain a GraphQL API for Amazon Neptune",
   "keywords": [
     "Amazon Neptune",
@@ -19,7 +19,7 @@
     "test": "test"
   },
   "scripts": {
-    "postinstall": "cd templates/Lambda4AppSyncHTTP && npm install && cd ../Lambda4AppSyncSDK && npm install && cd ../Lambda4AppSyncGraphSDK && npm install",
+    "postinstall": "cd templates/Lambda4AppSyncHTTP && npm install && cd ../Lambda4AppSyncSDK && npm install && cd ../Lambda4AppSyncGraphSDK && npm install && cd ../ApolloServer && npm install",
     "lint": "eslint neptune-for-graphql.mjs ./src",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage --runInBand --detectOpenHandles --config .jest.js",
     "test:sdk": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage --runInBand --detectOpenHandles --config .jest.js --testPathPattern=test/TestCases/Case07",
@@ -59,18 +59,18 @@
     "@aws-sdk/client-iam": "3.387.0",
     "@aws-sdk/client-lambda": "3.387.0",
     "@aws-sdk/client-neptune": "3.387.0",
-    "@aws-sdk/client-neptunedata": "3.403.0",
     "@aws-sdk/client-neptune-graph": "3.662.0",
+    "@aws-sdk/client-neptunedata": "3.403.0",
     "@aws-sdk/credential-providers": "3.414.0",
     "archiver": "7.0.1",
     "aws4-axios": "3.3.0",
-    "axios": "1.7.9",
+    "axios": "^1.9.0",
     "graphql": "^16.8.1",
     "graphql-tag": "2.12.6",
     "ora": "7.0.1",
-    "semver": "7.5.4",
     "pino": "9.4.0",
-    "pino-pretty": "11.2.2"
+    "pino-pretty": "11.2.2",
+    "semver": "7.5.4"
   },
   "devDependencies": {
     "@jest/test-sequencer": "^29.7.0",

--- a/templates/ApolloServer/package-lock.json
+++ b/templates/ApolloServer/package-lock.json
@@ -1,20 +1,20 @@
 {
-  "name": "apollo-server-test",
-  "version": "1.0.0",
+  "name": "neptune-apollo-server",
+  "version": "1.2.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "apollo-server-test",
-      "version": "1.0.0",
-      "license": "ISC",
+      "name": "neptune-apollo-server",
+      "version": "1.2.0-beta.2",
+      "license": "Apache-2.0",
       "dependencies": {
         "@apollo/server": "^4.11.3",
         "@apollo/subgraph": "^2.9.3",
         "@aws-sdk/credential-providers": "^3.729.0",
-        "apollo-server": "^3.13.0",
         "aws4-axios": "^3.3.14",
         "axios": "^1.7.9",
+        "dotenv": "^16.4.7",
         "graphql-tag": "^2.12.6",
         "retry-axios": "^3.1.3"
       }
@@ -292,28 +292,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@apollographql/apollo-tools": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.5.4.tgz",
-      "integrity": "sha512-shM3q7rUbNyXVVRkQJQseXv6bnYM3BUma/eZhwXR4xsuM+bqWnJKvW7SAfRjP7LuSCocrexa5AXhjjawNHrIlw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "graphql": "^14.2.1 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@apollographql/graphql-playground-html": {
-      "version": "1.6.29",
-      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.29.tgz",
-      "integrity": "sha512-xCcXpoz52rI4ksJSdOCxeOCn2DLocxwHf9dVT/Q90Pte1LX+LY+91SFtJF3KXVHH8kEin+g1KKCQPKBjZJfWNA==",
-      "license": "MIT",
-      "dependencies": {
-        "xss": "^1.0.8"
       }
     },
     "node_modules/@aws-crypto/sha256-browser": {
@@ -1040,21 +1018,6 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-tools/mock": {
-      "version": "8.7.20",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/mock/-/mock-8.7.20.tgz",
-      "integrity": "sha512-ljcHSJWjC/ZyzpXd5cfNhPI7YljRVvabKHPzKjEs5ElxWu2cdlLGvyNYepApXDsM/OJG/2xuhGM+9GWu5gEAPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/schema": "^9.0.18",
-        "@graphql-tools/utils": "^9.2.1",
-        "fast-json-stable-stringify": "^2.1.0",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/@graphql-tools/schema": {
       "version": "9.0.19",
       "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.19.tgz",
@@ -1091,12 +1054,6 @@
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
-    },
-    "node_modules/@josephg/resolvable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@josephg/resolvable/-/resolvable-1.0.1.tgz",
-      "integrity": "sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg==",
-      "license": "ISC"
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -1727,15 +1684,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@types/accepts": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.7.tgz",
-      "integrity": "sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
@@ -1754,12 +1702,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/cors": {
-      "version": "2.8.12",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
-      "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
-      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "4.17.21",
@@ -1898,468 +1840,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/apollo-datasource": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-3.3.2.tgz",
-      "integrity": "sha512-L5TiS8E2Hn/Yz7SSnWIVbZw0ZfEIXZCa5VUiVxD9P53JvSrf4aStvsFDlGWPvpIdCR+aly2CfoB79B9/JjKFqg==",
-      "deprecated": "The `apollo-datasource` package is part of Apollo Server v2 and v3, which are now end-of-life (as of October 22nd 2023 and October 22nd 2024, respectively). See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "license": "MIT",
-      "dependencies": {
-        "@apollo/utils.keyvaluecache": "^1.0.1",
-        "apollo-server-env": "^4.2.1"
-      },
-      "engines": {
-        "node": ">=12.0"
-      }
-    },
-    "node_modules/apollo-datasource/node_modules/@apollo/utils.keyvaluecache": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-1.0.2.tgz",
-      "integrity": "sha512-p7PVdLPMnPzmXSQVEsy27cYEjVON+SH/Wb7COyW3rQN8+wJgT1nv9jZouYtztWW8ZgTkii5T6tC9qfoDREd4mg==",
-      "license": "MIT",
-      "dependencies": {
-        "@apollo/utils.logger": "^1.0.0",
-        "lru-cache": "7.10.1 - 7.13.1"
-      }
-    },
-    "node_modules/apollo-datasource/node_modules/@apollo/utils.logger": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-1.0.1.tgz",
-      "integrity": "sha512-XdlzoY7fYNK4OIcvMD2G94RoFZbzTQaNP0jozmqqMudmaGo2I/2Jx71xlDJ801mWA/mbYRihyaw6KJii7k5RVA==",
-      "license": "MIT"
-    },
-    "node_modules/apollo-datasource/node_modules/lru-cache": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.13.1.tgz",
-      "integrity": "sha512-CHqbAq7NFlW3RSnoWXLJBxCWaZVBrfa9UEHId2M3AW8iEBurbqduNexEUCGc3SHc6iCYXNJCDi903LajSVAEPQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/apollo-reporting-protobuf": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-3.4.0.tgz",
-      "integrity": "sha512-h0u3EbC/9RpihWOmcSsvTW2O6RXVaD/mPEjfrPkxRPTEPWqncsgOoRJw+wih4OqfH3PvTJvoEIf4LwKrUaqWog==",
-      "deprecated": "The `apollo-reporting-protobuf` package is part of Apollo Server v2 and v3, which are now end-of-life (as of October 22nd 2023 and October 22nd 2024, respectively). This package's functionality is now found in the `@apollo/usage-reporting-protobuf` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "license": "MIT",
-      "dependencies": {
-        "@apollo/protobufjs": "1.2.6"
-      }
-    },
-    "node_modules/apollo-reporting-protobuf/node_modules/@apollo/protobufjs": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.6.tgz",
-      "integrity": "sha512-Wqo1oSHNUj/jxmsVp4iR3I480p6qdqHikn38lKrFhfzcDJ7lwd7Ck7cHRl4JE81tWNArl77xhnG/OkZhxKBYOw==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "apollo-pbjs": "bin/pbjs",
-        "apollo-pbts": "bin/pbts"
-      }
-    },
-    "node_modules/apollo-reporting-protobuf/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-      "license": "MIT"
-    },
-    "node_modules/apollo-server": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-3.13.0.tgz",
-      "integrity": "sha512-hgT/MswNB5G1r+oBhggVX4Fjw53CFLqG15yB5sN+OrYkCVWF5YwPbJWHfSWa7699JMEXJGaoVfFzcvLZK0UlDg==",
-      "deprecated": "The `apollo-server` package is part of Apollo Server v2 and v3, which are now end-of-life (as of October 22nd 2023 and October 22nd 2024, respectively). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "license": "MIT",
-      "dependencies": {
-        "@types/express": "4.17.14",
-        "apollo-server-core": "^3.13.0",
-        "apollo-server-express": "^3.13.0",
-        "express": "^4.17.1"
-      },
-      "peerDependencies": {
-        "graphql": "^15.3.0 || ^16.0.0"
-      }
-    },
-    "node_modules/apollo-server-core": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.13.0.tgz",
-      "integrity": "sha512-v/g6DR6KuHn9DYSdtQijz8dLOkP78I5JSVJzPkARhDbhpH74QNwrQ2PP2URAPPEDJ2EeZNQDX8PvbYkAKqg+kg==",
-      "deprecated": "The `apollo-server-core` package is part of Apollo Server v2 and v3, which are now end-of-life (as of October 22nd 2023 and October 22nd 2024, respectively). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "license": "MIT",
-      "dependencies": {
-        "@apollo/utils.keyvaluecache": "^1.0.1",
-        "@apollo/utils.logger": "^1.0.0",
-        "@apollo/utils.usagereporting": "^1.0.0",
-        "@apollographql/apollo-tools": "^0.5.3",
-        "@apollographql/graphql-playground-html": "1.6.29",
-        "@graphql-tools/mock": "^8.1.2",
-        "@graphql-tools/schema": "^8.0.0",
-        "@josephg/resolvable": "^1.0.0",
-        "apollo-datasource": "^3.3.2",
-        "apollo-reporting-protobuf": "^3.4.0",
-        "apollo-server-env": "^4.2.1",
-        "apollo-server-errors": "^3.3.1",
-        "apollo-server-plugin-base": "^3.7.2",
-        "apollo-server-types": "^3.8.0",
-        "async-retry": "^1.2.1",
-        "fast-json-stable-stringify": "^2.1.0",
-        "graphql-tag": "^2.11.0",
-        "loglevel": "^1.6.8",
-        "lru-cache": "^6.0.0",
-        "node-abort-controller": "^3.0.1",
-        "sha.js": "^2.4.11",
-        "uuid": "^9.0.0",
-        "whatwg-mimetype": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=12.0"
-      },
-      "peerDependencies": {
-        "graphql": "^15.3.0 || ^16.0.0"
-      }
-    },
-    "node_modules/apollo-server-core/node_modules/@apollo/utils.dropunuseddefinitions": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.dropunuseddefinitions/-/utils.dropunuseddefinitions-1.1.0.tgz",
-      "integrity": "sha512-jU1XjMr6ec9pPoL+BFWzEPW7VHHulVdGKMkPAMiCigpVIT11VmCbnij0bWob8uS3ODJ65tZLYKAh/55vLw2rbg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.13.0"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x || 16.x"
-      }
-    },
-    "node_modules/apollo-server-core/node_modules/@apollo/utils.keyvaluecache": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-1.0.2.tgz",
-      "integrity": "sha512-p7PVdLPMnPzmXSQVEsy27cYEjVON+SH/Wb7COyW3rQN8+wJgT1nv9jZouYtztWW8ZgTkii5T6tC9qfoDREd4mg==",
-      "license": "MIT",
-      "dependencies": {
-        "@apollo/utils.logger": "^1.0.0",
-        "lru-cache": "7.10.1 - 7.13.1"
-      }
-    },
-    "node_modules/apollo-server-core/node_modules/@apollo/utils.keyvaluecache/node_modules/lru-cache": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.13.1.tgz",
-      "integrity": "sha512-CHqbAq7NFlW3RSnoWXLJBxCWaZVBrfa9UEHId2M3AW8iEBurbqduNexEUCGc3SHc6iCYXNJCDi903LajSVAEPQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/apollo-server-core/node_modules/@apollo/utils.logger": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-1.0.1.tgz",
-      "integrity": "sha512-XdlzoY7fYNK4OIcvMD2G94RoFZbzTQaNP0jozmqqMudmaGo2I/2Jx71xlDJ801mWA/mbYRihyaw6KJii7k5RVA==",
-      "license": "MIT"
-    },
-    "node_modules/apollo-server-core/node_modules/@apollo/utils.printwithreducedwhitespace": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.printwithreducedwhitespace/-/utils.printwithreducedwhitespace-1.1.0.tgz",
-      "integrity": "sha512-GfFSkAv3n1toDZ4V6u2d7L4xMwLA+lv+6hqXicMN9KELSJ9yy9RzuEXaX73c/Ry+GzRsBy/fdSUGayGqdHfT2Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.13.0"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x || 16.x"
-      }
-    },
-    "node_modules/apollo-server-core/node_modules/@apollo/utils.removealiases": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.removealiases/-/utils.removealiases-1.0.0.tgz",
-      "integrity": "sha512-6cM8sEOJW2LaGjL/0vHV0GtRaSekrPQR4DiywaApQlL9EdROASZU5PsQibe2MWeZCOhNrPRuHh4wDMwPsWTn8A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.13.0"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x || 16.x"
-      }
-    },
-    "node_modules/apollo-server-core/node_modules/@apollo/utils.sortast": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.sortast/-/utils.sortast-1.1.0.tgz",
-      "integrity": "sha512-VPlTsmUnOwzPK5yGZENN069y6uUHgeiSlpEhRnLFYwYNoJHsuJq2vXVwIaSmts015WTPa2fpz1inkLYByeuRQA==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash.sortby": "^4.7.0"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x || 16.x"
-      }
-    },
-    "node_modules/apollo-server-core/node_modules/@apollo/utils.stripsensitiveliterals": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.stripsensitiveliterals/-/utils.stripsensitiveliterals-1.2.0.tgz",
-      "integrity": "sha512-E41rDUzkz/cdikM5147d8nfCFVKovXxKBcjvLEQ7bjZm/cg9zEcXvS6vFY8ugTubI3fn6zoqo0CyU8zT+BGP9w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.13.0"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x || 16.x"
-      }
-    },
-    "node_modules/apollo-server-core/node_modules/@apollo/utils.usagereporting": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.usagereporting/-/utils.usagereporting-1.0.1.tgz",
-      "integrity": "sha512-6dk+0hZlnDbahDBB2mP/PZ5ybrtCJdLMbeNJD+TJpKyZmSY6bA3SjI8Cr2EM9QA+AdziywuWg+SgbWUF3/zQqQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@apollo/usage-reporting-protobuf": "^4.0.0",
-        "@apollo/utils.dropunuseddefinitions": "^1.1.0",
-        "@apollo/utils.printwithreducedwhitespace": "^1.1.0",
-        "@apollo/utils.removealiases": "1.0.0",
-        "@apollo/utils.sortast": "^1.1.0",
-        "@apollo/utils.stripsensitiveliterals": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x || 16.x"
-      }
-    },
-    "node_modules/apollo-server-core/node_modules/@graphql-tools/merge": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.1.tgz",
-      "integrity": "sha512-BMm99mqdNZbEYeTPK3it9r9S6rsZsQKtlqJsSBknAclXq2pGEfOxjcIZi+kBSkHZKPKCRrYDd5vY0+rUmIHVLg==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "8.9.0",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/apollo-server-core/node_modules/@graphql-tools/schema": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.5.1.tgz",
-      "integrity": "sha512-0Esilsh0P/qYcB5DKQpiKeQs/jevzIadNTaT0jeWklPMwNbT7yMX4EqZany7mbeRRlSRwMzNzL5olyFdffHBZg==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/merge": "8.3.1",
-        "@graphql-tools/utils": "8.9.0",
-        "tslib": "^2.4.0",
-        "value-or-promise": "1.0.11"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/apollo-server-core/node_modules/@graphql-tools/utils": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
-      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/apollo-server-core/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/apollo-server-core/node_modules/value-or-promise": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.11.tgz",
-      "integrity": "sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/apollo-server-env": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-4.2.1.tgz",
-      "integrity": "sha512-vm/7c7ld+zFMxibzqZ7SSa5tBENc4B0uye9LTfjJwGoQFY5xsUPH5FpO5j0bMUDZ8YYNbrF9SNtzc5Cngcr90g==",
-      "deprecated": "The `apollo-server-env` package is part of Apollo Server v2 and v3, which are now end-of-life (as of October 22nd 2023 and October 22nd 2024, respectively). This package's functionality is now found in the `@apollo/utils.fetcher` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.6.7"
-      },
-      "engines": {
-        "node": ">=12.0"
-      }
-    },
-    "node_modules/apollo-server-errors": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-3.3.1.tgz",
-      "integrity": "sha512-xnZJ5QWs6FixHICXHxUfm+ZWqqxrNuPlQ+kj5m6RtEgIpekOPssH/SD9gf2B4HuWV0QozorrygwZnux8POvyPA==",
-      "deprecated": "The `apollo-server-errors` package is part of Apollo Server v2 and v3, which are now end-of-life (as of October 22nd 2023 and October 22nd 2024, respectively). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0"
-      },
-      "peerDependencies": {
-        "graphql": "^15.3.0 || ^16.0.0"
-      }
-    },
-    "node_modules/apollo-server-express": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-3.13.0.tgz",
-      "integrity": "sha512-iSxICNbDUyebOuM8EKb3xOrpIwOQgKxGbR2diSr4HP3IW8T3njKFOoMce50vr+moOCe1ev8BnLcw9SNbuUtf7g==",
-      "deprecated": "The `apollo-server-express` package is part of Apollo Server v2 and v3, which are now end-of-life (as of October 22nd 2023 and October 22nd 2024, respectively). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "license": "MIT",
-      "dependencies": {
-        "@types/accepts": "^1.3.5",
-        "@types/body-parser": "1.19.2",
-        "@types/cors": "2.8.12",
-        "@types/express": "4.17.14",
-        "@types/express-serve-static-core": "4.17.31",
-        "accepts": "^1.3.5",
-        "apollo-server-core": "^3.13.0",
-        "apollo-server-types": "^3.8.0",
-        "body-parser": "^1.19.0",
-        "cors": "^2.8.5",
-        "parseurl": "^1.3.3"
-      },
-      "engines": {
-        "node": ">=12.0"
-      },
-      "peerDependencies": {
-        "express": "^4.17.1",
-        "graphql": "^15.3.0 || ^16.0.0"
-      }
-    },
-    "node_modules/apollo-server-express/node_modules/@types/body-parser": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
-      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/apollo-server-express/node_modules/@types/express": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
-      "integrity": "sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.18",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "node_modules/apollo-server-express/node_modules/@types/express-serve-static-core": {
-      "version": "4.17.31",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz",
-      "integrity": "sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*"
-      }
-    },
-    "node_modules/apollo-server-plugin-base": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-3.7.2.tgz",
-      "integrity": "sha512-wE8dwGDvBOGehSsPTRZ8P/33Jan6/PmL0y0aN/1Z5a5GcbFhDaaJCjK5cav6npbbGL2DPKK0r6MPXi3k3N45aw==",
-      "deprecated": "The `apollo-server-plugin-base` package is part of Apollo Server v2 and v3, which are now end-of-life (as of October 22nd 2023 and October 22nd 2024, respectively). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "license": "MIT",
-      "dependencies": {
-        "apollo-server-types": "^3.8.0"
-      },
-      "engines": {
-        "node": ">=12.0"
-      },
-      "peerDependencies": {
-        "graphql": "^15.3.0 || ^16.0.0"
-      }
-    },
-    "node_modules/apollo-server-types": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.8.0.tgz",
-      "integrity": "sha512-ZI/8rTE4ww8BHktsVpb91Sdq7Cb71rdSkXELSwdSR0eXu600/sY+1UXhTWdiJvk+Eq5ljqoHLwLbY2+Clq2b9A==",
-      "deprecated": "The `apollo-server-types` package is part of Apollo Server v2 and v3, which are now end-of-life (as of October 22nd 2023 and October 22nd 2024, respectively). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
-      "license": "MIT",
-      "dependencies": {
-        "@apollo/utils.keyvaluecache": "^1.0.1",
-        "@apollo/utils.logger": "^1.0.0",
-        "apollo-reporting-protobuf": "^3.4.0",
-        "apollo-server-env": "^4.2.1"
-      },
-      "engines": {
-        "node": ">=12.0"
-      },
-      "peerDependencies": {
-        "graphql": "^15.3.0 || ^16.0.0"
-      }
-    },
-    "node_modules/apollo-server-types/node_modules/@apollo/utils.keyvaluecache": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-1.0.2.tgz",
-      "integrity": "sha512-p7PVdLPMnPzmXSQVEsy27cYEjVON+SH/Wb7COyW3rQN8+wJgT1nv9jZouYtztWW8ZgTkii5T6tC9qfoDREd4mg==",
-      "license": "MIT",
-      "dependencies": {
-        "@apollo/utils.logger": "^1.0.0",
-        "lru-cache": "7.10.1 - 7.13.1"
-      }
-    },
-    "node_modules/apollo-server-types/node_modules/@apollo/utils.logger": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-1.0.1.tgz",
-      "integrity": "sha512-XdlzoY7fYNK4OIcvMD2G94RoFZbzTQaNP0jozmqqMudmaGo2I/2Jx71xlDJ801mWA/mbYRihyaw6KJii7k5RVA==",
-      "license": "MIT"
-    },
-    "node_modules/apollo-server-types/node_modules/lru-cache": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.13.1.tgz",
-      "integrity": "sha512-CHqbAq7NFlW3RSnoWXLJBxCWaZVBrfa9UEHId2M3AW8iEBurbqduNexEUCGc3SHc6iCYXNJCDi903LajSVAEPQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/apollo-server/node_modules/@types/express": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
-      "integrity": "sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.18",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -2407,9 +1887,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -2531,12 +2011,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
-    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -2586,12 +2060,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/cssfilter": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
-      "license": "MIT"
-    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2627,6 +2095,18 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -2748,12 +2228,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
       "version": "4.4.1",
@@ -3597,28 +3071,6 @@
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
-    },
-    "node_modules/xss": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
-      "integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^2.20.3",
-        "cssfilter": "0.0.10"
-      },
-      "bin": {
-        "xss": "bin/xss"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
     }
   }
 }

--- a/templates/ApolloServer/package.json
+++ b/templates/ApolloServer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neptune-apollo-server",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "description": "",
   "license": "Apache-2.0",
   "author": "",

--- a/templates/Lambda4AppSyncGraphSDK/package-lock.json
+++ b/templates/Lambda4AppSyncGraphSDK/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lambda4appsyncgraphsdk",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lambda4appsyncgraphsdk",
-      "version": "1.2.0-beta.1",
+      "version": "1.2.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-neptune-graph": "3.662.0",

--- a/templates/Lambda4AppSyncGraphSDK/package.json
+++ b/templates/Lambda4AppSyncGraphSDK/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda4appsyncgraphsdk",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "description": "AWS Lambda function to bridge AppSync to Neptune Analytics",
   "main": "index.mjs",
   "type": "module",

--- a/templates/Lambda4AppSyncHTTP/package-lock.json
+++ b/templates/Lambda4AppSyncHTTP/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "lambda4appsynchttp",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lambda4appsynchttp",
-      "version": "1.2.0-beta.1",
+      "version": "1.2.0-beta.2",
       "license": "ISC",
       "dependencies": {
         "aws4-axios": "3.3.0",
-        "axios": "1.7.9",
+        "axios": "^1.9.0",
         "graphql-tag": "2.12.6",
         "retry-axios": "3.1.0"
       }
@@ -1205,9 +1205,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/templates/Lambda4AppSyncHTTP/package.json
+++ b/templates/Lambda4AppSyncHTTP/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda4appsynchttp",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "description": "AWS Lambda function to bridge AppSync to Neptune or Neptune Analytics",
   "main": "index.mjs",
   "type": "module",
@@ -11,8 +11,8 @@
   "license": "ISC",
   "dependencies": {
     "aws4-axios": "3.3.0",
-    "axios": "1.7.9",
+    "axios": "^1.9.0",
     "graphql-tag": "2.12.6",
-    "retry-axios": "3.1.0"    
+    "retry-axios": "3.1.0"
   }
 }

--- a/templates/Lambda4AppSyncSDK/package-lock.json
+++ b/templates/Lambda4AppSyncSDK/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lambda4appsyncsdk",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lambda4appsyncsdk",
-      "version": "1.2.0-beta.1",
+      "version": "1.2.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-neptunedata": "3.403.0",

--- a/templates/Lambda4AppSyncSDK/package.json
+++ b/templates/Lambda4AppSyncSDK/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda4appsyncsdk",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "description": "AWS Lambda function to bridge AppSync to Neptune",
   "main": "index.mjs",
   "type": "module",


### PR DESCRIPTION
Versioning changes:
* upgraded axios and babel versions to fix security warnings 
* fixed ApolloServer package-lock.json which was incorrectly identified as a test module
* upgraded version to 1.2.0-beta.2 to prep for release.

Verification:
* tested utility deployment and basic querying of app sync API with HTTP option (axios is used for http requests)
* tested utility creation of apollo server package and local deployment and basic querying of the apollo API (also uses axios for http requests)
* executed jest unit and integration tests (babel is transitive dependency from jest)
