### PR TITLE
Allow custom scalars in schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,28 +20,30 @@ This release contains new support for Apollo Server integration.
 
 ### Bug Fixes
 
-* Don't cast integers to floats in Neptune schema (#62)
-* Fix query from AppSync with an empty filter object (#61)
-* Retain numeric parameter value type when creating open cypher query (#63)
-* Fixed bug with ID argument type conversion and added Apollo arguments to help menu (#74)
-* Upgraded axios and babel versions to fix security warnings (#90)
-* Fixed failing integration test by excluding `node_modules` from Apollo zip (#94)
-* Fixed enum types in schema to be included in input types (#95)
-* Fixed bug where id fields without @id directives are not accounted for (#96)
+* Don't cast integers to floats in Neptune schema ([#62](https://github.com/aws/amazon-neptune-for-graphql/pull/62))
+* Fix query from AppSync with an empty filter object ([#61](https://github.com/aws/amazon-neptune-for-graphql/pull/61))
+* Retain numeric parameter value type when creating open cypher query ([#63](https://github.com/aws/amazon-neptune-for-graphql/pull/63))
+* Fixed bug with ID argument type conversion and added Apollo arguments to help menu ([#74](https://github.com/aws/amazon-neptune-for-graphql/pull/74))
+* Upgraded axios and babel versions to fix security warnings ([#90](https://github.com/aws/amazon-neptune-for-graphql/pull/90))
+* Fixed failing integration test by excluding `node_modules` from Apollo zip ([#94](https://github.com/aws/amazon-neptune-for-graphql/pull/94))
+* Fixed enum types in schema to be included in input types ([#95](https://github.com/aws/amazon-neptune-for-graphql/pull/95))
+* Fixed bug where id fields without @id directives are not accounted for ([#96](https://github.com/aws/amazon-neptune-for-graphql/pull/96))
+* Fixed custom scalar types in schema to be included in input types and queries generated from an input schema which retrieve an array to have an option parameter with limit ([#95](https://github.com/aws/amazon-neptune-for-graphql/pull/97))
+
 
 ### Features
 
-* Support output of zip package of Apollo Server artifacts (#70, #72, #73, #75, #76)
+* Support output of zip package of Apollo Server artifacts (([#70](https://github.com/aws/amazon-neptune-for-graphql/pull/70)), ([#72](https://github.com/aws/amazon-neptune-for-graphql/pull/72)), ([#73](https://github.com/aws/amazon-neptune-for-graphql/pull/73)), ([#75](https://github.com/aws/amazon-neptune-for-graphql/pull/75)), ([#76](https://github.com/aws/amazon-neptune-for-graphql/pull/76)))
 
 ### Improvements
 
-* Increased graphdb.js test coverage using sample data (#53)
-* Saved the neptune schema to file early so that it can be used for troubleshooting (#56)
-* Alias edges with same label as a node (#57)
-* Cap concurrent requests to get Neptune schema (#58)
-* Honour @id directive on type fields (#60)
-* Changed lambda template to use ECMAScripts modules (#68)
-* Add template file missing from packaging (#71)
-* Separated graphQL schema from resolver template (#79)
-* Added unit tests for resolver and moved resolver integration tests to be unit tests (#83)
-* Set limit on the expensive query which is retrieving distinct to and from labels for edges (#89)
+* Increased graphdb.js test coverage using sample data ([#53](https://github.com/aws/amazon-neptune-for-graphql/pull/53))
+* Saved the neptune schema to file early so that it can be used for troubleshooting ([#56](https://github.com/aws/amazon-neptune-for-graphql/pull/56))
+* Alias edges with same label as a node ([#57](https://github.com/aws/amazon-neptune-for-graphql/pull/57))
+* Cap concurrent requests to get Neptune schema ([#58](https://github.com/aws/amazon-neptune-for-graphql/pull/58))
+* Honour @id directive on type fields ([#60](https://github.com/aws/amazon-neptune-for-graphql/pull/60))
+* Changed lambda template to use ECMAScripts modules ([#68](https://github.com/aws/amazon-neptune-for-graphql/pull/68))
+* Add template file missing from packaging ([#71](https://github.com/aws/amazon-neptune-for-graphql/pull/71))
+* Separated graphQL schema from resolver template ([#79](https://github.com/aws/amazon-neptune-for-graphql/pull/79))
+* Added unit tests for resolver and moved resolver integration tests to be unit tests ([#83](https://github.com/aws/amazon-neptune-for-graphql/pull/83))
+* Set limit on the expensive query which is retrieving distinct to and from labels for edges ([#89](https://github.com/aws/amazon-neptune-for-graphql/pull/89))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ This release contains new support for Apollo Server integration.
 * Fixed failing integration test by excluding `node_modules` from Apollo zip ([#94](https://github.com/aws/amazon-neptune-for-graphql/pull/94))
 * Fixed enum types in schema to be included in input types ([#95](https://github.com/aws/amazon-neptune-for-graphql/pull/95))
 * Fixed bug where id fields without @id directives are not accounted for ([#96](https://github.com/aws/amazon-neptune-for-graphql/pull/96))
-* Fixed custom scalar types in schema to be included in input types and queries generated from an input schema which retrieve an array to have an option parameter with limit ([#95](https://github.com/aws/amazon-neptune-for-graphql/pull/97))
+* Fixed custom scalar types in schema to be included in input types ([#97](https://github.com/aws/amazon-neptune-for-graphql/pull/97))
+* Fixed queries generated from an input schema which retrieve an array to have an option parameter with limit ([#97](https://github.com/aws/amazon-neptune-for-graphql/pull/97))
 
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -302,12 +302,17 @@ The example commands above will generate the file `apollo-server-<identifier>-<t
 > [!NOTE] 
 > Node's default AWS credentials provider is used for authentication with Neptune. See [AWS SDK credential providers](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-credential-providers/#fromnodeproviderchain) for more information.
 
+### Using Custom Scalars with Apollo Server
+When using custom scalars in your schema (specified via `--input-schema-file`), you should add corresponding scalar resolvers to the index.mjs file in the generated Apollo Server artifact. Although queries will execute without these resolvers, the absence of the custom scalar resolvers will bypass important data validation for fields using custom scalar types. See [Apollo Custom Scalars](https://www.apollographql.com/docs/apollo-server/schema/custom-scalars) for more details on how to attach custom scalar resolvers with Apollo Server.
+
 # Known limitations
 - @graphQuery using Gremlin works only if the query returns a scalar value, one elementMap(), or list as elementMap().fold(), this feature is under development.
 - Neptune RDF database and SPARQL language is not supported.
 - Querying Neptune via SDK is not yet supported for Apollo Server, only HTTPS is supported.
 - Mutations are not yet supported for Apollo Server
-<br>
+- Schemas specified by `--input-schema-file` with `--create-update-aws-pipeline` may not contain custom scalars. See [AWS App Sync Scalar types in GraphQL](https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html) for more information.
+- Schemas specified by `--input-schema-file` with `--create-update-apollo-server` or `--create-update-apollo-server-subgraph` which contain custom scalars require manual steps to add custom scalar resolvers for additional query validation.
+  <br>
 
 # Roadmap
 - Gremlin resolver.

--- a/doc/todoExample.md
+++ b/doc/todoExample.md
@@ -73,10 +73,10 @@ input Options {
 }
 
 type Query {
-  getNodeTodo(filter: TodoInput, options: Options): Todo
-  getNodeTodos(filter: TodoInput): [Todo]
-  getNodeComment(filter: CommentInput, options: Options): Comment
-  getNodeComments(filter: CommentInput): [Comment]
+  getNodeTodo(filter: TodoInput): Todo
+  getNodeTodos(filter: TodoInput, options: Options): [Todo]
+  getNodeComment(filter: CommentInput): Comment
+  getNodeComments(filter: CommentInput, options: Options): [Comment]
 }
 
 type Mutation {

--- a/src/test/schemaModelValidator.test.js
+++ b/src/test/schemaModelValidator.test.js
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { loggerInit } from '../logger.js';
 import { validatedSchemaModel } from '../schemaModelValidator.js';
-import {schemaParser, schemaStringify} from '../schemaParser.js';
+import { schemaParser, schemaStringify } from '../schemaParser.js';
 
 describe('validatedSchemaModel', () => {
     let model;

--- a/src/test/schemaModelValidator.test.js
+++ b/src/test/schemaModelValidator.test.js
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { loggerInit } from '../logger.js';
 import { validatedSchemaModel } from '../schemaModelValidator.js';
-import { schemaParser } from '../schemaParser.js';
+import {schemaParser, schemaStringify} from '../schemaParser.js';
 
 describe('validatedSchemaModel', () => {
     let model;
@@ -9,7 +9,7 @@ describe('validatedSchemaModel', () => {
     beforeAll(() => {
         loggerInit('./output', false, 'silent');
 
-        const schema = readFileSync('./src/test/directive-id.graphql');
+        const schema = readFileSync('./src/test/user-group.graphql');
         model = validatedSchemaModel(schemaParser(schema));
     });
 
@@ -28,9 +28,9 @@ describe('validatedSchemaModel', () => {
         const groupType = objTypeDefs.find(def => def.name.value === 'Group');
         const moderatorType = objTypeDefs.find(def => def.name.value === 'Moderator');
 
-        expect(userType.fields).toHaveLength(4);
+        expect(userType.fields).toHaveLength(5);
         expect(groupType.fields).toHaveLength(2);
-        expect(moderatorType.fields).toHaveLength(2);
+        expect(moderatorType.fields).toHaveLength(4);
 
         const userIdFields = getIdFields(userType);
         const groupIdFields = getIdFields(groupType);
@@ -73,6 +73,12 @@ describe('validatedSchemaModel', () => {
         const userInput = model.definitions.find(def => def.kind === 'InputObjectTypeDefinition' && def.name.value === 'UserInput');
         const userRoleField = userInput.fields.find(field => field.name.value === 'role');
         expect(userRoleField.type.name.value).toEqual('Role');
+    });
+    
+    test('should output expected validated schema', () => {
+        const actual = schemaStringify(model, true);
+        const expected = readFileSync('./src/test/user-group-validated.graphql', 'utf8')
+        expect(actual).toBe(expected); 
     });
 
     function getIdFields(objTypeDef) {

--- a/src/test/user-group-validated.graphql
+++ b/src/test/user-group-validated.graphql
@@ -1,0 +1,82 @@
+type User {
+  userId: ID! @id
+  firstName: String
+  lastName: String
+  role: Role
+  email: EmailAddress
+}
+
+type Group {
+  _id: ID! @id
+  name: String
+}
+
+type Moderator {
+  moderatorId: ID! @id
+  name: String
+  moderates: Group @relationship(type: "GroupEdge", direction: OUT)
+  groupEdge: GroupEdge
+}
+
+enum Role {
+  ADMIN
+  USER
+  GUEST
+}
+
+"https://the-guild.dev/graphql/scalars/docs/scalars/email-address"
+scalar EmailAddress
+
+input UserInput {
+  userId: ID! @id
+  firstName: String
+  lastName: String
+  role: Role
+  email: EmailAddress
+}
+
+input GroupInput {
+  _id: ID! @id
+  name: String
+}
+
+input ModeratorInput {
+  moderatorId: ID! @id
+  name: String
+}
+
+type GroupEdge {
+  _id: ID! @id
+}
+
+input Options {
+  limit: Int
+}
+
+type Query {
+  getNodeUser(filter: UserInput): User
+  getNodeUsers(filter: UserInput, options: Options): [User]
+  getNodeGroup(filter: GroupInput): Group
+  getNodeGroups(filter: GroupInput, options: Options): [Group]
+  getNodeModerator(filter: ModeratorInput): Moderator
+  getNodeModerators(filter: ModeratorInput, options: Options): [Moderator]
+}
+
+type Mutation {
+  createNodeUser(input: UserInput!): User
+  updateNodeUser(input: UserInput!): User
+  deleteNodeUser(userId: ID!): Boolean
+  createNodeGroup(input: GroupInput!): Group
+  updateNodeGroup(input: GroupInput!): Group
+  deleteNodeGroup(_id: ID!): Boolean
+  createNodeModerator(input: ModeratorInput!): Moderator
+  updateNodeModerator(input: ModeratorInput!): Moderator
+  deleteNodeModerator(moderatorId: ID!): Boolean
+  connectNodeModeratorToNodeGroupEdgeGroupEdge(from_id: ID!, to_id: ID!): GroupEdge
+  deleteEdgeGroupEdgeFromModeratorToGroup(from_id: ID!, to_id: ID!): Boolean
+}
+
+schema {
+  query: Query
+  mutation: Mutation
+}

--- a/src/test/user-group.graphql
+++ b/src/test/user-group.graphql
@@ -3,6 +3,7 @@ type User {
     firstName: String
     lastName: String
     role: Role
+    email: EmailAddress
 }
 
 type Group {
@@ -12,6 +13,7 @@ type Group {
 type Moderator {
     moderatorId: ID!
     name: String
+    moderates: Group
 }
 
 enum Role {
@@ -19,3 +21,6 @@ enum Role {
     USER
     GUEST
 }
+
+"https://the-guild.dev/graphql/scalars/docs/scalars/email-address"
+scalar EmailAddress


### PR DESCRIPTION
If a given input schema contained a custom scalar, the utility would generate an invalid schema and any field which has a custom scalar type will not be able to be used as input for a query or mutation.

Changes include:
* fixed `schemaModelValidator.js` to no longer interpret custom scalars as edges and also allow fields of custom scalar types to be included as part of input types
* fixed `schemaModelValidator.js` to add the `Options` parameter to generated queries that retrieve an array of objects instead of the queries that retrieve single objects
* added documentation for how to use custom scalars with Apollo Server and scalar restrictions with App Sync
