### PR TITLE
Allow enum types in schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This release contains new support for Apollo Server integration.
 * Fixed bug with ID argument type conversion and added Apollo arguments to help menu (#74)
 * Upgraded axios and babel versions to fix security warnings (#90)
 * Fixed failing integration test by excluding `node_modules` from Apollo zip (#94)
+* Fixed enum types in schema to be included in input types (#95)
 
 ### Features
 

--- a/src/test/directive-id.graphql
+++ b/src/test/directive-id.graphql
@@ -2,8 +2,15 @@ type User {
     userId: ID! @id
     firstName: String
     lastName: String
+    role: Role
 }
 
 type Group {
     name: String
+}
+
+enum Role {
+    ADMIN
+    USER
+    GUEST
 }

--- a/templates/queryHttpNeptune.mjs
+++ b/templates/queryHttpNeptune.mjs
@@ -33,6 +33,9 @@ export async function queryNeptune(neptuneUrl, resolvedQuery, options = {logging
         };
 
         let response;
+        if (loggingEnabled) {
+            console.log("Query: ", JSON.stringify(resolvedQuery, null, 2));
+        }
         if (resolvedQuery.language === 'opencypher') {
             response = await axios.post(`${neptuneUrl}/opencypher`, {
                 query: resolvedQuery.query, parameters: JSON.stringify(resolvedQuery.parameters)


### PR DESCRIPTION
Fix issues with schema generation which was causing input schema enum types to be generated as edge types and prevented enum fields from being used as part of input types.

Example of generated schema before fix:
```
type Todo {
  _id: ID!
  name: String
  description: String
  category: Category
  # category enum should not produce an edge field
  categoryEdge: CategoryEdge
}
enum Category {
  CAT1
  CAT2
}
# category enum should not produce an edge type
type CategoryEdge {
  _id: ID!
}
input TodoInput {
  _id: ID!
  name: String
  description: String
  # category enum field missing from input
}
```

After fix:
```
type Todo {
  _id: ID!
  name: String
  description: String
  category: Category
}
enum Category {
  CAT1
  CAT2
}
input TodoInput {
  _id: ID!
  name: String
  description: String
  category: Category
}
```
