### PR TITLE
Account for id fields which may be missing the @id directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This release contains new support for Apollo Server integration.
 * Upgraded axios and babel versions to fix security warnings (#90)
 * Fixed failing integration test by excluding `node_modules` from Apollo zip (#94)
 * Fixed enum types in schema to be included in input types (#95)
+* Fixed bug where id fields without @id directives are not accounted for (#96)
 
 ### Features
 

--- a/src/test/directive-id.graphql
+++ b/src/test/directive-id.graphql
@@ -9,6 +9,11 @@ type Group {
     name: String
 }
 
+type Moderator {
+    moderatorId: ID!
+    name: String
+}
+
 enum Role {
     ADMIN
     USER

--- a/src/test/schemaModelValidator.test.js
+++ b/src/test/schemaModelValidator.test.js
@@ -15,9 +15,9 @@ describe('validatedSchemaModel', () => {
 
     test('types definitions should be as expected', () => {
         const objectTypes = model.definitions.filter(def => def.kind === 'ObjectTypeDefinition').map(def => def.name.value);
-        expect(objectTypes).toEqual(expect.arrayContaining(['User','Group','Query', 'Mutation']));
+        expect(objectTypes).toEqual(expect.arrayContaining(['User','Group','Moderator','Query', 'Mutation']));
         const inputTypes = model.definitions.filter(def => def.kind === 'InputObjectTypeDefinition').map(def => def.name.value);
-        expect(inputTypes).toEqual(expect.arrayContaining(['UserInput','GroupInput','Options']));
+        expect(inputTypes).toEqual(expect.arrayContaining(['UserInput','GroupInput','ModeratorInput','Options']));
         const enumTypes = model.definitions.filter(def => def.kind === 'EnumTypeDefinition').map(def => def.name.value);
         expect(enumTypes).toEqual(expect.arrayContaining(['Role']));
     });
@@ -26,18 +26,26 @@ describe('validatedSchemaModel', () => {
         const objTypeDefs = model.definitions.filter(def => def.kind === 'ObjectTypeDefinition');
         const userType = objTypeDefs.find(def => def.name.value === 'User');
         const groupType = objTypeDefs.find(def => def.name.value === 'Group');
+        const moderatorType = objTypeDefs.find(def => def.name.value === 'Moderator');
+
+        expect(userType.fields).toHaveLength(4);
+        expect(groupType.fields).toHaveLength(2);
+        expect(moderatorType.fields).toHaveLength(2);
 
         const userIdFields = getIdFields(userType);
         const groupIdFields = getIdFields(groupType);
+        const moderatorIdFields = getIdFields(moderatorType);
 
         expect(userIdFields).toHaveLength(1);
         expect(groupIdFields).toHaveLength(1);
+        expect(moderatorIdFields).toHaveLength(1);
         expect(userIdFields[0].name.value).toEqual('userId');
         expect(groupIdFields[0].name.value).toEqual('_id');
+        expect(moderatorIdFields[0].name.value).toEqual('moderatorId');
     });
 
     test('should define the same ID fields on a type and its input type', () => {
-        const typeNames = ['User', 'Group'];
+        const typeNames = ['User', 'Group', 'Moderator'];
 
         typeNames.forEach(typeName => {
             const type = model.definitions.find(


### PR DESCRIPTION
Currently, if an input schema does not contain the @id directive for id fields, the utility does not recognize it as an id field and adds another id field with the @id directive. 

PR for fixing duplication bug.