### PR TITLE
Set limit on the expensive query which is retrieving distinct to and from labels for edges

### DIFF
--- a/src/NeptuneSchema.js
+++ b/src/NeptuneSchema.js
@@ -178,8 +178,9 @@ async function getEdgesNames() {
 
 
 async function findFromAndToLabels(edgeStructure) {
-    let query = `MATCH (from)-[r:${sanitize(edgeStructure.label)}]->(to) RETURN DISTINCT labels(from) as fromLabel, labels(to) as toLabel`;
-    let response = await queryNeptune(query);
+    const query = `MATCH (from)-[r:${sanitize(edgeStructure.label)}]->(to) WITH from, to LIMIT $sample RETURN DISTINCT labels(from) as fromLabel, labels(to) as toLabel`;
+    loggerDebug(`Retrieving incoming and outgoing labels for edge ${edgeStructure.label} with limit ${SAMPLE}`, {toConsole: true});
+    const response = await queryNeptune(query, {sample: SAMPLE});
     for (let result of response.results) {
         for (let fromLabel of result.fromLabel) {
             for (let toLabel of result.toLabel) {


### PR DESCRIPTION
Set limit on the expensive query which is retrieving distinct to and from labels for edges, otherwise large graphs could result in out of memory errors.

https://github.com/aws/amazon-neptune-for-graphql/issues/86
