### PR TITLE
Added separate input types for create and update mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,3 +48,4 @@ This release contains new support for Apollo Server integration.
 * Separated graphQL schema from resolver template ([#79](https://github.com/aws/amazon-neptune-for-graphql/pull/79))
 * Added unit tests for resolver and moved resolver integration tests to be unit tests ([#83](https://github.com/aws/amazon-neptune-for-graphql/pull/83))
 * Set limit on the expensive query which is retrieving distinct to and from labels for edges ([#89](https://github.com/aws/amazon-neptune-for-graphql/pull/89))
+* Added distinct input types for create and update mutations ([#93](https://github.com/aws/amazon-neptune-for-graphql/pull/93))

--- a/src/schemaModelValidator.js
+++ b/src/schemaModelValidator.js
@@ -11,10 +11,9 @@ permissions and limitations under the License.
 */
 
 import { schemaStringify } from './schemaParser.js';
-import { print } from 'graphql';
+import { GraphQLID, print } from 'graphql';
 import {gql} from 'graphql-tag'
 import { loggerInfo, yellow } from "./logger.js";
-import { GraphQLID } from 'graphql';
 
 let quiet = false;
 // TODO change variables to local scope instead of global so this module can be used against multiple schemas
@@ -142,19 +141,55 @@ function addNode(def) {
     let name = def.name.value;
     const idField = getIdFieldWithDirective(def);
 
+    // General Input type
+    typesToAdd.push(`input ${name}Input {\n${print(getInputFields(def))}\n}`);
+
     // Create Input type
-    typesToAdd.push(`input ${name}Input {\n${print(getInputFields(def))}\n}`);    
+    const createFields = [];
+    for (const field of def.fields) {
+        if (isScalarOrEnum(nullable(field.type))) {
+            if (field.type?.kind === 'NonNullType' && field.type?.type?.name?.value === GraphQLID.name) {
+                const idFieldCopy = {
+                    ...field,
+                    type: field.type.type
+                };
+                createFields.push(idFieldCopy);
+            } else {
+                createFields.push(field);
+            }
+        }
+    }
+    typesToAdd.push(`input ${name}CreateInput {\n${print(createFields)}\n}`);
+
+    // Update Input type
+    const updateFields = [];
+    for (const field of def.fields) {
+        if (isScalarOrEnum(nullable(field.type))) {
+            if (field.type?.kind === 'NonNullType' && field.type?.type?.name?.value !== GraphQLID.name) {
+                const fieldCopy = {
+                    ...field,
+                    type: field.type.type
+                };
+                updateFields.push(fieldCopy);
+            } else {
+                updateFields.push(field);
+            }
+        }
+    }
+    typesToAdd.push(`input ${name}UpdateInput {\n${print(updateFields)}\n}`);
 
     // Create query
     queriesToAdd.push(`getNode${name}(filter: ${name}Input): ${name}\n`);
     queriesToAdd.push(`getNode${name}s(filter: ${name}Input, options: Options): [${name}]\n`);
 
     // Create mutation
-    mutationsToAdd.push(`createNode${name}(input: ${name}Input!): ${name}\n`);
-    mutationsToAdd.push(`updateNode${name}(input: ${name}Input!): ${name}\n`);
+    mutationsToAdd.push(`createNode${name}(input: ${name}CreateInput!): ${name}\n`);
+    mutationsToAdd.push(`updateNode${name}(input: ${name}UpdateInput!): ${name}\n`);
     mutationsToAdd.push(`deleteNode${name}(${print(idFieldToInputValue(idField))}): Boolean\n`);
 
     loggerInfo(`Added input type: ${yellow(name+'Input')}`);
+    loggerInfo(`Added input type: ${yellow(name+'CreateInput')}`);
+    loggerInfo(`Added input type: ${yellow(name+'UpdateInput')}`);
     loggerInfo(`Added query: ${yellow('getNode' + name)}`);
     loggerInfo(`Added query: ${yellow('getNode' + name + 's')}`);
     loggerInfo(`Added mutation: ${yellow('createNode' + name)}`);

--- a/src/test/airports-mutations.graphql
+++ b/src/test/airports-mutations.graphql
@@ -1,0 +1,220 @@
+type Continent @alias(property:"continent") {
+  _id: ID! @id
+  type: String
+  code: String
+  desc: String
+  airportContainssOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType:"contains", direction:OUT)
+  contains:Contains
+}
+
+input ContinentInput {
+  _id: ID @id
+  type: String
+  code: String
+  desc: String
+}
+
+input ContinentCreateInput {
+  _id: ID @id
+  type: String
+  code: String
+  desc: String
+}
+
+input ContinentUpdateInput {
+  _id: ID! @id
+  type: String
+  code: String
+  desc: String
+}
+
+type Country @alias(property:"country") {
+  _id: ID! @id
+  type: String
+  code: String
+  desc: String
+  airportContainssOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType:"contains", direction:OUT)
+  contains:Contains
+}
+
+input CountryInput {
+  _id: ID @id
+  type: String
+  code: String
+  desc: String
+}
+
+input CountryCreateInput {
+  _id: ID @id
+  type: String
+  code: String
+  desc: String
+}
+
+input CountryUpdateInput {
+  _id: ID! @id
+  type: String
+  code: String
+  desc: String
+}
+
+type Version @alias(property:"version") {
+  _id: ID! @id
+  date: String
+  desc: String
+  author: String
+  type: String
+  code: String
+}
+
+input VersionInput {
+  _id: ID @id
+  date: String
+  desc: String
+  author: String
+  type: String
+  code: String
+}
+
+input VersionCreateInput {
+  _id: ID @id
+  date: String
+  desc: String
+  author: String
+  type: String
+  code: String
+}
+
+input VersionUpdateInput {
+  _id: ID! @id
+  date: String
+  desc: String
+  author: String
+  type: String
+  code: String
+}
+
+type Airport @alias(property:"airport") {
+  _id: ID! @id
+  type: String
+  city: String
+  icao: String
+  code: String
+  country: String
+  lat: Float
+  longest: Int
+  runways: Int
+  desc: String
+  lon: Float
+  region: String
+  elev: Int
+  continentContainsIn: Continent @relationship(edgeType:"contains", direction:IN)
+  countryContainsIn: Country @relationship(edgeType:"contains", direction:IN)
+  airportRoutesOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType:"route", direction:OUT)
+  airportRoutesIn(filter: AirportInput, options: Options): [Airport] @relationship(edgeType:"route", direction:IN)
+  contains:Contains
+  route:Route
+}
+
+input AirportInput {
+  _id: ID @id
+  type: String
+  city: String
+  icao: String
+  code: String
+  country: String
+  lat: Float
+  longest: Int
+  runways: Int
+  desc: String
+  lon: Float
+  region: String
+  elev: Int
+}
+
+input AirportCreateInput {
+  _id: ID @id
+  type: String
+  city: String
+  icao: String
+  code: String
+  country: String
+  lat: Float
+  longest: Int
+  runways: Int
+  desc: String
+  lon: Float
+  region: String
+  elev: Int
+}
+
+input AirportUpdateInput {
+  _id: ID! @id
+  type: String
+  city: String
+  icao: String
+  code: String
+  country: String
+  lat: Float
+  longest: Int
+  runways: Int
+  desc: String
+  lon: Float
+  region: String
+  elev: Int
+}
+
+type Contains @alias(property:"contains") {
+  _id: ID! @id
+}
+
+type Route @alias(property:"route") {
+  _id: ID! @id
+  dist: Int
+}
+
+input RouteInput {
+  dist: Int
+}
+
+input Options {
+  limit:Int
+}
+
+type Query {
+  getNodeContinent(filter: ContinentInput): Continent
+  getNodeContinents(filter: ContinentInput, options: Options): [Continent]
+  getNodeCountry(filter: CountryInput): Country
+  getNodeCountrys(filter: CountryInput, options: Options): [Country]
+  getNodeVersion(filter: VersionInput): Version
+  getNodeVersions(filter: VersionInput, options: Options): [Version]
+  getNodeAirport(filter: AirportInput): Airport
+  getNodeAirports(filter: AirportInput, options: Options): [Airport]
+}
+
+type Mutation {
+  createNodeContinent(input: ContinentCreateInput!): Continent
+  updateNodeContinent(input: ContinentUpdateInput!): Continent
+  deleteNodeContinent(_id: ID!): Boolean
+  createNodeCountry(input: CountryCreateInput!): Country
+  updateNodeCountry(input: CountryUpdateInput!): Country
+  deleteNodeCountry(_id: ID!): Boolean
+  createNodeVersion(input: VersionCreateInput!): Version
+  updateNodeVersion(input: VersionUpdateInput!): Version
+  deleteNodeVersion(_id: ID!): Boolean
+  createNodeAirport(input: AirportCreateInput!): Airport
+  updateNodeAirport(input: AirportUpdateInput!): Airport
+  deleteNodeAirport(_id: ID!): Boolean
+  connectNodeContinentToNodeAirportEdgeContains(from_id: ID!, to_id: ID!): Contains
+  deleteEdgeContainsFromContinentToAirport(from_id: ID!, to_id: ID!): Boolean
+  connectNodeCountryToNodeAirportEdgeContains(from_id: ID!, to_id: ID!): Contains
+  deleteEdgeContainsFromCountryToAirport(from_id: ID!, to_id: ID!): Boolean
+  connectNodeAirportToNodeAirportEdgeRoute(from_id: ID!, to_id: ID!, edge: RouteInput!): Route
+  updateEdgeRouteFromAirportToAirport(from_id: ID!, to_id: ID!, edge: RouteInput!): Route
+  deleteEdgeRouteFromAirportToAirport(from_id: ID!, to_id: ID!): Boolean
+}
+
+schema {
+  query: Query
+  mutation: Mutation
+}

--- a/src/test/graphdb.test.js
+++ b/src/test/graphdb.test.js
@@ -8,56 +8,68 @@ test('node with same property and edge label should add underscore prefix', () =
 
 test('should properly replace special chars in schema', () => {
     const actual = inferGraphQLSchema('./src/test/special-chars-neptune-schema.json');
-    const expected = loadGraphQLSchema('./src/test/special-chars.graphql')
+    const expected = loadGraphQLSchema('./src/test/special-chars.graphql');
+    expect(actual).toBe(expected);
+});
+
+test('should correctly generate mutation input types after replacing special characters in schema', () => {
+    const actual = inferGraphQLSchema('./src/test/special-chars-neptune-schema.json', { addMutations: true });
+    const expected = loadGraphQLSchema('./src/test/special-chars-mutations.graphql');
     expect(actual).toBe(expected);
 });
 
 test('should output airport schema', () => {
     const actual = inferGraphQLSchema('./src/test/airports-neptune-schema.json');
-    const expected = loadGraphQLSchema('./src/test/airports.graphql')
+    const expected = loadGraphQLSchema('./src/test/airports.graphql');
+    expect(actual).toBe(expected);
+});
+
+test('should correctly generate mutation input types after outputting airport schema', () => {
+    const actual = inferGraphQLSchema('./src/test/airports-neptune-schema.json', { addMutations: true });
+    const expected = loadGraphQLSchema('./src/test/airports-mutations.graphql');
     expect(actual).toBe(expected);
 });
 
 test('should output dining by friends schema', () => {
     const actual = inferGraphQLSchema('./src/test/dining-neptune-schema.json');
-    const expected = loadGraphQLSchema('./src/test/dining.graphql')
+    const expected = loadGraphQLSchema('./src/test/dining.graphql');
     expect(actual).toBe(expected);
 });
 
 test('should output epl schema', () => {
     const actual = inferGraphQLSchema('./src/test/epl-neptune-schema.json');
-    const expected = loadGraphQLSchema('./src/test/epl.graphql')
+    const expected = loadGraphQLSchema('./src/test/epl.graphql');
     expect(actual).toBe(expected);
 });
 
 test('should output fraud graph schema', () => {
     const actual = inferGraphQLSchema('./src/test/fraud-neptune-schema.json');
-    const expected = loadGraphQLSchema('./src/test/fraud.graphql')
+    const expected = loadGraphQLSchema('./src/test/fraud.graphql');
     expect(actual).toBe(expected);
 });
 
 test('should output knowledge graph schema', () => {
     const actual = inferGraphQLSchema('./src/test/knowledge-neptune-schema.json');
-    const expected = loadGraphQLSchema('./src/test/knowledge.graphql')
+    const expected = loadGraphQLSchema('./src/test/knowledge.graphql');
     expect(actual).toBe(expected);
 });
 
 test('should output security graph schema', () => {
     const actual = inferGraphQLSchema('./src/test/security-neptune-schema.json');
-    const expected = loadGraphQLSchema('./src/test/security.graphql')
+    const expected = loadGraphQLSchema('./src/test/security.graphql');
     expect(actual).toBe(expected);
 });
 
 test('should alias edge with same label as node', () => {
     loggerInit('./src/test/output', false, 'info');
     const actual = inferGraphQLSchema('./src/test/node-edge-same-label-neptune-schema.json');
-    const expected = loadGraphQLSchema('./src/test/node-edge-same-label.graphql')
+    const expected = loadGraphQLSchema('./src/test/node-edge-same-label.graphql');
     expect(actual).toBe(expected);
 });
 
-function inferGraphQLSchema(neptuneSchemaFilePath) {
+function inferGraphQLSchema(neptuneSchemaFilePath, options = { addMutations: false }) {
     let neptuneSchema = readFile(neptuneSchemaFilePath);
-    let inferredSchema = graphDBInferenceSchema(neptuneSchema);
+    let inferredSchema = graphDBInferenceSchema(neptuneSchema, options.addMutations);
     return sanitizeWhitespace(inferredSchema);
 }
 

--- a/src/test/schemaModelValidator.test.js
+++ b/src/test/schemaModelValidator.test.js
@@ -66,10 +66,37 @@ describe('validatedSchemaModel', () => {
         });
     });
 
+    test('should add CreateInput with nullable ID and UpdateInput with non-nullable ID as mutation input types', () => {
+        const typeNames = ['User', 'Group'];
+
+        typeNames.forEach(typeName => {
+            const createInputType = model.definitions.find(
+                def =>
+                    def.kind === 'InputObjectTypeDefinition' &&
+                    def.name.value === `${typeName}CreateInput`
+            );
+
+            const updateInputType = model.definitions.find(
+                def =>
+                    def.kind === 'InputObjectTypeDefinition' &&
+                    def.name.value === `${typeName}UpdateInput`
+            );
+
+            expect(createInputType).toBeDefined();
+            expect(updateInputType).toBeDefined();
+
+            const createIdField = getIdFields(createInputType)[0];
+            const updateIdField = getIdFields(updateInputType)[0];
+
+            expect(createIdField.type.kind).toEqual('NamedType');
+            expect(updateIdField.type.kind).toEqual('NonNullType');
+        });
+    });
+
     test('should allow enum types as input fields', () => {
         const roleEnumType = model.definitions.find(def => def.kind === 'EnumTypeDefinition' && def.name.value === 'Role');
         expect(roleEnumType.values.map(value => value.name.value)).toEqual(expect.arrayContaining(['USER','ADMIN','GUEST']));
-        
+
         const userInput = model.definitions.find(def => def.kind === 'InputObjectTypeDefinition' && def.name.value === 'UserInput');
         const userRoleField = userInput.fields.find(field => field.name.value === 'role');
         expect(userRoleField.type.name.value).toEqual('Role');

--- a/src/test/special-chars-mutations.graphql
+++ b/src/test/special-chars-mutations.graphql
@@ -1,0 +1,160 @@
+type Abc_ex__dol_123_amp_efg @alias(property:"abc!$123&efg") {
+  _id: ID! @id
+  instance_type: String
+  state: String
+  arn: String
+  abc_op_123_cp__dot_efg_cn_456Resource_linkOut: Abc_op_123_cp__dot_efg_cn_456 @relationship(edgeType:"resource_link", direction:OUT)
+  abc_ex__dol_123_amp_efgResource_linkOut: Abc_ex__dol_123_amp_efg @relationship(edgeType:"resource_link", direction:OUT)
+  abc_ex__dol_123_amp_efgResource_linkIn: Abc_ex__dol_123_amp_efg @relationship(edgeType:"resource_link", direction:IN)
+  resource_link:Resource_link
+}
+
+input Abc_ex__dol_123_amp_efgInput {
+  _id: ID @id
+  instance_type: String
+  state: String
+  arn: String
+}
+
+input Abc_ex__dol_123_amp_efgCreateInput {
+  _id: ID @id
+  instance_type: String
+  state: String
+  arn: String
+}
+
+input Abc_ex__dol_123_amp_efgUpdateInput {
+  _id: ID! @id
+  instance_type: String
+  state: String
+  arn: String
+}
+
+type Abc_op_123_cp__dot_efg_cn_456 @alias(property:"abc(123).efg:456") {
+  _id: ID! @id
+  name: String
+  ip_range_dot_first_ip: String @alias(property: "ip_range.first_ip")
+  ip_range_dot_last_ip: String @alias(property: "ip_range.last_ip")
+  abc_ex__dol_123_amp_efgResource_linksIn(filter: Abc_ex__dol_123_amp_efgInput, options: Options): [Abc_ex__dol_123_amp_efg] @relationship(edgeType:"resource_link", direction:IN)
+  resource_link:Resource_link
+}
+
+input Abc_op_123_cp__dot_efg_cn_456Input {
+  _id: ID @id
+  name: String
+  ip_range_dot_first_ip: String @alias(property: "ip_range.first_ip")
+  ip_range_dot_last_ip: String @alias(property: "ip_range.last_ip")
+}
+
+input Abc_op_123_cp__dot_efg_cn_456CreateInput {
+  _id: ID @id
+  name: String
+  ip_range_dot_first_ip: String @alias(property: "ip_range.first_ip")
+  ip_range_dot_last_ip: String @alias(property: "ip_range.last_ip")
+}
+
+input Abc_op_123_cp__dot_efg_cn_456UpdateInput {
+  _id: ID! @id
+  name: String
+  ip_range_dot_first_ip: String @alias(property: "ip_range.first_ip")
+  ip_range_dot_last_ip: String @alias(property: "ip_range.last_ip")
+}
+
+type Abc_eq_123_at__os_efg_cs_456 @alias(property:"abc=123@[efg]456") {
+  _id: ID! @id
+  instance_type: String
+  state: String
+  arn: String
+}
+
+input Abc_eq_123_at__os_efg_cs_456Input {
+  _id: ID @id
+  instance_type: String
+  state: String
+  arn: String
+}
+
+input Abc_eq_123_at__os_efg_cs_456CreateInput {
+  _id: ID @id
+  instance_type: String
+  state: String
+  arn: String
+}
+
+input Abc_eq_123_at__os_efg_cs_456UpdateInput {
+  _id: ID! @id
+  instance_type: String
+  state: String
+  arn: String
+}
+
+type Abc_oc_123_cc__vb_efg_hy_456 @alias(property:"abc{123}|efg-456") {
+  _id: ID! @id
+  name: String
+  ip_range_dot_first_ip: String @alias(property: "ip_range.first_ip")
+  ip_range_dot_last_ip: String @alias(property: "ip_range.last_ip")
+}
+
+input Abc_oc_123_cc__vb_efg_hy_456Input {
+  _id: ID @id
+  name: String
+  ip_range_dot_first_ip: String @alias(property: "ip_range.first_ip")
+  ip_range_dot_last_ip: String @alias(property: "ip_range.last_ip")
+}
+
+input Abc_oc_123_cc__vb_efg_hy_456CreateInput {
+  _id: ID @id
+  name: String
+  ip_range_dot_first_ip: String @alias(property: "ip_range.first_ip")
+  ip_range_dot_last_ip: String @alias(property: "ip_range.last_ip")
+}
+
+input Abc_oc_123_cc__vb_efg_hy_456UpdateInput {
+  _id: ID! @id
+  name: String
+  ip_range_dot_first_ip: String @alias(property: "ip_range.first_ip")
+  ip_range_dot_last_ip: String @alias(property: "ip_range.last_ip")
+}
+
+type Resource_link @alias(property:"resource_link") {
+  _id: ID! @id
+}
+
+input Options {
+  limit:Int
+}
+
+type Query {
+  getNodeAbc_ex__dol_123_amp_efg(filter: Abc_ex__dol_123_amp_efgInput): Abc_ex__dol_123_amp_efg
+  getNodeAbc_ex__dol_123_amp_efgs(filter: Abc_ex__dol_123_amp_efgInput, options: Options): [Abc_ex__dol_123_amp_efg]
+  getNodeAbc_op_123_cp__dot_efg_cn_456(filter: Abc_op_123_cp__dot_efg_cn_456Input): Abc_op_123_cp__dot_efg_cn_456
+  getNodeAbc_op_123_cp__dot_efg_cn_456s(filter: Abc_op_123_cp__dot_efg_cn_456Input, options: Options): [Abc_op_123_cp__dot_efg_cn_456]
+  getNodeAbc_eq_123_at__os_efg_cs_456(filter: Abc_eq_123_at__os_efg_cs_456Input): Abc_eq_123_at__os_efg_cs_456
+  getNodeAbc_eq_123_at__os_efg_cs_456s(filter: Abc_eq_123_at__os_efg_cs_456Input, options: Options): [Abc_eq_123_at__os_efg_cs_456]
+  getNodeAbc_oc_123_cc__vb_efg_hy_456(filter: Abc_oc_123_cc__vb_efg_hy_456Input): Abc_oc_123_cc__vb_efg_hy_456
+  getNodeAbc_oc_123_cc__vb_efg_hy_456s(filter: Abc_oc_123_cc__vb_efg_hy_456Input, options: Options): [Abc_oc_123_cc__vb_efg_hy_456]
+}
+
+type Mutation {
+  createNodeAbc_ex__dol_123_amp_efg(input: Abc_ex__dol_123_amp_efgCreateInput!): Abc_ex__dol_123_amp_efg
+  updateNodeAbc_ex__dol_123_amp_efg(input: Abc_ex__dol_123_amp_efgUpdateInput!): Abc_ex__dol_123_amp_efg
+  deleteNodeAbc_ex__dol_123_amp_efg(_id: ID!): Boolean
+  createNodeAbc_op_123_cp__dot_efg_cn_456(input: Abc_op_123_cp__dot_efg_cn_456CreateInput!): Abc_op_123_cp__dot_efg_cn_456
+  updateNodeAbc_op_123_cp__dot_efg_cn_456(input: Abc_op_123_cp__dot_efg_cn_456UpdateInput!): Abc_op_123_cp__dot_efg_cn_456
+  deleteNodeAbc_op_123_cp__dot_efg_cn_456(_id: ID!): Boolean
+  createNodeAbc_eq_123_at__os_efg_cs_456(input: Abc_eq_123_at__os_efg_cs_456CreateInput!): Abc_eq_123_at__os_efg_cs_456
+  updateNodeAbc_eq_123_at__os_efg_cs_456(input: Abc_eq_123_at__os_efg_cs_456UpdateInput!): Abc_eq_123_at__os_efg_cs_456
+  deleteNodeAbc_eq_123_at__os_efg_cs_456(_id: ID!): Boolean
+  createNodeAbc_oc_123_cc__vb_efg_hy_456(input: Abc_oc_123_cc__vb_efg_hy_456CreateInput!): Abc_oc_123_cc__vb_efg_hy_456
+  updateNodeAbc_oc_123_cc__vb_efg_hy_456(input: Abc_oc_123_cc__vb_efg_hy_456UpdateInput!): Abc_oc_123_cc__vb_efg_hy_456
+  deleteNodeAbc_oc_123_cc__vb_efg_hy_456(_id: ID!): Boolean
+  connectNodeAbc_ex__dol_123_amp_efgToNodeAbc_op_123_cp__dot_efg_cn_456EdgeResource_link(from_id: ID!, to_id: ID!): Resource_link
+  deleteEdgeResource_linkFromAbc_ex__dol_123_amp_efgToAbc_op_123_cp__dot_efg_cn_456(from_id: ID!, to_id: ID!): Boolean
+  connectNodeAbc_ex__dol_123_amp_efgToNodeAbc_ex__dol_123_amp_efgEdgeResource_link(from_id: ID!, to_id: ID!): Resource_link
+  deleteEdgeResource_linkFromAbc_ex__dol_123_amp_efgToAbc_ex__dol_123_amp_efg(from_id: ID!, to_id: ID!): Boolean
+}
+
+schema {
+  query: Query
+  mutation: Mutation
+}

--- a/src/test/user-group-validated.graphql
+++ b/src/test/user-group-validated.graphql
@@ -35,12 +35,48 @@ input UserInput {
   email: EmailAddress
 }
 
+input UserCreateInput {
+  userId: ID @id
+  firstName: String
+  lastName: String
+  role: Role
+  email: EmailAddress
+}
+
+input UserUpdateInput {
+  userId: ID! @id
+  firstName: String
+  lastName: String
+  role: Role
+  email: EmailAddress
+}
+
 input GroupInput {
   _id: ID! @id
   name: String
 }
 
+input GroupCreateInput {
+  _id: ID @id
+  name: String
+}
+
+input GroupUpdateInput {
+  _id: ID! @id
+  name: String
+}
+
 input ModeratorInput {
+  moderatorId: ID! @id
+  name: String
+}
+
+input ModeratorCreateInput {
+  moderatorId: ID @id
+  name: String
+}
+
+input ModeratorUpdateInput {
   moderatorId: ID! @id
   name: String
 }
@@ -63,14 +99,14 @@ type Query {
 }
 
 type Mutation {
-  createNodeUser(input: UserInput!): User
-  updateNodeUser(input: UserInput!): User
+  createNodeUser(input: UserCreateInput!): User
+  updateNodeUser(input: UserUpdateInput!): User
   deleteNodeUser(userId: ID!): Boolean
-  createNodeGroup(input: GroupInput!): Group
-  updateNodeGroup(input: GroupInput!): Group
+  createNodeGroup(input: GroupCreateInput!): Group
+  updateNodeGroup(input: GroupUpdateInput!): Group
   deleteNodeGroup(_id: ID!): Boolean
-  createNodeModerator(input: ModeratorInput!): Moderator
-  updateNodeModerator(input: ModeratorInput!): Moderator
+  createNodeModerator(input: ModeratorCreateInput!): Moderator
+  updateNodeModerator(input: ModeratorUpdateInput!): Moderator
   deleteNodeModerator(moderatorId: ID!): Boolean
   connectNodeModeratorToNodeGroupEdgeGroupEdge(from_id: ID!, to_id: ID!): GroupEdge
   deleteEdgeGroupEdgeFromModeratorToGroup(from_id: ID!, to_id: ID!): Boolean


### PR DESCRIPTION
The utility currently generates the same input types for queries as mutations.

This is not ideal as it would be expected that the required fields will differ for queries vs mutations. For example, id should not be mandatory when creating a node as it should be auto generated by the server. However id should be required when updating a node.

Generating distinct input types for queries vs create and update mutations will provide better flexibility to the user to modify the generated schema accordingly.