### PR TITLE
Enabled mutations for apollo server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,3 +49,4 @@ This release contains new support for Apollo Server integration.
 * Added unit tests for resolver and moved resolver integration tests to be unit tests ([#83](https://github.com/aws/amazon-neptune-for-graphql/pull/83))
 * Set limit on the expensive query which is retrieving distinct to and from labels for edges ([#89](https://github.com/aws/amazon-neptune-for-graphql/pull/89))
 * Added distinct input types for create and update mutations ([#93](https://github.com/aws/amazon-neptune-for-graphql/pull/93))
+* Enabled mutations for the Apollo Server ([#98](https://github.com/aws/amazon-neptune-for-graphql/pull/98))

--- a/README.md
+++ b/README.md
@@ -309,7 +309,6 @@ When using custom scalars in your schema (specified via `--input-schema-file`), 
 - @graphQuery using Gremlin works only if the query returns a scalar value, one elementMap(), or list as elementMap().fold(), this feature is under development.
 - Neptune RDF database and SPARQL language is not supported.
 - Querying Neptune via SDK is not yet supported for Apollo Server, only HTTPS is supported.
-- Mutations are not yet supported for Apollo Server
 - Schemas specified by `--input-schema-file` with `--create-update-aws-pipeline` may not contain custom scalars. See [AWS App Sync Scalar types in GraphQL](https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html) for more information.
 - Schemas specified by `--input-schema-file` with `--create-update-apollo-server` or `--create-update-apollo-server-subgraph` which contain custom scalars require manual steps to add custom scalar resolvers for additional query validation.
   <br>


### PR DESCRIPTION
As mutations are currently unsupported in the apollo server, they have been enabled and verified that they work as expected when executed against the graphQL API.