### PR TITLE
Enhanced string filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,14 @@ This release contains new support for Apollo Server integration.
 * Fixed bug where id fields without @id directives are not accounted for ([#96](https://github.com/aws/amazon-neptune-for-graphql/pull/96))
 * Fixed custom scalar types in schema to be included in input types ([#97](https://github.com/aws/amazon-neptune-for-graphql/pull/97))
 * Fixed queries generated from an input schema which retrieve an array to have an option parameter with limit ([#97](https://github.com/aws/amazon-neptune-for-graphql/pull/97))
+* Fixed nested edge subqueries to return an empty array if no results were found (([#100](https://github.com/aws/amazon-neptune-for-graphql/pull/100))
+* Fixed usage of variables with nested edge subqueries (([#100](https://github.com/aws/amazon-neptune-for-graphql/pull/100))
 
 
 ### Features
 
 * Support output of zip package of Apollo Server artifacts (([#70](https://github.com/aws/amazon-neptune-for-graphql/pull/70)), ([#72](https://github.com/aws/amazon-neptune-for-graphql/pull/72)), ([#73](https://github.com/aws/amazon-neptune-for-graphql/pull/73)), ([#75](https://github.com/aws/amazon-neptune-for-graphql/pull/75)), ([#76](https://github.com/aws/amazon-neptune-for-graphql/pull/76)))
+* Allow filtering using string comparison operators `eq`, `contains`, `startsWith`, `endsWith` (([#100](https://github.com/aws/amazon-neptune-for-graphql/pull/100))
 
 ### Improvements
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ type Query {
 }
 
 type Mutation {
-  createAirport(input: AirportInput!): Airport @graphQuery(statement: "CREATE (this:airport {$input}) RETURN this")
+  createAirport(input: AirportCreateInput!): Airport @graphQuery(statement: "CREATE (this:airport {$input}) RETURN this")
   addRoute(fromAirportCode:String, toAirportCode:String, dist:Int): Route @graphQuery(statement: "MATCH (from:airport{code:'$fromAirportCode'}), (to:airport{code:'$toAirportCode'}) CREATE (from)-[this:route{dist:$dist}]->(to) RETURN this")
 }
 ```
@@ -206,8 +206,8 @@ type Query {
 }
 
 type Mutation {  
-  createNodeAirport(input: AirportInput!): Airport
-  updateNodeAirport(id: ID!, input: AirportInput!): Airport
+  createNodeAirport(input: AirportCreateInput!): Airport
+  updateNodeAirport(id: ID!, input: AirportUpdateInput!): Airport
   deleteNodeAirport(id: ID!): Boolean  
   connectNodeAirportToNodeAirportEdgeRoute(from: ID!, to: ID!, edge: RouteInput!): Route
   updateEdgeRouteFromAirportToAirport(from: ID!, to: ID!, edge: RouteInput!): Route

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "ora": "7.0.1",
         "pino": "9.4.0",
         "pino-pretty": "11.2.2",
+        "prettier": "^3.5.3",
         "semver": "7.5.4"
       },
       "bin": {
@@ -10012,6 +10013,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "ora": "7.0.1",
     "pino": "9.4.0",
     "pino-pretty": "11.2.2",
+    "prettier": "^3.5.3",
     "semver": "7.5.4"
   },
   "devDependencies": {

--- a/src/pipelineResources.js
+++ b/src/pipelineResources.js
@@ -570,6 +570,7 @@ export function request(ctx) {
         payload: {
             field: ctx.info.fieldName, 
             arguments: args,
+            variables: ctx.info.variables,
             selectionSetGraphQL: ctx.info.selectionSetGraphQL,
             source 
         },

--- a/src/schemaModelValidator.js
+++ b/src/schemaModelValidator.js
@@ -384,6 +384,12 @@ function inferGraphDatabaseDirectives(schemaModel) {
     });
 
     typesToAdd.push(`input Options {\n  limit: Int\n}\n`);
+    typesToAdd.push('input StringScalarFilters {\n' +
+        '\teq: String\n' +
+        '\tcontains: String\n' +
+        '\tendsWith: String\n' +
+        '\tstartsWith: String\n' +
+        '}\n');
 
     return injectChanges(schemaModel);
 }

--- a/src/test/airports-mutations.graphql
+++ b/src/test/airports-mutations.graphql
@@ -9,9 +9,9 @@ type Continent @alias(property:"continent") {
 
 input ContinentInput {
   _id: ID @id
-  type: String
-  code: String
-  desc: String
+  type: StringScalarFilters
+  code: StringScalarFilters
+  desc: StringScalarFilters
 }
 
 input ContinentCreateInput {
@@ -39,9 +39,9 @@ type Country @alias(property:"country") {
 
 input CountryInput {
   _id: ID @id
-  type: String
-  code: String
-  desc: String
+  type: StringScalarFilters
+  code: StringScalarFilters
+  desc: StringScalarFilters
 }
 
 input CountryCreateInput {
@@ -69,11 +69,11 @@ type Version @alias(property:"version") {
 
 input VersionInput {
   _id: ID @id
-  date: String
-  desc: String
-  author: String
-  type: String
-  code: String
+  date: StringScalarFilters
+  desc: StringScalarFilters
+  author: StringScalarFilters
+  type: StringScalarFilters
+  code: StringScalarFilters
 }
 
 input VersionCreateInput {
@@ -118,17 +118,17 @@ type Airport @alias(property:"airport") {
 
 input AirportInput {
   _id: ID @id
-  type: String
-  city: String
-  icao: String
-  code: String
-  country: String
+  type: StringScalarFilters
+  city: StringScalarFilters
+  icao: StringScalarFilters
+  code: StringScalarFilters
+  country: StringScalarFilters
   lat: Float
   longest: Int
   runways: Int
-  desc: String
+  desc: StringScalarFilters
   lon: Float
-  region: String
+  region: StringScalarFilters
   elev: Int
 }
 
@@ -179,6 +179,13 @@ input RouteInput {
 
 input Options {
   limit:Int
+}
+
+input StringScalarFilters {
+  eq: String
+  contains: String
+  endsWith: String
+  startsWith: String
 }
 
 type Query {

--- a/src/test/airports.customized.graphql
+++ b/src/test/airports.customized.graphql
@@ -9,9 +9,9 @@ contains:Contains
 
 input ContinentInput {
 _id: ID @id
-type: String
-code: String
-desc: String
+type: StringScalarFilters
+code: StringScalarFilters
+desc: StringScalarFilters
 }
 
 type Country @alias(property:"country") {
@@ -25,9 +25,9 @@ contains:Contains
 
 input CountryInput {
 _id: ID @id
-type: String
-code: String
-desc: String
+type: StringScalarFilters
+code: StringScalarFilters
+desc: StringScalarFilters
 }
 
 type Version @alias(property:"version") {
@@ -41,11 +41,11 @@ code: String
 
 input VersionInput {
 _id: ID @id
-date: String
-desc: String
-author: String
-type: String
-code: String
+date: StringScalarFilters
+desc: StringScalarFilters
+author: StringScalarFilters
+type: StringScalarFilters
+code: StringScalarFilters
 }
 
 type Airport @alias(property:"airport") {
@@ -73,17 +73,17 @@ route:Route
 
 input AirportInput {
 _id: ID @id
-type: String
-city: String
-icao: String
-code: String
-country: String
+type: StringScalarFilters
+city: StringScalarFilters
+icao: StringScalarFilters
+code: StringScalarFilters
+country: StringScalarFilters
 lat: Float
 longest: Int
 runways: Int
-desc: String
+desc: StringScalarFilters
 lon: Float
-region: String
+region: StringScalarFilters
 elev: Int
 }
 
@@ -102,6 +102,13 @@ dist: Int
 
 input Options {
 limit:Int
+}
+
+input StringScalarFilters {
+eq: String
+contains: String
+endsWith: String
+startsWith: String
 }
 
 type Query {
@@ -124,6 +131,10 @@ getCountriesCount: Int @graphQuery(statement: "g.V().hasLabel('country').count()
 type Mutation {
 createNodeAirport(input: AirportInput!): Airport
 updateNodeAirport(input: AirportInput!): Airport
+connectNodeCountryToNodeAirportEdgeContains(from_id: ID!, to_id: ID!): Contains
+deleteEdgeContainsFromCountryToAirport(from_id: ID!, to_id: ID!): Boolean
+updateEdgeRouteFromAirportToAirport(from_id: ID!, to_id: ID!, edge: RouteInput!): Route
+createAirport(input: AirportInput!): Airport @graphQuery(statement: "CREATE (this:airport {$input}) RETURN this")
 }
 
 schema {

--- a/src/test/airports.graphql
+++ b/src/test/airports.graphql
@@ -1,119 +1,126 @@
-type Continent @alias(property:"continent") {
-_id: ID! @id
-type: String
-code: String
-desc: String
-airportContainssOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType:"contains", direction:OUT)
-contains:Contains
+type Continent @alias(property: "continent") {
+    _id: ID! @id
+    type: String
+    code: String
+    desc: String
+    airportContainssOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "contains", direction: OUT)
+    contains: Contains
 }
 
 input ContinentInput {
-_id: ID @id
-type: String
-code: String
-desc: String
+    _id: ID @id
+    type: StringScalarFilters
+    code: StringScalarFilters
+    desc: StringScalarFilters
 }
 
-type Country @alias(property:"country") {
-_id: ID! @id
-type: String
-code: String
-desc: String
-airportContainssOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType:"contains", direction:OUT)
-contains:Contains
+type Country @alias(property: "country") {
+    _id: ID! @id
+    type: String
+    code: String
+    desc: String
+    airportContainssOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "contains", direction: OUT)
+    contains: Contains
 }
 
 input CountryInput {
-_id: ID @id
-type: String
-code: String
-desc: String
+    _id: ID @id
+    type: StringScalarFilters
+    code: StringScalarFilters
+    desc: StringScalarFilters
 }
 
-type Version @alias(property:"version") {
-_id: ID! @id
-date: String
-desc: String
-author: String
-type: String
-code: String
+type Version @alias(property: "version") {
+    _id: ID! @id
+    date: String
+    desc: String
+    author: String
+    type: String
+    code: String
 }
 
 input VersionInput {
-_id: ID @id
-date: String
-desc: String
-author: String
-type: String
-code: String
+    _id: ID @id
+    date: StringScalarFilters
+    desc: StringScalarFilters
+    author: StringScalarFilters
+    type: StringScalarFilters
+    code: StringScalarFilters
 }
 
-type Airport @alias(property:"airport") {
-_id: ID! @id
-type: String
-city: String
-icao: String
-code: String
-country: String
-lat: Float
-longest: Int
-runways: Int
-desc: String
-lon: Float
-region: String
-elev: Int
-continentContainsIn: Continent @relationship(edgeType:"contains", direction:IN)
-countryContainsIn: Country @relationship(edgeType:"contains", direction:IN)
-airportRoutesOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType:"route", direction:OUT)
-airportRoutesIn(filter: AirportInput, options: Options): [Airport] @relationship(edgeType:"route", direction:IN)
-contains:Contains
-route:Route
+type Airport @alias(property: "airport") {
+    _id: ID! @id
+    type: String
+    city: String
+    icao: String
+    code: String
+    country: String
+    lat: Float
+    longest: Int
+    runways: Int
+    desc: String
+    lon: Float
+    region: String
+    elev: Int
+    continentContainsIn: Continent @relationship(edgeType: "contains", direction: IN)
+    countryContainsIn: Country @relationship(edgeType: "contains", direction: IN)
+    airportRoutesOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "route", direction: OUT)
+    airportRoutesIn(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "route", direction: IN)
+    contains: Contains
+    route: Route
 }
 
 input AirportInput {
-_id: ID @id
-type: String
-city: String
-icao: String
-code: String
-country: String
-lat: Float
-longest: Int
-runways: Int
-desc: String
-lon: Float
-region: String
-elev: Int
+    _id: ID @id
+    type: StringScalarFilters
+    city: StringScalarFilters
+    icao: StringScalarFilters
+    code: StringScalarFilters
+    country: StringScalarFilters
+    lat: Float
+    longest: Int
+    runways: Int
+    desc: StringScalarFilters
+    lon: Float
+    region: StringScalarFilters
+    elev: Int
 }
 
-type Contains @alias(property:"contains") {
-_id: ID! @id
+type Contains @alias(property: "contains") {
+    _id: ID! @id
 }
 
-type Route @alias(property:"route") {
-_id: ID! @id
-dist: Int
+type Route @alias(property: "route") {
+    _id: ID! @id
+    dist: Int
 }
 
 input RouteInput {
-dist: Int
+    dist: Int
 }
 
 input Options {
-limit:Int
+    limit: Int
+}
+
+input StringScalarFilters {
+    eq: String
+    contains: String
+    endsWith: String
+    startsWith: String
 }
 
 type Query {
-getNodeContinent(filter: ContinentInput): Continent
-getNodeContinents(filter: ContinentInput, options: Options): [Continent]
-getNodeCountry(filter: CountryInput): Country
-getNodeCountrys(filter: CountryInput, options: Options): [Country]
-getNodeVersion(filter: VersionInput): Version
-getNodeVersions(filter: VersionInput, options: Options): [Version]
-getNodeAirport(filter: AirportInput): Airport
-getNodeAirports(filter: AirportInput, options: Options): [Airport]
+    getNodeContinent(filter: ContinentInput): Continent
+    getNodeContinents(filter: ContinentInput, options: Options): [Continent]
+    getNodeCountry(filter: CountryInput): Country
+    getNodeCountrys(filter: CountryInput, options: Options): [Country]
+    getNodeVersion(filter: VersionInput): Version
+    getNodeVersions(filter: VersionInput, options: Options): [Version]
+    getNodeAirport(filter: AirportInput): Airport
+    getNodeAirports(filter: AirportInput, options: Options): [Airport]
 }
 
 schema {
-query: Query
+    query: Query
 }

--- a/src/test/dining.graphql
+++ b/src/test/dining.graphql
@@ -1,142 +1,149 @@
-type City @alias(property:"city") {
-_id: ID! @id
-name: String
-personLivessIn(filter: PersonInput, options: Options): [Person] @relationship(edgeType:"lives", direction:IN)
-restaurantWithinsIn(filter: RestaurantInput, options: Options): [Restaurant] @relationship(edgeType:"within", direction:IN)
-lives:Lives
-within:Within
+type City @alias(property: "city") {
+    _id: ID! @id
+    name: String
+    personLivessIn(filter: PersonInput, options: Options): [Person] @relationship(edgeType: "lives", direction: IN)
+    restaurantWithinsIn(filter: RestaurantInput, options: Options): [Restaurant] @relationship(edgeType: "within", direction: IN)
+    lives: Lives
+    within: Within
 }
 
 input CityInput {
-_id: ID @id
-name: String
+    _id: ID @id
+    name: StringScalarFilters
 }
 
-type Review @alias(property:"review") {
-_id: ID! @id
-body: String
-created_date: String
-rating: Int
-personWroteIn: Person @relationship(edgeType:"wrote", direction:IN)
-restaurantAboutOut: Restaurant @relationship(edgeType:"about", direction:OUT)
-wrote:Wrote
-about:About
+type Review @alias(property: "review") {
+    _id: ID! @id
+    body: String
+    created_date: String
+    rating: Int
+    personWroteIn: Person @relationship(edgeType: "wrote", direction: IN)
+    restaurantAboutOut: Restaurant @relationship(edgeType: "about", direction: OUT)
+    wrote: Wrote
+    about: About
 }
 
 input ReviewInput {
-_id: ID @id
-body: String
-created_date: String
-rating: Int
+    _id: ID @id
+    body: StringScalarFilters
+    created_date: StringScalarFilters
+    rating: Int
 }
 
-type Person @alias(property:"person") {
-_id: ID! @id
-first_name: String
-last_name: String
-person_id: Int
-cityLivesOut: City @relationship(edgeType:"lives", direction:OUT)
-reviewWrotesOut(filter: ReviewInput, options: Options): [Review] @relationship(edgeType:"wrote", direction:OUT)
-personFriendssOut(filter: PersonInput, options: Options): [Person] @relationship(edgeType:"friends", direction:OUT)
-personFriendssIn(filter: PersonInput, options: Options): [Person] @relationship(edgeType:"friends", direction:IN)
-lives:Lives
-wrote:Wrote
-friends:Friends
+type Person @alias(property: "person") {
+    _id: ID! @id
+    first_name: String
+    last_name: String
+    person_id: Int
+    cityLivesOut: City @relationship(edgeType: "lives", direction: OUT)
+    reviewWrotesOut(filter: ReviewInput, options: Options): [Review] @relationship(edgeType: "wrote", direction: OUT)
+    personFriendssOut(filter: PersonInput, options: Options): [Person] @relationship(edgeType: "friends", direction: OUT)
+    personFriendssIn(filter: PersonInput, options: Options): [Person] @relationship(edgeType: "friends", direction: IN)
+    lives: Lives
+    wrote: Wrote
+    friends: Friends
 }
 
 input PersonInput {
-_id: ID @id
-first_name: String
-last_name: String
-person_id: Int
+    _id: ID @id
+    first_name: StringScalarFilters
+    last_name: StringScalarFilters
+    person_id: Int
 }
 
-type Restaurant @alias(property:"restaurant") {
-_id: ID! @id
-restaurant_id: Int
-name: String
-address: String
-cityWithinOut: City @relationship(edgeType:"within", direction:OUT)
-cuisineServesOut: Cuisine @relationship(edgeType:"serves", direction:OUT)
-reviewAboutsIn(filter: ReviewInput, options: Options): [Review] @relationship(edgeType:"about", direction:IN)
-within:Within
-serves:Serves
-about:About
+type Restaurant @alias(property: "restaurant") {
+    _id: ID! @id
+    restaurant_id: Int
+    name: String
+    address: String
+    cityWithinOut: City @relationship(edgeType: "within", direction: OUT)
+    cuisineServesOut: Cuisine @relationship(edgeType: "serves", direction: OUT)
+    reviewAboutsIn(filter: ReviewInput, options: Options): [Review] @relationship(edgeType: "about", direction: IN)
+    within: Within
+    serves: Serves
+    about: About
 }
 
 input RestaurantInput {
-_id: ID @id
-restaurant_id: Int
-name: String
-address: String
+    _id: ID @id
+    restaurant_id: Int
+    name: StringScalarFilters
+    address: StringScalarFilters
 }
 
-type Cuisine @alias(property:"cuisine") {
-_id: ID! @id
-name: String
-restaurantServessIn(filter: RestaurantInput, options: Options): [Restaurant] @relationship(edgeType:"serves", direction:IN)
-serves:Serves
+type Cuisine @alias(property: "cuisine") {
+    _id: ID! @id
+    name: String
+    restaurantServessIn(filter: RestaurantInput, options: Options): [Restaurant] @relationship(edgeType: "serves", direction: IN)
+    serves: Serves
 }
 
 input CuisineInput {
-_id: ID @id
-name: String
+    _id: ID @id
+    name: StringScalarFilters
 }
 
-type State @alias(property:"state") {
-_id: ID! @id
-name: String
-within:Within
+type State @alias(property: "state") {
+    _id: ID! @id
+    name: String
+    within: Within
 }
 
 input StateInput {
-_id: ID @id
-name: String
+    _id: ID @id
+    name: StringScalarFilters
 }
 
-type Lives @alias(property:"lives") {
-_id: ID! @id
+type Lives @alias(property: "lives") {
+    _id: ID! @id
 }
 
-type Within @alias(property:"within") {
-_id: ID! @id
+type Within @alias(property: "within") {
+    _id: ID! @id
 }
 
-type Serves @alias(property:"serves") {
-_id: ID! @id
+type Serves @alias(property: "serves") {
+    _id: ID! @id
 }
 
-type Wrote @alias(property:"wrote") {
-_id: ID! @id
+type Wrote @alias(property: "wrote") {
+    _id: ID! @id
 }
 
-type About @alias(property:"about") {
-_id: ID! @id
+type About @alias(property: "about") {
+    _id: ID! @id
 }
 
-type Friends @alias(property:"friends") {
-_id: ID! @id
+type Friends @alias(property: "friends") {
+    _id: ID! @id
 }
 
 input Options {
-limit:Int
+    limit: Int
+}
+
+input StringScalarFilters {
+    eq: String
+    contains: String
+    endsWith: String
+    startsWith: String
 }
 
 type Query {
-getNodeCity(filter: CityInput): City
-getNodeCitys(filter: CityInput, options: Options): [City]
-getNodeReview(filter: ReviewInput): Review
-getNodeReviews(filter: ReviewInput, options: Options): [Review]
-getNodePerson(filter: PersonInput): Person
-getNodePersons(filter: PersonInput, options: Options): [Person]
-getNodeRestaurant(filter: RestaurantInput): Restaurant
-getNodeRestaurants(filter: RestaurantInput, options: Options): [Restaurant]
-getNodeCuisine(filter: CuisineInput): Cuisine
-getNodeCuisines(filter: CuisineInput, options: Options): [Cuisine]
-getNodeState(filter: StateInput): State
-getNodeStates(filter: StateInput, options: Options): [State]
+    getNodeCity(filter: CityInput): City
+    getNodeCitys(filter: CityInput, options: Options): [City]
+    getNodeReview(filter: ReviewInput): Review
+    getNodeReviews(filter: ReviewInput, options: Options): [Review]
+    getNodePerson(filter: PersonInput): Person
+    getNodePersons(filter: PersonInput, options: Options): [Person]
+    getNodeRestaurant(filter: RestaurantInput): Restaurant
+    getNodeRestaurants(filter: RestaurantInput, options: Options): [Restaurant]
+    getNodeCuisine(filter: CuisineInput): Cuisine
+    getNodeCuisines(filter: CuisineInput, options: Options): [Cuisine]
+    getNodeState(filter: StateInput): State
+    getNodeStates(filter: StateInput, options: Options): [State]
 }
 
 schema {
-query: Query
+    query: Query
 }

--- a/src/test/epl.graphql
+++ b/src/test/epl.graphql
@@ -1,92 +1,99 @@
 type Stadium {
-_id: ID! @id
-opened: Int
-capacity: Int
-name: String
-cityCity_edgeOut: City @relationship(edgeType:"CITY_EDGE", direction:OUT)
-CITY_EDGE:City_edge
-STADIUM_EDGE:Stadium_edge
+    _id: ID! @id
+    opened: Int
+    capacity: Int
+    name: String
+    cityCity_edgeOut: City @relationship(edgeType: "CITY_EDGE", direction: OUT)
+    CITY_EDGE: City_edge
+    STADIUM_EDGE: Stadium_edge
 }
 
 input StadiumInput {
-_id: ID @id
-opened: Int
-capacity: Int
-name: String
+    _id: ID @id
+    opened: Int
+    capacity: Int
+    name: StringScalarFilters
 }
 
 type League {
-_id: ID! @id
-nickname: String
-name: String
-teamCurrent_leaguesIn(filter: TeamInput, options: Options): [Team] @relationship(edgeType:"CURRENT_LEAGUE", direction:IN)
-CURRENT_LEAGUE:Current_league
+    _id: ID! @id
+    nickname: String
+    name: String
+    teamCurrent_leaguesIn(filter: TeamInput, options: Options): [Team] @relationship(edgeType: "CURRENT_LEAGUE", direction: IN)
+    CURRENT_LEAGUE: Current_league
 }
 
 input LeagueInput {
-_id: ID @id
-nickname: String
-name: String
+    _id: ID @id
+    nickname: StringScalarFilters
+    name: StringScalarFilters
 }
 
 type Team {
-_id: ID! @id
-nickname: String
-name: String
-fullName: String
-founded: Int
-leagueCurrent_leagueOut: League @relationship(edgeType:"CURRENT_LEAGUE", direction:OUT)
-CURRENT_LEAGUE:Current_league
-STADIUM_EDGE:Stadium_edge
+    _id: ID! @id
+    nickname: String
+    name: String
+    fullName: String
+    founded: Int
+    leagueCurrent_leagueOut: League @relationship(edgeType: "CURRENT_LEAGUE", direction: OUT)
+    CURRENT_LEAGUE: Current_league
+    STADIUM_EDGE: Stadium_edge
 }
 
 input TeamInput {
-_id: ID @id
-nickname: String
-name: String
-fullName: String
-founded: Int
+    _id: ID @id
+    nickname: StringScalarFilters
+    name: StringScalarFilters
+    fullName: StringScalarFilters
+    founded: Int
 }
 
 type City {
-_id: ID! @id
-name: String
-stadiumCity_edgesIn(filter: StadiumInput, options: Options): [Stadium] @relationship(edgeType:"CITY_EDGE", direction:IN)
-CITY_EDGE:City_edge
+    _id: ID! @id
+    name: String
+    stadiumCity_edgesIn(filter: StadiumInput, options: Options): [Stadium] @relationship(edgeType: "CITY_EDGE", direction: IN)
+    CITY_EDGE: City_edge
 }
 
 input CityInput {
-_id: ID @id
-name: String
+    _id: ID @id
+    name: StringScalarFilters
 }
 
-type City_edge @alias(property:"CITY_EDGE") {
-_id: ID! @id
+type City_edge @alias(property: "CITY_EDGE") {
+    _id: ID! @id
 }
 
-type Current_league @alias(property:"CURRENT_LEAGUE") {
-_id: ID! @id
+type Current_league @alias(property: "CURRENT_LEAGUE") {
+    _id: ID! @id
 }
 
-type Stadium_edge @alias(property:"STADIUM_EDGE") {
-_id: ID! @id
+type Stadium_edge @alias(property: "STADIUM_EDGE") {
+    _id: ID! @id
 }
 
 input Options {
-limit:Int
+    limit: Int
+}
+
+input StringScalarFilters {
+    eq: String
+    contains: String
+    endsWith: String
+    startsWith: String
 }
 
 type Query {
-getNodeStadium(filter: StadiumInput): Stadium
-getNodeStadiums(filter: StadiumInput, options: Options): [Stadium]
-getNodeLeague(filter: LeagueInput): League
-getNodeLeagues(filter: LeagueInput, options: Options): [League]
-getNodeTeam(filter: TeamInput): Team
-getNodeTeams(filter: TeamInput, options: Options): [Team]
-getNodeCity(filter: CityInput): City
-getNodeCitys(filter: CityInput, options: Options): [City]
+    getNodeStadium(filter: StadiumInput): Stadium
+    getNodeStadiums(filter: StadiumInput, options: Options): [Stadium]
+    getNodeLeague(filter: LeagueInput): League
+    getNodeLeagues(filter: LeagueInput, options: Options): [League]
+    getNodeTeam(filter: TeamInput): Team
+    getNodeTeams(filter: TeamInput, options: Options): [Team]
+    getNodeCity(filter: CityInput): City
+    getNodeCitys(filter: CityInput, options: Options): [City]
 }
 
 schema {
-query: Query
+    query: Query
 }

--- a/src/test/fraud.graphql
+++ b/src/test/fraud.graphql
@@ -1,159 +1,166 @@
-type Dateofbirth @alias(property:"DateOfBirth") {
-_id: ID! @id
-value: String
-accountFeature_of_accountsOut(filter: AccountInput, options: Options): [Account] @relationship(edgeType:"FEATURE_OF_ACCOUNT", direction:OUT)
-FEATURE_OF_ACCOUNT:Feature_of_account
+type Dateofbirth @alias(property: "DateOfBirth") {
+    _id: ID! @id
+    value: String
+    accountFeature_of_accountsOut(filter: AccountInput, options: Options): [Account] @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: OUT)
+    FEATURE_OF_ACCOUNT: Feature_of_account
 }
 
 input DateofbirthInput {
-_id: ID @id
-value: String
+    _id: ID @id
+    value: StringScalarFilters
 }
 
 type Account {
-_id: ID! @id
-first_name: String
-account_number: String
-last_name: String
-emailaddressFeature_of_accountsIn(filter: EmailaddressInput, options: Options): [Emailaddress] @relationship(edgeType:"FEATURE_OF_ACCOUNT", direction:IN)
-ipaddressFeature_of_accountIn: Ipaddress @relationship(edgeType:"FEATURE_OF_ACCOUNT", direction:IN)
-addressFeature_of_accountIn: Address @relationship(edgeType:"FEATURE_OF_ACCOUNT", direction:IN)
-dateofbirthFeature_of_accountIn: Dateofbirth @relationship(edgeType:"FEATURE_OF_ACCOUNT", direction:IN)
-phonenumberFeature_of_accountsIn(filter: PhonenumberInput, options: Options): [Phonenumber] @relationship(edgeType:"FEATURE_OF_ACCOUNT", direction:IN)
-transactionAccount_edgesIn(filter: TransactionInput, options: Options): [Transaction] @relationship(edgeType:"ACCOUNT_EDGE", direction:IN)
-FEATURE_OF_ACCOUNT:Feature_of_account
-ACCOUNT_EDGE:Account_edge
+    _id: ID! @id
+    first_name: String
+    account_number: String
+    last_name: String
+    emailaddressFeature_of_accountsIn(filter: EmailaddressInput, options: Options): [Emailaddress] @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: IN)
+    ipaddressFeature_of_accountIn: Ipaddress @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: IN)
+    addressFeature_of_accountIn: Address @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: IN)
+    dateofbirthFeature_of_accountIn: Dateofbirth @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: IN)
+    phonenumberFeature_of_accountsIn(filter: PhonenumberInput, options: Options): [Phonenumber] @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: IN)
+    transactionAccount_edgesIn(filter: TransactionInput, options: Options): [Transaction] @relationship(edgeType: "ACCOUNT_EDGE", direction: IN)
+    FEATURE_OF_ACCOUNT: Feature_of_account
+    ACCOUNT_EDGE: Account_edge
 }
 
 input AccountInput {
-_id: ID @id
-first_name: String
-account_number: String
-last_name: String
+    _id: ID @id
+    first_name: StringScalarFilters
+    account_number: StringScalarFilters
+    last_name: StringScalarFilters
 }
 
 type Merchant {
-_id: ID! @id
-name: String
-transactionMerchant_edgesIn(filter: TransactionInput, options: Options): [Transaction] @relationship(edgeType:"MERCHANT_EDGE", direction:IN)
-MERCHANT_EDGE:Merchant_edge
+    _id: ID! @id
+    name: String
+    transactionMerchant_edgesIn(filter: TransactionInput, options: Options): [Transaction] @relationship(edgeType: "MERCHANT_EDGE", direction: IN)
+    MERCHANT_EDGE: Merchant_edge
 }
 
 input MerchantInput {
-_id: ID @id
-name: String
+    _id: ID @id
+    name: StringScalarFilters
 }
 
 type Transaction {
-_id: ID! @id
-amount: Int
-created: String
-accountAccount_edgeOut: Account @relationship(edgeType:"ACCOUNT_EDGE", direction:OUT)
-ipaddressFeature_of_transactionIn: Ipaddress @relationship(edgeType:"FEATURE_OF_TRANSACTION", direction:IN)
-phonenumberFeature_of_transactionIn: Phonenumber @relationship(edgeType:"FEATURE_OF_TRANSACTION", direction:IN)
-merchantMerchant_edgeOut: Merchant @relationship(edgeType:"MERCHANT_EDGE", direction:OUT)
-ACCOUNT_EDGE:Account_edge
-FEATURE_OF_TRANSACTION:Feature_of_transaction
-MERCHANT_EDGE:Merchant_edge
+    _id: ID! @id
+    amount: Int
+    created: String
+    accountAccount_edgeOut: Account @relationship(edgeType: "ACCOUNT_EDGE", direction: OUT)
+    ipaddressFeature_of_transactionIn: Ipaddress @relationship(edgeType: "FEATURE_OF_TRANSACTION", direction: IN)
+    phonenumberFeature_of_transactionIn: Phonenumber @relationship(edgeType: "FEATURE_OF_TRANSACTION", direction: IN)
+    merchantMerchant_edgeOut: Merchant @relationship(edgeType: "MERCHANT_EDGE", direction: OUT)
+    ACCOUNT_EDGE: Account_edge
+    FEATURE_OF_TRANSACTION: Feature_of_transaction
+    MERCHANT_EDGE: Merchant_edge
 }
 
 input TransactionInput {
-_id: ID @id
-amount: Int
-created: String
+    _id: ID @id
+    amount: Int
+    created: StringScalarFilters
 }
 
 type Address {
-_id: ID! @id
-value: String
-accountFeature_of_accountsOut(filter: AccountInput, options: Options): [Account] @relationship(edgeType:"FEATURE_OF_ACCOUNT", direction:OUT)
-FEATURE_OF_ACCOUNT:Feature_of_account
+    _id: ID! @id
+    value: String
+    accountFeature_of_accountsOut(filter: AccountInput, options: Options): [Account] @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: OUT)
+    FEATURE_OF_ACCOUNT: Feature_of_account
 }
 
 input AddressInput {
-_id: ID @id
-value: String
+    _id: ID @id
+    value: StringScalarFilters
 }
 
-type Phonenumber @alias(property:"PhoneNumber") {
-_id: ID! @id
-value: String
-accountFeature_of_accountsOut(filter: AccountInput, options: Options): [Account] @relationship(edgeType:"FEATURE_OF_ACCOUNT", direction:OUT)
-transactionFeature_of_transactionsOut(filter: TransactionInput, options: Options): [Transaction] @relationship(edgeType:"FEATURE_OF_TRANSACTION", direction:OUT)
-FEATURE_OF_ACCOUNT:Feature_of_account
-FEATURE_OF_TRANSACTION:Feature_of_transaction
+type Phonenumber @alias(property: "PhoneNumber") {
+    _id: ID! @id
+    value: String
+    accountFeature_of_accountsOut(filter: AccountInput, options: Options): [Account] @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: OUT)
+    transactionFeature_of_transactionsOut(filter: TransactionInput, options: Options): [Transaction] @relationship(edgeType: "FEATURE_OF_TRANSACTION", direction: OUT)
+    FEATURE_OF_ACCOUNT: Feature_of_account
+    FEATURE_OF_TRANSACTION: Feature_of_transaction
 }
 
 input PhonenumberInput {
-_id: ID @id
-value: String
+    _id: ID @id
+    value: StringScalarFilters
 }
 
-type Ipaddress @alias(property:"IpAddress") {
-_id: ID! @id
-value: String
-accountFeature_of_accountsOut(filter: AccountInput, options: Options): [Account] @relationship(edgeType:"FEATURE_OF_ACCOUNT", direction:OUT)
-transactionFeature_of_transactionsOut(filter: TransactionInput, options: Options): [Transaction] @relationship(edgeType:"FEATURE_OF_TRANSACTION", direction:OUT)
-FEATURE_OF_ACCOUNT:Feature_of_account
-FEATURE_OF_TRANSACTION:Feature_of_transaction
+type Ipaddress @alias(property: "IpAddress") {
+    _id: ID! @id
+    value: String
+    accountFeature_of_accountsOut(filter: AccountInput, options: Options): [Account] @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: OUT)
+    transactionFeature_of_transactionsOut(filter: TransactionInput, options: Options): [Transaction] @relationship(edgeType: "FEATURE_OF_TRANSACTION", direction: OUT)
+    FEATURE_OF_ACCOUNT: Feature_of_account
+    FEATURE_OF_TRANSACTION: Feature_of_transaction
 }
 
 input IpaddressInput {
-_id: ID @id
-value: String
+    _id: ID @id
+    value: StringScalarFilters
 }
 
-type Emailaddress @alias(property:"EmailAddress") {
-_id: ID! @id
-value: String
-accountFeature_of_accountsOut(filter: AccountInput, options: Options): [Account] @relationship(edgeType:"FEATURE_OF_ACCOUNT", direction:OUT)
-FEATURE_OF_ACCOUNT:Feature_of_account
+type Emailaddress @alias(property: "EmailAddress") {
+    _id: ID! @id
+    value: String
+    accountFeature_of_accountsOut(filter: AccountInput, options: Options): [Account] @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: OUT)
+    FEATURE_OF_ACCOUNT: Feature_of_account
 }
 
 input EmailaddressInput {
-_id: ID @id
-value: String
+    _id: ID @id
+    value: StringScalarFilters
 }
 
-type Feature_of_account @alias(property:"FEATURE_OF_ACCOUNT") {
-_id: ID! @id
+type Feature_of_account @alias(property: "FEATURE_OF_ACCOUNT") {
+    _id: ID! @id
 }
 
-type Account_edge @alias(property:"ACCOUNT_EDGE") {
-_id: ID! @id
+type Account_edge @alias(property: "ACCOUNT_EDGE") {
+    _id: ID! @id
 }
 
-type Feature_of_transaction @alias(property:"FEATURE_OF_TRANSACTION") {
-_id: ID! @id
+type Feature_of_transaction @alias(property: "FEATURE_OF_TRANSACTION") {
+    _id: ID! @id
 }
 
-type Merchant_edge @alias(property:"MERCHANT_EDGE") {
-_id: ID! @id
+type Merchant_edge @alias(property: "MERCHANT_EDGE") {
+    _id: ID! @id
 }
 
 input Options {
-limit:Int
+    limit: Int
+}
+
+input StringScalarFilters {
+    eq: String
+    contains: String
+    endsWith: String
+    startsWith: String
 }
 
 type Query {
-getNodeDateofbirth(filter: DateofbirthInput): Dateofbirth
-getNodeDateofbirths(filter: DateofbirthInput, options: Options): [Dateofbirth]
-getNodeAccount(filter: AccountInput): Account
-getNodeAccounts(filter: AccountInput, options: Options): [Account]
-getNodeMerchant(filter: MerchantInput): Merchant
-getNodeMerchants(filter: MerchantInput, options: Options): [Merchant]
-getNodeTransaction(filter: TransactionInput): Transaction
-getNodeTransactions(filter: TransactionInput, options: Options): [Transaction]
-getNodeAddress(filter: AddressInput): Address
-getNodeAddresss(filter: AddressInput, options: Options): [Address]
-getNodePhonenumber(filter: PhonenumberInput): Phonenumber
-getNodePhonenumbers(filter: PhonenumberInput, options: Options): [Phonenumber]
-getNodeIpaddress(filter: IpaddressInput): Ipaddress
-getNodeIpaddresss(filter: IpaddressInput, options: Options): [Ipaddress]
-getNodeEmailaddress(filter: EmailaddressInput): Emailaddress
-getNodeEmailaddresss(filter: EmailaddressInput, options: Options): [Emailaddress]
+    getNodeDateofbirth(filter: DateofbirthInput): Dateofbirth
+    getNodeDateofbirths(filter: DateofbirthInput, options: Options): [Dateofbirth]
+    getNodeAccount(filter: AccountInput): Account
+    getNodeAccounts(filter: AccountInput, options: Options): [Account]
+    getNodeMerchant(filter: MerchantInput): Merchant
+    getNodeMerchants(filter: MerchantInput, options: Options): [Merchant]
+    getNodeTransaction(filter: TransactionInput): Transaction
+    getNodeTransactions(filter: TransactionInput, options: Options): [Transaction]
+    getNodeAddress(filter: AddressInput): Address
+    getNodeAddresss(filter: AddressInput, options: Options): [Address]
+    getNodePhonenumber(filter: PhonenumberInput): Phonenumber
+    getNodePhonenumbers(filter: PhonenumberInput, options: Options): [Phonenumber]
+    getNodeIpaddress(filter: IpaddressInput): Ipaddress
+    getNodeIpaddresss(filter: IpaddressInput, options: Options): [Ipaddress]
+    getNodeEmailaddress(filter: EmailaddressInput): Emailaddress
+    getNodeEmailaddresss(filter: EmailaddressInput, options: Options): [Emailaddress]
 }
 
 schema {
-query: Query
+    query: Query
 }

--- a/src/test/graphdb.test.js
+++ b/src/test/graphdb.test.js
@@ -1,87 +1,87 @@
 import { graphDBInferenceSchema } from '../graphdb.js';
 import fs from "fs";
 import { loggerInit } from "../logger.js";
+import * as prettier from "prettier";
 
 test('node with same property and edge label should add underscore prefix', () => {
     expect(graphDBInferenceSchema(readFile('./src/test/node-edge-same-property-neptune-schema.json'), false)).toContain('_commonName:Commonname');
 });
 
-test('should properly replace special chars in schema', () => {
-    const actual = inferGraphQLSchema('./src/test/special-chars-neptune-schema.json');
-    const expected = loadGraphQLSchema('./src/test/special-chars.graphql');
+test('should properly replace special chars in schema', async () => {
+    const actual = await inferGraphQLSchema('./src/test/special-chars-neptune-schema.json');
+    const expected = await loadGraphQLSchema('./src/test/special-chars.graphql');
     expect(actual).toBe(expected);
 });
 
-test('should correctly generate mutation input types after replacing special characters in schema', () => {
-    const actual = inferGraphQLSchema('./src/test/special-chars-neptune-schema.json', { addMutations: true });
-    const expected = loadGraphQLSchema('./src/test/special-chars-mutations.graphql');
+test('should correctly generate mutation input types after replacing special characters in schema', async () => {
+    const actual = await inferGraphQLSchema('./src/test/special-chars-neptune-schema.json', { addMutations: true });
+    const expected = await loadGraphQLSchema('./src/test/special-chars-mutations.graphql');
     expect(actual).toBe(expected);
 });
 
-test('should output airport schema', () => {
-    const actual = inferGraphQLSchema('./src/test/airports-neptune-schema.json');
-    const expected = loadGraphQLSchema('./src/test/airports.graphql');
+test('should output airport schema', async () => {
+    const actual = await inferGraphQLSchema('./src/test/airports-neptune-schema.json');
+    const expected = await loadGraphQLSchema('./src/test/airports.graphql');
     expect(actual).toBe(expected);
 });
 
-test('should correctly generate mutation input types after outputting airport schema', () => {
-    const actual = inferGraphQLSchema('./src/test/airports-neptune-schema.json', { addMutations: true });
-    const expected = loadGraphQLSchema('./src/test/airports-mutations.graphql');
+test('should correctly generate mutation input types after outputting airport schema', async () => {
+    const actual = await inferGraphQLSchema('./src/test/airports-neptune-schema.json', { addMutations: true });
+    const expected = await loadGraphQLSchema('./src/test/airports-mutations.graphql');
     expect(actual).toBe(expected);
 });
 
-test('should output dining by friends schema', () => {
-    const actual = inferGraphQLSchema('./src/test/dining-neptune-schema.json');
-    const expected = loadGraphQLSchema('./src/test/dining.graphql');
+test('should output dining by friends schema', async () => {
+    const actual = await inferGraphQLSchema('./src/test/dining-neptune-schema.json');
+    const expected = await loadGraphQLSchema('./src/test/dining.graphql');
     expect(actual).toBe(expected);
 });
 
-test('should output epl schema', () => {
-    const actual = inferGraphQLSchema('./src/test/epl-neptune-schema.json');
-    const expected = loadGraphQLSchema('./src/test/epl.graphql');
+test('should output epl schema', async () => {
+    const actual = await inferGraphQLSchema('./src/test/epl-neptune-schema.json');
+    const expected = await loadGraphQLSchema('./src/test/epl.graphql');
     expect(actual).toBe(expected);
 });
 
-test('should output fraud graph schema', () => {
-    const actual = inferGraphQLSchema('./src/test/fraud-neptune-schema.json');
-    const expected = loadGraphQLSchema('./src/test/fraud.graphql');
+test('should output fraud graph schema', async () => {
+    const actual = await inferGraphQLSchema('./src/test/fraud-neptune-schema.json');
+    const expected = await loadGraphQLSchema('./src/test/fraud.graphql');
     expect(actual).toBe(expected);
 });
 
-test('should output knowledge graph schema', () => {
-    const actual = inferGraphQLSchema('./src/test/knowledge-neptune-schema.json');
-    const expected = loadGraphQLSchema('./src/test/knowledge.graphql');
+test('should output knowledge graph schema', async () => {
+    const actual = await inferGraphQLSchema('./src/test/knowledge-neptune-schema.json');
+    const expected = await loadGraphQLSchema('./src/test/knowledge.graphql');
     expect(actual).toBe(expected);
 });
 
-test('should output security graph schema', () => {
-    const actual = inferGraphQLSchema('./src/test/security-neptune-schema.json');
-    const expected = loadGraphQLSchema('./src/test/security.graphql');
+test('should output security graph schema', async () => {
+    const actual = await inferGraphQLSchema('./src/test/security-neptune-schema.json');
+    const expected = await loadGraphQLSchema('./src/test/security.graphql');
     expect(actual).toBe(expected);
 });
 
-test('should alias edge with same label as node', () => {
+test('should alias edge with same label as node', async () => {
     loggerInit('./src/test/output', false, 'info');
-    const actual = inferGraphQLSchema('./src/test/node-edge-same-label-neptune-schema.json');
-    const expected = loadGraphQLSchema('./src/test/node-edge-same-label.graphql');
+    const actual = await inferGraphQLSchema('./src/test/node-edge-same-label-neptune-schema.json');
+    const expected = await loadGraphQLSchema('./src/test/node-edge-same-label.graphql');
     expect(actual).toBe(expected);
 });
 
-function inferGraphQLSchema(neptuneSchemaFilePath, options = { addMutations: false }) {
+async function inferGraphQLSchema(neptuneSchemaFilePath, options = { addMutations: false }) {
     let neptuneSchema = readFile(neptuneSchemaFilePath);
     let inferredSchema = graphDBInferenceSchema(neptuneSchema, options.addMutations);
-    return sanitizeWhitespace(inferredSchema);
+    return await sanitizeWhitespace(inferredSchema);
 }
 
-function loadGraphQLSchema(graphQLSchemaFilePath) {
+async function loadGraphQLSchema(graphQLSchemaFilePath) {
     let expectedSchema = readFile(graphQLSchemaFilePath);
-    return sanitizeWhitespace(expectedSchema);
+    return await sanitizeWhitespace(expectedSchema);
 }
 
-function sanitizeWhitespace(str) {
-    return str
-        .replace(/\s+/g, ' ') // replace whitespace with a space
-        .trim();  // trim leading and trailing whitespace
+async function sanitizeWhitespace(str) {
+    // max printWidth to prevent line wrapping (which tends to wrap in unexpected ways)
+    return await prettier.format(str, {parser: "graphql", printWidth: Number.MAX_VALUE});
 }
 
 function readFile(fileName) {

--- a/src/test/knowledge.graphql
+++ b/src/test/knowledge.graphql
@@ -1,176 +1,183 @@
-type Date @alias(property:"date") {
-_id: ID! @id
-type: String
-text: String
-postFound_insIn(filter: PostInput, options: Options): [Post] @relationship(edgeType:"found_in", direction:IN)
-found_in:Found_in
+type Date @alias(property: "date") {
+    _id: ID! @id
+    type: String
+    text: String
+    postFound_insIn(filter: PostInput, options: Options): [Post] @relationship(edgeType: "found_in", direction: IN)
+    found_in: Found_in
 }
 
 input DateInput {
-_id: ID @id
-type: String
-text: String
+    _id: ID @id
+    type: StringScalarFilters
+    text: StringScalarFilters
 }
 
-type Other @alias(property:"other") {
-_id: ID! @id
-type: String
-text: String
-postFound_inIn: Post @relationship(edgeType:"found_in", direction:IN)
-found_in:Found_in
+type Other @alias(property: "other") {
+    _id: ID! @id
+    type: String
+    text: String
+    postFound_inIn: Post @relationship(edgeType: "found_in", direction: IN)
+    found_in: Found_in
 }
 
 input OtherInput {
-_id: ID @id
-type: String
-text: String
+    _id: ID @id
+    type: StringScalarFilters
+    text: StringScalarFilters
 }
 
-type Post @alias(property:"post") {
-_id: ID! @id
-title: String
-post_date: String
-tagTaggedsOut(filter: TagInput, options: Options): [Tag] @relationship(edgeType:"tagged", direction:OUT)
-organizationFound_insOut(filter: OrganizationInput, options: Options): [Organization] @relationship(edgeType:"found_in", direction:OUT)
-titleFound_insOut(filter: TitleInput, options: Options): [Title] @relationship(edgeType:"found_in", direction:OUT)
-locationFound_insOut(filter: LocationInput, options: Options): [Location] @relationship(edgeType:"found_in", direction:OUT)
-dateFound_insOut(filter: DateInput, options: Options): [Date] @relationship(edgeType:"found_in", direction:OUT)
-commercial_itemFound_insOut(filter: Commercial_itemInput, options: Options): [Commercial_item] @relationship(edgeType:"found_in", direction:OUT)
-otherFound_insOut(filter: OtherInput, options: Options): [Other] @relationship(edgeType:"found_in", direction:OUT)
-authorWritten_bysOut(filter: AuthorInput, options: Options): [Author] @relationship(edgeType:"written_by", direction:OUT)
-tagged:Tagged
-found_in:Found_in
-written_by:Written_by
+type Post @alias(property: "post") {
+    _id: ID! @id
+    title: String
+    post_date: String
+    tagTaggedsOut(filter: TagInput, options: Options): [Tag] @relationship(edgeType: "tagged", direction: OUT)
+    organizationFound_insOut(filter: OrganizationInput, options: Options): [Organization] @relationship(edgeType: "found_in", direction: OUT)
+    titleFound_insOut(filter: TitleInput, options: Options): [Title] @relationship(edgeType: "found_in", direction: OUT)
+    locationFound_insOut(filter: LocationInput, options: Options): [Location] @relationship(edgeType: "found_in", direction: OUT)
+    dateFound_insOut(filter: DateInput, options: Options): [Date] @relationship(edgeType: "found_in", direction: OUT)
+    commercial_itemFound_insOut(filter: Commercial_itemInput, options: Options): [Commercial_item] @relationship(edgeType: "found_in", direction: OUT)
+    otherFound_insOut(filter: OtherInput, options: Options): [Other] @relationship(edgeType: "found_in", direction: OUT)
+    authorWritten_bysOut(filter: AuthorInput, options: Options): [Author] @relationship(edgeType: "written_by", direction: OUT)
+    tagged: Tagged
+    found_in: Found_in
+    written_by: Written_by
 }
 
 input PostInput {
-_id: ID @id
-title: String
-post_date: String
+    _id: ID @id
+    title: StringScalarFilters
+    post_date: StringScalarFilters
 }
 
-type Author @alias(property:"author") {
-_id: ID! @id
-name: String
-postWritten_bysIn(filter: PostInput, options: Options): [Post] @relationship(edgeType:"written_by", direction:IN)
-written_by:Written_by
+type Author @alias(property: "author") {
+    _id: ID! @id
+    name: String
+    postWritten_bysIn(filter: PostInput, options: Options): [Post] @relationship(edgeType: "written_by", direction: IN)
+    written_by: Written_by
 }
 
 input AuthorInput {
-_id: ID @id
-name: String
+    _id: ID @id
+    name: StringScalarFilters
 }
 
-type Organization @alias(property:"organization") {
-_id: ID! @id
-type: String
-text: String
-postFound_insIn(filter: PostInput, options: Options): [Post] @relationship(edgeType:"found_in", direction:IN)
-found_in:Found_in
+type Organization @alias(property: "organization") {
+    _id: ID! @id
+    type: String
+    text: String
+    postFound_insIn(filter: PostInput, options: Options): [Post] @relationship(edgeType: "found_in", direction: IN)
+    found_in: Found_in
 }
 
 input OrganizationInput {
-_id: ID @id
-type: String
-text: String
+    _id: ID @id
+    type: StringScalarFilters
+    text: StringScalarFilters
 }
 
-type Location @alias(property:"location") {
-_id: ID! @id
-type: String
-text: String
-postFound_insIn(filter: PostInput, options: Options): [Post] @relationship(edgeType:"found_in", direction:IN)
-found_in:Found_in
+type Location @alias(property: "location") {
+    _id: ID! @id
+    type: String
+    text: String
+    postFound_insIn(filter: PostInput, options: Options): [Post] @relationship(edgeType: "found_in", direction: IN)
+    found_in: Found_in
 }
 
 input LocationInput {
-_id: ID @id
-type: String
-text: String
+    _id: ID @id
+    type: StringScalarFilters
+    text: StringScalarFilters
 }
 
-type Tag @alias(property:"tag") {
-_id: ID! @id
-tag: String
-postTaggedsIn(filter: PostInput, options: Options): [Post] @relationship(edgeType:"tagged", direction:IN)
-tagged:Tagged
+type Tag @alias(property: "tag") {
+    _id: ID! @id
+    tag: String
+    postTaggedsIn(filter: PostInput, options: Options): [Post] @relationship(edgeType: "tagged", direction: IN)
+    tagged: Tagged
 }
 
 input TagInput {
-_id: ID @id
-tag: String
+    _id: ID @id
+    tag: StringScalarFilters
 }
 
-type Title @alias(property:"title") {
-_id: ID! @id
-type: String
-text: String
-postFound_insIn(filter: PostInput, options: Options): [Post] @relationship(edgeType:"found_in", direction:IN)
-found_in:Found_in
+type Title @alias(property: "title") {
+    _id: ID! @id
+    type: String
+    text: String
+    postFound_insIn(filter: PostInput, options: Options): [Post] @relationship(edgeType: "found_in", direction: IN)
+    found_in: Found_in
 }
 
 input TitleInput {
-_id: ID @id
-type: String
-text: String
+    _id: ID @id
+    type: StringScalarFilters
+    text: StringScalarFilters
 }
 
-type Commercial_item @alias(property:"commercial_item") {
-_id: ID! @id
-type: String
-text: String
-postFound_insIn(filter: PostInput, options: Options): [Post] @relationship(edgeType:"found_in", direction:IN)
-found_in:Found_in
+type Commercial_item @alias(property: "commercial_item") {
+    _id: ID! @id
+    type: String
+    text: String
+    postFound_insIn(filter: PostInput, options: Options): [Post] @relationship(edgeType: "found_in", direction: IN)
+    found_in: Found_in
 }
 
 input Commercial_itemInput {
-_id: ID @id
-type: String
-text: String
+    _id: ID @id
+    type: StringScalarFilters
+    text: StringScalarFilters
 }
 
-type Tagged @alias(property:"tagged") {
-_id: ID! @id
+type Tagged @alias(property: "tagged") {
+    _id: ID! @id
 }
 
-type Found_in @alias(property:"found_in") {
-_id: ID! @id
-score: Float
+type Found_in @alias(property: "found_in") {
+    _id: ID! @id
+    score: Float
 }
 
 input Found_inInput {
-score: Float
+    score: Float
 }
 
-type Written_by @alias(property:"written_by") {
-_id: ID! @id
+type Written_by @alias(property: "written_by") {
+    _id: ID! @id
 }
 
 input Options {
-limit:Int
+    limit: Int
+}
+
+input StringScalarFilters {
+    eq: String
+    contains: String
+    endsWith: String
+    startsWith: String
 }
 
 type Query {
-getNodeDate(filter: DateInput): Date
-getNodeDates(filter: DateInput, options: Options): [Date]
-getNodeOther(filter: OtherInput): Other
-getNodeOthers(filter: OtherInput, options: Options): [Other]
-getNodePost(filter: PostInput): Post
-getNodePosts(filter: PostInput, options: Options): [Post]
-getNodeAuthor(filter: AuthorInput): Author
-getNodeAuthors(filter: AuthorInput, options: Options): [Author]
-getNodeOrganization(filter: OrganizationInput): Organization
-getNodeOrganizations(filter: OrganizationInput, options: Options): [Organization]
-getNodeLocation(filter: LocationInput): Location
-getNodeLocations(filter: LocationInput, options: Options): [Location]
-getNodeTag(filter: TagInput): Tag
-getNodeTags(filter: TagInput, options: Options): [Tag]
-getNodeTitle(filter: TitleInput): Title
-getNodeTitles(filter: TitleInput, options: Options): [Title]
-getNodeCommercial_item(filter: Commercial_itemInput): Commercial_item
-getNodeCommercial_items(filter: Commercial_itemInput, options: Options): [Commercial_item]
+    getNodeDate(filter: DateInput): Date
+    getNodeDates(filter: DateInput, options: Options): [Date]
+    getNodeOther(filter: OtherInput): Other
+    getNodeOthers(filter: OtherInput, options: Options): [Other]
+    getNodePost(filter: PostInput): Post
+    getNodePosts(filter: PostInput, options: Options): [Post]
+    getNodeAuthor(filter: AuthorInput): Author
+    getNodeAuthors(filter: AuthorInput, options: Options): [Author]
+    getNodeOrganization(filter: OrganizationInput): Organization
+    getNodeOrganizations(filter: OrganizationInput, options: Options): [Organization]
+    getNodeLocation(filter: LocationInput): Location
+    getNodeLocations(filter: LocationInput, options: Options): [Location]
+    getNodeTag(filter: TagInput): Tag
+    getNodeTags(filter: TagInput, options: Options): [Tag]
+    getNodeTitle(filter: TitleInput): Title
+    getNodeTitles(filter: TitleInput, options: Options): [Title]
+    getNodeCommercial_item(filter: Commercial_itemInput): Commercial_item
+    getNodeCommercial_items(filter: Commercial_itemInput, options: Options): [Commercial_item]
 }
 
 schema {
-query: Query
+    query: Query
 }

--- a/src/test/node-edge-same-label.graphql
+++ b/src/test/node-edge-same-label.graphql
@@ -1,26 +1,26 @@
 type post {
     _id: ID! @id
     text: String
-    author:author
+    author: author
 }
 
 input postInput {
     _id: ID @id
-    text: String
+    text: StringScalarFilters
 }
 
 type author {
     _id: ID! @id
     username: String
-    author:author
+    author: author
 }
 
 input authorInput {
     _id: ID @id
-    username: String
+    username: StringScalarFilters
 }
 
-type _author @alias(property:"author") {
+type _author @alias(property: "author") {
     _id: ID! @id
     date: Date
 }
@@ -30,7 +30,14 @@ input _authorInput {
 }
 
 input Options {
-    limit:Int
+    limit: Int
+}
+
+input StringScalarFilters {
+    eq: String
+    contains: String
+    endsWith: String
+    startsWith: String
 }
 
 type Query {

--- a/src/test/security.graphql
+++ b/src/test/security.graphql
@@ -1,537 +1,544 @@
-type Image @alias(property:"image") {
-_id: ID! @id
-scan_id: String
-arn: String
-ec2_cn_instanceTransient_resource_linksIn(filter: Ec2_cn_instanceInput, options: Options): [Ec2_cn_instance] @relationship(edgeType:"transient_resource_link", direction:IN)
-transient_resource_link:Transient_resource_link
+type Image @alias(property: "image") {
+    _id: ID! @id
+    scan_id: String
+    arn: String
+    ec2_cn_instanceTransient_resource_linksIn(filter: Ec2_cn_instanceInput, options: Options): [Ec2_cn_instance] @relationship(edgeType: "transient_resource_link", direction: IN)
+    transient_resource_link: Transient_resource_link
 }
 
 input ImageInput {
-_id: ID @id
-scan_id: String
-arn: String
+    _id: ID @id
+    scan_id: StringScalarFilters
+    arn: StringScalarFilters
 }
 
-type Guardduty_cn_detector @alias(property:"guardduty:detector") {
-_id: ID! @id
-created_at: String
-updated_at: String
-scan_id: String
-status: String
-arn: String
-service_role: String
-finding_publishing_frequency: String
+type Guardduty_cn_detector @alias(property: "guardduty:detector") {
+    _id: ID! @id
+    created_at: String
+    updated_at: String
+    scan_id: String
+    status: String
+    arn: String
+    service_role: String
+    finding_publishing_frequency: String
 }
 
 input Guardduty_cn_detectorInput {
-_id: ID @id
-created_at: String
-updated_at: String
-scan_id: String
-status: String
-arn: String
-service_role: String
-finding_publishing_frequency: String
+    _id: ID @id
+    created_at: StringScalarFilters
+    updated_at: StringScalarFilters
+    scan_id: StringScalarFilters
+    status: StringScalarFilters
+    arn: StringScalarFilters
+    service_role: StringScalarFilters
+    finding_publishing_frequency: StringScalarFilters
 }
 
-type Ec2_cn_vpc @alias(property:"ec2:vpc") {
-_id: ID! @id
-scan_id: String
-state: String
-arn: String
-is_default: String
-cidr_block: String
-ec2_cn_network_hy_interfaceResource_linksIn(filter: Ec2_cn_network_hy_interfaceInput, options: Options): [Ec2_cn_network_hy_interface] @relationship(edgeType:"resource_link", direction:IN)
-ec2_cn_subnetResource_linksIn(filter: Ec2_cn_subnetInput, options: Options): [Ec2_cn_subnet] @relationship(edgeType:"resource_link", direction:IN)
-ec2_cn_instanceResource_linksIn(filter: Ec2_cn_instanceInput, options: Options): [Ec2_cn_instance] @relationship(edgeType:"resource_link", direction:IN)
-resource_link:Resource_link
-transient_resource_link:Transient_resource_link
+type Ec2_cn_vpc @alias(property: "ec2:vpc") {
+    _id: ID! @id
+    scan_id: String
+    state: String
+    arn: String
+    is_default: String
+    cidr_block: String
+    ec2_cn_network_hy_interfaceResource_linksIn(filter: Ec2_cn_network_hy_interfaceInput, options: Options): [Ec2_cn_network_hy_interface] @relationship(edgeType: "resource_link", direction: IN)
+    ec2_cn_subnetResource_linksIn(filter: Ec2_cn_subnetInput, options: Options): [Ec2_cn_subnet] @relationship(edgeType: "resource_link", direction: IN)
+    ec2_cn_instanceResource_linksIn(filter: Ec2_cn_instanceInput, options: Options): [Ec2_cn_instance] @relationship(edgeType: "resource_link", direction: IN)
+    resource_link: Resource_link
+    transient_resource_link: Transient_resource_link
 }
 
 input Ec2_cn_vpcInput {
-_id: ID @id
-scan_id: String
-state: String
-arn: String
-is_default: String
-cidr_block: String
+    _id: ID @id
+    scan_id: StringScalarFilters
+    state: StringScalarFilters
+    arn: StringScalarFilters
+    is_default: StringScalarFilters
+    cidr_block: StringScalarFilters
 }
 
-type Iam_cn_role @alias(property:"iam:role") {
-_id: ID! @id
-name: String
-principal_dot_aws: String @alias(property: "principal.aws")
-statement_dot_effect: String @alias(property: "statement.effect")
-statement_dot_action: String @alias(property: "statement.action")
-max_session_duration: String
-arn: String
-nassume_role_policy_document_text: String
-scan_id: String
-assume_role_policy_document_dot_version: String @alias(property: "assume_role_policy_document.version")
-iam_cn_policyResource_linksOut(filter: Iam_cn_policyInput, options: Options): [Iam_cn_policy] @relationship(edgeType:"resource_link", direction:OUT)
-resource_link:Resource_link
+type Iam_cn_role @alias(property: "iam:role") {
+    _id: ID! @id
+    name: String
+    principal_dot_aws: String @alias(property: "principal.aws")
+    statement_dot_effect: String @alias(property: "statement.effect")
+    statement_dot_action: String @alias(property: "statement.action")
+    max_session_duration: String
+    arn: String
+    nassume_role_policy_document_text: String
+    scan_id: String
+    assume_role_policy_document_dot_version: String @alias(property: "assume_role_policy_document.version")
+    iam_cn_policyResource_linksOut(filter: Iam_cn_policyInput, options: Options): [Iam_cn_policy] @relationship(edgeType: "resource_link", direction: OUT)
+    resource_link: Resource_link
 }
 
 input Iam_cn_roleInput {
-_id: ID @id
-name: String
-principal_dot_aws: String @alias(property: "principal.aws")
-statement_dot_effect: String @alias(property: "statement.effect")
-statement_dot_action: String @alias(property: "statement.action")
-max_session_duration: String
-arn: String
-nassume_role_policy_document_text: String
-scan_id: String
-assume_role_policy_document_dot_version: String @alias(property: "assume_role_policy_document.version")
+    _id: ID @id
+    name: StringScalarFilters
+    principal_dot_aws: StringScalarFilters @alias(property: "principal.aws")
+    statement_dot_effect: StringScalarFilters @alias(property: "statement.effect")
+    statement_dot_action: StringScalarFilters @alias(property: "statement.action")
+    max_session_duration: StringScalarFilters
+    arn: StringScalarFilters
+    nassume_role_policy_document_text: StringScalarFilters
+    scan_id: StringScalarFilters
+    assume_role_policy_document_dot_version: StringScalarFilters @alias(property: "assume_role_policy_document.version")
 }
 
-type Ec2_cn_network_hy_interface @alias(property:"ec2:network-interface") {
-_id: ID! @id
-public_ip: String
-public_dns_name: String
-arn: String
-private_ip_address: String
-mac_address: String
-scan_id: String
-private_dns_name: String
-status: String
-interface_type: String
-description: String
-ec2_cn_vpcResource_linkOut: Ec2_cn_vpc @relationship(edgeType:"resource_link", direction:OUT)
-resource_link:Resource_link
+type Ec2_cn_network_hy_interface @alias(property: "ec2:network-interface") {
+    _id: ID! @id
+    public_ip: String
+    public_dns_name: String
+    arn: String
+    private_ip_address: String
+    mac_address: String
+    scan_id: String
+    private_dns_name: String
+    status: String
+    interface_type: String
+    description: String
+    ec2_cn_vpcResource_linkOut: Ec2_cn_vpc @relationship(edgeType: "resource_link", direction: OUT)
+    resource_link: Resource_link
 }
 
 input Ec2_cn_network_hy_interfaceInput {
-_id: ID @id
-public_ip: String
-public_dns_name: String
-arn: String
-private_ip_address: String
-mac_address: String
-scan_id: String
-private_dns_name: String
-status: String
-interface_type: String
-description: String
+    _id: ID @id
+    public_ip: StringScalarFilters
+    public_dns_name: StringScalarFilters
+    arn: StringScalarFilters
+    private_ip_address: StringScalarFilters
+    mac_address: StringScalarFilters
+    scan_id: StringScalarFilters
+    private_dns_name: StringScalarFilters
+    status: StringScalarFilters
+    interface_type: StringScalarFilters
+    description: StringScalarFilters
 }
 
-type Rds_cn_db @alias(property:"rds:db") {
-_id: ID! @id
-storage_type: String
-performance_insights_enabled: String
-dbi_resource_id: String
-scan_id: String
-db_instance_identifier: String
-backup_retention_period: String
-publicly_accessible: String
-multi_az: String
-availability_zone: String
-arn: String
-storage_encrypted: String
-iam_database_authentication_enabled: String
-db_instance_class: String
-endpoint_hosted_zone: String
-deletion_protection: String
-endpoint_address: String
-db_instance_status: String
-endpoint_port: String
-instance_create_time: String
-engine: String
-transient_resource_link:Transient_resource_link
+type Rds_cn_db @alias(property: "rds:db") {
+    _id: ID! @id
+    storage_type: String
+    performance_insights_enabled: String
+    dbi_resource_id: String
+    scan_id: String
+    db_instance_identifier: String
+    backup_retention_period: String
+    publicly_accessible: String
+    multi_az: String
+    availability_zone: String
+    arn: String
+    storage_encrypted: String
+    iam_database_authentication_enabled: String
+    db_instance_class: String
+    endpoint_hosted_zone: String
+    deletion_protection: String
+    endpoint_address: String
+    db_instance_status: String
+    endpoint_port: String
+    instance_create_time: String
+    engine: String
+    transient_resource_link: Transient_resource_link
 }
 
 input Rds_cn_dbInput {
-_id: ID @id
-storage_type: String
-performance_insights_enabled: String
-dbi_resource_id: String
-scan_id: String
-db_instance_identifier: String
-backup_retention_period: String
-publicly_accessible: String
-multi_az: String
-availability_zone: String
-arn: String
-storage_encrypted: String
-iam_database_authentication_enabled: String
-db_instance_class: String
-endpoint_hosted_zone: String
-deletion_protection: String
-endpoint_address: String
-db_instance_status: String
-endpoint_port: String
-instance_create_time: String
-engine: String
+    _id: ID @id
+    storage_type: StringScalarFilters
+    performance_insights_enabled: StringScalarFilters
+    dbi_resource_id: StringScalarFilters
+    scan_id: StringScalarFilters
+    db_instance_identifier: StringScalarFilters
+    backup_retention_period: StringScalarFilters
+    publicly_accessible: StringScalarFilters
+    multi_az: StringScalarFilters
+    availability_zone: StringScalarFilters
+    arn: StringScalarFilters
+    storage_encrypted: StringScalarFilters
+    iam_database_authentication_enabled: StringScalarFilters
+    db_instance_class: StringScalarFilters
+    endpoint_hosted_zone: StringScalarFilters
+    deletion_protection: StringScalarFilters
+    endpoint_address: StringScalarFilters
+    db_instance_status: StringScalarFilters
+    endpoint_port: StringScalarFilters
+    instance_create_time: StringScalarFilters
+    engine: StringScalarFilters
 }
 
-type Ec2_cn_instance @alias(property:"ec2:instance") {
-_id: ID! @id
-scan_id: String
-public_ip_address: String
-instance_type: String
-state: String
-arn: String
-private_ip_address: String
-launch_time: String
-ec2_cn_security_hy_groupResource_linkOut: Ec2_cn_security_hy_group @relationship(edgeType:"resource_link", direction:OUT)
-ec2_cn_subnetResource_linkOut: Ec2_cn_subnet @relationship(edgeType:"resource_link", direction:OUT)
-ec2_cn_vpcResource_linkOut: Ec2_cn_vpc @relationship(edgeType:"resource_link", direction:OUT)
-imageTransient_resource_linkOut: Image @relationship(edgeType:"transient_resource_link", direction:OUT)
-resource_link:Resource_link
-tagged:Tagged
-transient_resource_link:Transient_resource_link
+type Ec2_cn_instance @alias(property: "ec2:instance") {
+    _id: ID! @id
+    scan_id: String
+    public_ip_address: String
+    instance_type: String
+    state: String
+    arn: String
+    private_ip_address: String
+    launch_time: String
+    ec2_cn_security_hy_groupResource_linkOut: Ec2_cn_security_hy_group @relationship(edgeType: "resource_link", direction: OUT)
+    ec2_cn_subnetResource_linkOut: Ec2_cn_subnet @relationship(edgeType: "resource_link", direction: OUT)
+    ec2_cn_vpcResource_linkOut: Ec2_cn_vpc @relationship(edgeType: "resource_link", direction: OUT)
+    imageTransient_resource_linkOut: Image @relationship(edgeType: "transient_resource_link", direction: OUT)
+    resource_link: Resource_link
+    tagged: Tagged
+    transient_resource_link: Transient_resource_link
 }
 
 input Ec2_cn_instanceInput {
-_id: ID @id
-scan_id: String
-public_ip_address: String
-instance_type: String
-state: String
-arn: String
-private_ip_address: String
-launch_time: String
+    _id: ID @id
+    scan_id: StringScalarFilters
+    public_ip_address: StringScalarFilters
+    instance_type: StringScalarFilters
+    state: StringScalarFilters
+    arn: StringScalarFilters
+    private_ip_address: StringScalarFilters
+    launch_time: StringScalarFilters
 }
 
-type Iam_cn_user @alias(property:"iam:user") {
-_id: ID! @id
-password_last_used: String
-name: String
-login_profile_dot_password_reset_required: String @alias(property: "login_profile.password_reset_required")
-arn: String
-access_key_dot_access_key_id: String @alias(property: "access_key.access_key_id")
-login_profile_dot_create_date: String @alias(property: "login_profile.create_date")
-scan_id: String
-create_date: String
-access_key_dot_last_used_date: String @alias(property: "access_key.last_used_date")
-access_key_dot_status: String @alias(property: "access_key.status")
-user_id: String
-access_key_dot_create_date: String @alias(property: "access_key.create_date")
+type Iam_cn_user @alias(property: "iam:user") {
+    _id: ID! @id
+    password_last_used: String
+    name: String
+    login_profile_dot_password_reset_required: String @alias(property: "login_profile.password_reset_required")
+    arn: String
+    access_key_dot_access_key_id: String @alias(property: "access_key.access_key_id")
+    login_profile_dot_create_date: String @alias(property: "login_profile.create_date")
+    scan_id: String
+    create_date: String
+    access_key_dot_last_used_date: String @alias(property: "access_key.last_used_date")
+    access_key_dot_status: String @alias(property: "access_key.status")
+    user_id: String
+    access_key_dot_create_date: String @alias(property: "access_key.create_date")
 }
 
 input Iam_cn_userInput {
-_id: ID @id
-password_last_used: String
-name: String
-login_profile_dot_password_reset_required: String @alias(property: "login_profile.password_reset_required")
-arn: String
-access_key_dot_access_key_id: String @alias(property: "access_key.access_key_id")
-login_profile_dot_create_date: String @alias(property: "login_profile.create_date")
-scan_id: String
-create_date: String
-access_key_dot_last_used_date: String @alias(property: "access_key.last_used_date")
-access_key_dot_status: String @alias(property: "access_key.status")
-user_id: String
-access_key_dot_create_date: String @alias(property: "access_key.create_date")
+    _id: ID @id
+    password_last_used: StringScalarFilters
+    name: StringScalarFilters
+    login_profile_dot_password_reset_required: StringScalarFilters @alias(property: "login_profile.password_reset_required")
+    arn: StringScalarFilters
+    access_key_dot_access_key_id: StringScalarFilters @alias(property: "access_key.access_key_id")
+    login_profile_dot_create_date: StringScalarFilters @alias(property: "login_profile.create_date")
+    scan_id: StringScalarFilters
+    create_date: StringScalarFilters
+    access_key_dot_last_used_date: StringScalarFilters @alias(property: "access_key.last_used_date")
+    access_key_dot_status: StringScalarFilters @alias(property: "access_key.status")
+    user_id: StringScalarFilters
+    access_key_dot_create_date: StringScalarFilters @alias(property: "access_key.create_date")
 }
 
-type Ec2_cn_security_hy_group @alias(property:"ec2:security-group") {
-_id: ID! @id
-egress_rule_dot_ip_protocol: String @alias(property: "egress_rule.ip_protocol")
-name: String
-ip_range_dot_first_ip: String @alias(property: "ip_range.first_ip")
-arn: String
-egress_rule_dot_to_port: String @alias(property: "egress_rule.to_port")
-scan_id: String
-ip_range_dot_last_ip: String @alias(property: "ip_range.last_ip")
-egress_rule_dot_from_port: String @alias(property: "egress_rule.from_port")
-ip_range_dot_cidr_ip: String @alias(property: "ip_range.cidr_ip")
-ingress_rule_dot_from_port: String @alias(property: "ingress_rule.from_port")
-ingress_rule_dot_ip_protocol: String @alias(property: "ingress_rule.ip_protocol")
-ingress_rule_dot_to_port: String @alias(property: "ingress_rule.to_port")
-user_id_group_pairs_dot_account_id: String @alias(property: "user_id_group_pairs.account_id")
-ec2_cn_instanceResource_linksIn(filter: Ec2_cn_instanceInput, options: Options): [Ec2_cn_instance] @relationship(edgeType:"resource_link", direction:IN)
-ec2_cn_security_hy_groupResource_linkOut: Ec2_cn_security_hy_group @relationship(edgeType:"resource_link", direction:OUT)
-ec2_cn_security_hy_groupResource_linkIn: Ec2_cn_security_hy_group @relationship(edgeType:"resource_link", direction:IN)
-tagTaggedsOut(filter: TagInput, options: Options): [Tag] @relationship(edgeType:"tagged", direction:OUT)
-resource_link:Resource_link
-tagged:Tagged
-transient_resource_link:Transient_resource_link
+type Ec2_cn_security_hy_group @alias(property: "ec2:security-group") {
+    _id: ID! @id
+    egress_rule_dot_ip_protocol: String @alias(property: "egress_rule.ip_protocol")
+    name: String
+    ip_range_dot_first_ip: String @alias(property: "ip_range.first_ip")
+    arn: String
+    egress_rule_dot_to_port: String @alias(property: "egress_rule.to_port")
+    scan_id: String
+    ip_range_dot_last_ip: String @alias(property: "ip_range.last_ip")
+    egress_rule_dot_from_port: String @alias(property: "egress_rule.from_port")
+    ip_range_dot_cidr_ip: String @alias(property: "ip_range.cidr_ip")
+    ingress_rule_dot_from_port: String @alias(property: "ingress_rule.from_port")
+    ingress_rule_dot_ip_protocol: String @alias(property: "ingress_rule.ip_protocol")
+    ingress_rule_dot_to_port: String @alias(property: "ingress_rule.to_port")
+    user_id_group_pairs_dot_account_id: String @alias(property: "user_id_group_pairs.account_id")
+    ec2_cn_instanceResource_linksIn(filter: Ec2_cn_instanceInput, options: Options): [Ec2_cn_instance] @relationship(edgeType: "resource_link", direction: IN)
+    ec2_cn_security_hy_groupResource_linkOut: Ec2_cn_security_hy_group @relationship(edgeType: "resource_link", direction: OUT)
+    ec2_cn_security_hy_groupResource_linkIn: Ec2_cn_security_hy_group @relationship(edgeType: "resource_link", direction: IN)
+    tagTaggedsOut(filter: TagInput, options: Options): [Tag] @relationship(edgeType: "tagged", direction: OUT)
+    resource_link: Resource_link
+    tagged: Tagged
+    transient_resource_link: Transient_resource_link
 }
 
 input Ec2_cn_security_hy_groupInput {
-_id: ID @id
-egress_rule_dot_ip_protocol: String @alias(property: "egress_rule.ip_protocol")
-name: String
-ip_range_dot_first_ip: String @alias(property: "ip_range.first_ip")
-arn: String
-egress_rule_dot_to_port: String @alias(property: "egress_rule.to_port")
-scan_id: String
-ip_range_dot_last_ip: String @alias(property: "ip_range.last_ip")
-egress_rule_dot_from_port: String @alias(property: "egress_rule.from_port")
-ip_range_dot_cidr_ip: String @alias(property: "ip_range.cidr_ip")
-ingress_rule_dot_from_port: String @alias(property: "ingress_rule.from_port")
-ingress_rule_dot_ip_protocol: String @alias(property: "ingress_rule.ip_protocol")
-ingress_rule_dot_to_port: String @alias(property: "ingress_rule.to_port")
-user_id_group_pairs_dot_account_id: String @alias(property: "user_id_group_pairs.account_id")
+    _id: ID @id
+    egress_rule_dot_ip_protocol: StringScalarFilters @alias(property: "egress_rule.ip_protocol")
+    name: StringScalarFilters
+    ip_range_dot_first_ip: StringScalarFilters @alias(property: "ip_range.first_ip")
+    arn: StringScalarFilters
+    egress_rule_dot_to_port: StringScalarFilters @alias(property: "egress_rule.to_port")
+    scan_id: StringScalarFilters
+    ip_range_dot_last_ip: StringScalarFilters @alias(property: "ip_range.last_ip")
+    egress_rule_dot_from_port: StringScalarFilters @alias(property: "egress_rule.from_port")
+    ip_range_dot_cidr_ip: StringScalarFilters @alias(property: "ip_range.cidr_ip")
+    ingress_rule_dot_from_port: StringScalarFilters @alias(property: "ingress_rule.from_port")
+    ingress_rule_dot_ip_protocol: StringScalarFilters @alias(property: "ingress_rule.ip_protocol")
+    ingress_rule_dot_to_port: StringScalarFilters @alias(property: "ingress_rule.to_port")
+    user_id_group_pairs_dot_account_id: StringScalarFilters @alias(property: "user_id_group_pairs.account_id")
 }
 
-type Ec2_cn_internet_hy_gateway @alias(property:"ec2:internet-gateway") {
-_id: ID! @id
-arn: String
-scan_id: String
-owner_id: String
-attachment_dot_state: String @alias(property: "attachment.state")
-resource_link:Resource_link
+type Ec2_cn_internet_hy_gateway @alias(property: "ec2:internet-gateway") {
+    _id: ID! @id
+    arn: String
+    scan_id: String
+    owner_id: String
+    attachment_dot_state: String @alias(property: "attachment.state")
+    resource_link: Resource_link
 }
 
 input Ec2_cn_internet_hy_gatewayInput {
-_id: ID @id
-arn: String
-scan_id: String
-owner_id: String
-attachment_dot_state: String @alias(property: "attachment.state")
+    _id: ID @id
+    arn: StringScalarFilters
+    scan_id: StringScalarFilters
+    owner_id: StringScalarFilters
+    attachment_dot_state: StringScalarFilters @alias(property: "attachment.state")
 }
 
-type Events_cn_rule @alias(property:"events:rule") {
-_id: ID! @id
-arn: String
-name: String
-scan_id: String
-target_dot_arn: String @alias(property: "target.arn")
-target_dot_name: String @alias(property: "target.name")
-event_pattern: String
-state: String
+type Events_cn_rule @alias(property: "events:rule") {
+    _id: ID! @id
+    arn: String
+    name: String
+    scan_id: String
+    target_dot_arn: String @alias(property: "target.arn")
+    target_dot_name: String @alias(property: "target.name")
+    event_pattern: String
+    state: String
 }
 
 input Events_cn_ruleInput {
-_id: ID @id
-arn: String
-name: String
-scan_id: String
-target_dot_arn: String @alias(property: "target.arn")
-target_dot_name: String @alias(property: "target.name")
-event_pattern: String
-state: String
+    _id: ID @id
+    arn: StringScalarFilters
+    name: StringScalarFilters
+    scan_id: StringScalarFilters
+    target_dot_arn: StringScalarFilters @alias(property: "target.arn")
+    target_dot_name: StringScalarFilters @alias(property: "target.name")
+    event_pattern: StringScalarFilters
+    state: StringScalarFilters
 }
 
-type Ec2_cn_subnet @alias(property:"ec2:subnet") {
-_id: ID! @id
-scan_id: String
-first_ip: String
-state: String
-arn: String
-last_ip: String
-cidr_block: String
-ec2_cn_instanceResource_linksIn(filter: Ec2_cn_instanceInput, options: Options): [Ec2_cn_instance] @relationship(edgeType:"resource_link", direction:IN)
-ec2_cn_vpcResource_linkOut: Ec2_cn_vpc @relationship(edgeType:"resource_link", direction:OUT)
-resource_link:Resource_link
+type Ec2_cn_subnet @alias(property: "ec2:subnet") {
+    _id: ID! @id
+    scan_id: String
+    first_ip: String
+    state: String
+    arn: String
+    last_ip: String
+    cidr_block: String
+    ec2_cn_instanceResource_linksIn(filter: Ec2_cn_instanceInput, options: Options): [Ec2_cn_instance] @relationship(edgeType: "resource_link", direction: IN)
+    ec2_cn_vpcResource_linkOut: Ec2_cn_vpc @relationship(edgeType: "resource_link", direction: OUT)
+    resource_link: Resource_link
 }
 
 input Ec2_cn_subnetInput {
-_id: ID @id
-scan_id: String
-first_ip: String
-state: String
-arn: String
-last_ip: String
-cidr_block: String
+    _id: ID @id
+    scan_id: StringScalarFilters
+    first_ip: StringScalarFilters
+    state: StringScalarFilters
+    arn: StringScalarFilters
+    last_ip: StringScalarFilters
+    cidr_block: StringScalarFilters
 }
 
-type Iam_cn_instance_hy_profile @alias(property:"iam:instance-profile") {
-_id: ID! @id
-arn: String
-name: String
-scan_id: String
-resource_link:Resource_link
-transient_resource_link:Transient_resource_link
+type Iam_cn_instance_hy_profile @alias(property: "iam:instance-profile") {
+    _id: ID! @id
+    arn: String
+    name: String
+    scan_id: String
+    resource_link: Resource_link
+    transient_resource_link: Transient_resource_link
 }
 
 input Iam_cn_instance_hy_profileInput {
-_id: ID @id
-arn: String
-name: String
-scan_id: String
+    _id: ID @id
+    arn: StringScalarFilters
+    name: StringScalarFilters
+    scan_id: StringScalarFilters
 }
 
-type Iam_cn_policy @alias(property:"iam:policy") {
-_id: ID! @id
-default_version_policy_document_text: String
-default_version_id: String
-name: String
-scan_id: String
-arn: String
-policy_id: String
-iam_cn_roleResource_linksIn(filter: Iam_cn_roleInput, options: Options): [Iam_cn_role] @relationship(edgeType:"resource_link", direction:IN)
-resource_link:Resource_link
+type Iam_cn_policy @alias(property: "iam:policy") {
+    _id: ID! @id
+    default_version_policy_document_text: String
+    default_version_id: String
+    name: String
+    scan_id: String
+    arn: String
+    policy_id: String
+    iam_cn_roleResource_linksIn(filter: Iam_cn_roleInput, options: Options): [Iam_cn_role] @relationship(edgeType: "resource_link", direction: IN)
+    resource_link: Resource_link
 }
 
 input Iam_cn_policyInput {
-_id: ID @id
-default_version_policy_document_text: String
-default_version_id: String
-name: String
-scan_id: String
-arn: String
-policy_id: String
+    _id: ID @id
+    default_version_policy_document_text: StringScalarFilters
+    default_version_id: StringScalarFilters
+    name: StringScalarFilters
+    scan_id: StringScalarFilters
+    arn: StringScalarFilters
+    policy_id: StringScalarFilters
 }
 
-type S3_cn_bucket @alias(property:"s3:bucket") {
-_id: ID! @id
-name: String
-scan_id: String
-server_side_default_encryption_rule_dot_algorithm: String @alias(property: "server_side_default_encryption_rule.algorithm")
-creation_date: String
-arn: String
+type S3_cn_bucket @alias(property: "s3:bucket") {
+    _id: ID! @id
+    name: String
+    scan_id: String
+    server_side_default_encryption_rule_dot_algorithm: String @alias(property: "server_side_default_encryption_rule.algorithm")
+    creation_date: String
+    arn: String
 }
 
 input S3_cn_bucketInput {
-_id: ID @id
-name: String
-scan_id: String
-server_side_default_encryption_rule_dot_algorithm: String @alias(property: "server_side_default_encryption_rule.algorithm")
-creation_date: String
-arn: String
+    _id: ID @id
+    name: StringScalarFilters
+    scan_id: StringScalarFilters
+    server_side_default_encryption_rule_dot_algorithm: StringScalarFilters @alias(property: "server_side_default_encryption_rule.algorithm")
+    creation_date: StringScalarFilters
+    arn: StringScalarFilters
 }
 
-type Tag @alias(property:"tag") {
-_id: ID! @id
-scan_id: String
-Name: String
-ec2_cn_security_hy_groupTaggedIn: Ec2_cn_security_hy_group @relationship(edgeType:"tagged", direction:IN)
-tagged:Tagged
+type Tag @alias(property: "tag") {
+    _id: ID! @id
+    scan_id: String
+    Name: String
+    ec2_cn_security_hy_groupTaggedIn: Ec2_cn_security_hy_group @relationship(edgeType: "tagged", direction: IN)
+    tagged: Tagged
 }
 
 input TagInput {
-_id: ID @id
-scan_id: String
-Name: String
+    _id: ID @id
+    scan_id: StringScalarFilters
+    Name: StringScalarFilters
 }
 
-type Kms_cn_key @alias(property:"kms:key") {
-_id: ID! @id
-arn: String
-scan_id: String
-key_id: String
-transient_resource_link:Transient_resource_link
+type Kms_cn_key @alias(property: "kms:key") {
+    _id: ID! @id
+    arn: String
+    scan_id: String
+    key_id: String
+    transient_resource_link: Transient_resource_link
 }
 
 input Kms_cn_keyInput {
-_id: ID @id
-arn: String
-scan_id: String
-key_id: String
+    _id: ID @id
+    arn: StringScalarFilters
+    scan_id: StringScalarFilters
+    key_id: StringScalarFilters
 }
 
-type Ec2_cn_volume @alias(property:"ec2:volume") {
-_id: ID! @id
-encrypted: String
-availability_zone: String
-state: String
-arn: String
-attachment_dot_attach_time: String @alias(property: "attachment.attach_time")
-volume_type: String
-scan_id: String
-attachment_dot_state: String @alias(property: "attachment.state")
-size: String
-create_time: String
-attachment_dot_delete_on_termination: String @alias(property: "attachment.delete_on_termination")
-resource_link:Resource_link
+type Ec2_cn_volume @alias(property: "ec2:volume") {
+    _id: ID! @id
+    encrypted: String
+    availability_zone: String
+    state: String
+    arn: String
+    attachment_dot_attach_time: String @alias(property: "attachment.attach_time")
+    volume_type: String
+    scan_id: String
+    attachment_dot_state: String @alias(property: "attachment.state")
+    size: String
+    create_time: String
+    attachment_dot_delete_on_termination: String @alias(property: "attachment.delete_on_termination")
+    resource_link: Resource_link
 }
 
 input Ec2_cn_volumeInput {
-_id: ID @id
-encrypted: String
-availability_zone: String
-state: String
-arn: String
-attachment_dot_attach_time: String @alias(property: "attachment.attach_time")
-volume_type: String
-scan_id: String
-attachment_dot_state: String @alias(property: "attachment.state")
-size: String
-create_time: String
-attachment_dot_delete_on_termination: String @alias(property: "attachment.delete_on_termination")
+    _id: ID @id
+    encrypted: StringScalarFilters
+    availability_zone: StringScalarFilters
+    state: StringScalarFilters
+    arn: StringScalarFilters
+    attachment_dot_attach_time: StringScalarFilters @alias(property: "attachment.attach_time")
+    volume_type: StringScalarFilters
+    scan_id: StringScalarFilters
+    attachment_dot_state: StringScalarFilters @alias(property: "attachment.state")
+    size: StringScalarFilters
+    create_time: StringScalarFilters
+    attachment_dot_delete_on_termination: StringScalarFilters @alias(property: "attachment.delete_on_termination")
 }
 
-type Ec2_cn_route_hy_table @alias(property:"ec2:route-table") {
-_id: ID! @id
-route_dot_destination_cidr_block: String @alias(property: "route.destination_cidr_block")
-arn: String
-route_table_id: String
-association_dot_route_table_id: String @alias(property: "association.route_table_id")
-route_dot_origin: String @alias(property: "route.origin")
-route_dot_gateway_id: String @alias(property: "route.gateway_id")
-scan_id: String
-owner_id: String
-association_dot_main: String @alias(property: "association.main")
-route_dot_state: String @alias(property: "route.state")
-association_dot_route_table_association_id: String @alias(property: "association.route_table_association_id")
-resource_link:Resource_link
+type Ec2_cn_route_hy_table @alias(property: "ec2:route-table") {
+    _id: ID! @id
+    route_dot_destination_cidr_block: String @alias(property: "route.destination_cidr_block")
+    arn: String
+    route_table_id: String
+    association_dot_route_table_id: String @alias(property: "association.route_table_id")
+    route_dot_origin: String @alias(property: "route.origin")
+    route_dot_gateway_id: String @alias(property: "route.gateway_id")
+    scan_id: String
+    owner_id: String
+    association_dot_main: String @alias(property: "association.main")
+    route_dot_state: String @alias(property: "route.state")
+    association_dot_route_table_association_id: String @alias(property: "association.route_table_association_id")
+    resource_link: Resource_link
 }
 
 input Ec2_cn_route_hy_tableInput {
-_id: ID @id
-route_dot_destination_cidr_block: String @alias(property: "route.destination_cidr_block")
-arn: String
-route_table_id: String
-association_dot_route_table_id: String @alias(property: "association.route_table_id")
-route_dot_origin: String @alias(property: "route.origin")
-route_dot_gateway_id: String @alias(property: "route.gateway_id")
-scan_id: String
-owner_id: String
-association_dot_main: String @alias(property: "association.main")
-route_dot_state: String @alias(property: "route.state")
-association_dot_route_table_association_id: String @alias(property: "association.route_table_association_id")
+    _id: ID @id
+    route_dot_destination_cidr_block: StringScalarFilters @alias(property: "route.destination_cidr_block")
+    arn: StringScalarFilters
+    route_table_id: StringScalarFilters
+    association_dot_route_table_id: StringScalarFilters @alias(property: "association.route_table_id")
+    route_dot_origin: StringScalarFilters @alias(property: "route.origin")
+    route_dot_gateway_id: StringScalarFilters @alias(property: "route.gateway_id")
+    scan_id: StringScalarFilters
+    owner_id: StringScalarFilters
+    association_dot_main: StringScalarFilters @alias(property: "association.main")
+    route_dot_state: StringScalarFilters @alias(property: "route.state")
+    association_dot_route_table_association_id: StringScalarFilters @alias(property: "association.route_table_association_id")
 }
 
-type Resource_link @alias(property:"resource_link") {
-_id: ID! @id
+type Resource_link @alias(property: "resource_link") {
+    _id: ID! @id
 }
 
-type Tagged @alias(property:"tagged") {
-_id: ID! @id
+type Tagged @alias(property: "tagged") {
+    _id: ID! @id
 }
 
-type Transient_resource_link @alias(property:"transient_resource_link") {
-_id: ID! @id
+type Transient_resource_link @alias(property: "transient_resource_link") {
+    _id: ID! @id
 }
 
 input Options {
-limit:Int
+    limit: Int
+}
+
+input StringScalarFilters {
+    eq: String
+    contains: String
+    endsWith: String
+    startsWith: String
 }
 
 type Query {
-getNodeImage(filter: ImageInput): Image
-getNodeImages(filter: ImageInput, options: Options): [Image]
-getNodeGuardduty_cn_detector(filter: Guardduty_cn_detectorInput): Guardduty_cn_detector
-getNodeGuardduty_cn_detectors(filter: Guardduty_cn_detectorInput, options: Options): [Guardduty_cn_detector]
-getNodeEc2_cn_vpc(filter: Ec2_cn_vpcInput): Ec2_cn_vpc
-getNodeEc2_cn_vpcs(filter: Ec2_cn_vpcInput, options: Options): [Ec2_cn_vpc]
-getNodeIam_cn_role(filter: Iam_cn_roleInput): Iam_cn_role
-getNodeIam_cn_roles(filter: Iam_cn_roleInput, options: Options): [Iam_cn_role]
-getNodeEc2_cn_network_hy_interface(filter: Ec2_cn_network_hy_interfaceInput): Ec2_cn_network_hy_interface
-getNodeEc2_cn_network_hy_interfaces(filter: Ec2_cn_network_hy_interfaceInput, options: Options): [Ec2_cn_network_hy_interface]
-getNodeRds_cn_db(filter: Rds_cn_dbInput): Rds_cn_db
-getNodeRds_cn_dbs(filter: Rds_cn_dbInput, options: Options): [Rds_cn_db]
-getNodeEc2_cn_instance(filter: Ec2_cn_instanceInput): Ec2_cn_instance
-getNodeEc2_cn_instances(filter: Ec2_cn_instanceInput, options: Options): [Ec2_cn_instance]
-getNodeIam_cn_user(filter: Iam_cn_userInput): Iam_cn_user
-getNodeIam_cn_users(filter: Iam_cn_userInput, options: Options): [Iam_cn_user]
-getNodeEc2_cn_security_hy_group(filter: Ec2_cn_security_hy_groupInput): Ec2_cn_security_hy_group
-getNodeEc2_cn_security_hy_groups(filter: Ec2_cn_security_hy_groupInput, options: Options): [Ec2_cn_security_hy_group]
-getNodeEc2_cn_internet_hy_gateway(filter: Ec2_cn_internet_hy_gatewayInput): Ec2_cn_internet_hy_gateway
-getNodeEc2_cn_internet_hy_gateways(filter: Ec2_cn_internet_hy_gatewayInput, options: Options): [Ec2_cn_internet_hy_gateway]
-getNodeEvents_cn_rule(filter: Events_cn_ruleInput): Events_cn_rule
-getNodeEvents_cn_rules(filter: Events_cn_ruleInput, options: Options): [Events_cn_rule]
-getNodeEc2_cn_subnet(filter: Ec2_cn_subnetInput): Ec2_cn_subnet
-getNodeEc2_cn_subnets(filter: Ec2_cn_subnetInput, options: Options): [Ec2_cn_subnet]
-getNodeIam_cn_instance_hy_profile(filter: Iam_cn_instance_hy_profileInput): Iam_cn_instance_hy_profile
-getNodeIam_cn_instance_hy_profiles(filter: Iam_cn_instance_hy_profileInput, options: Options): [Iam_cn_instance_hy_profile]
-getNodeIam_cn_policy(filter: Iam_cn_policyInput): Iam_cn_policy
-getNodeIam_cn_policys(filter: Iam_cn_policyInput, options: Options): [Iam_cn_policy]
-getNodeS3_cn_bucket(filter: S3_cn_bucketInput): S3_cn_bucket
-getNodeS3_cn_buckets(filter: S3_cn_bucketInput, options: Options): [S3_cn_bucket]
-getNodeTag(filter: TagInput): Tag
-getNodeTags(filter: TagInput, options: Options): [Tag]
-getNodeKms_cn_key(filter: Kms_cn_keyInput): Kms_cn_key
-getNodeKms_cn_keys(filter: Kms_cn_keyInput, options: Options): [Kms_cn_key]
-getNodeEc2_cn_volume(filter: Ec2_cn_volumeInput): Ec2_cn_volume
-getNodeEc2_cn_volumes(filter: Ec2_cn_volumeInput, options: Options): [Ec2_cn_volume]
-getNodeEc2_cn_route_hy_table(filter: Ec2_cn_route_hy_tableInput): Ec2_cn_route_hy_table
-getNodeEc2_cn_route_hy_tables(filter: Ec2_cn_route_hy_tableInput, options: Options): [Ec2_cn_route_hy_table]
+    getNodeImage(filter: ImageInput): Image
+    getNodeImages(filter: ImageInput, options: Options): [Image]
+    getNodeGuardduty_cn_detector(filter: Guardduty_cn_detectorInput): Guardduty_cn_detector
+    getNodeGuardduty_cn_detectors(filter: Guardduty_cn_detectorInput, options: Options): [Guardduty_cn_detector]
+    getNodeEc2_cn_vpc(filter: Ec2_cn_vpcInput): Ec2_cn_vpc
+    getNodeEc2_cn_vpcs(filter: Ec2_cn_vpcInput, options: Options): [Ec2_cn_vpc]
+    getNodeIam_cn_role(filter: Iam_cn_roleInput): Iam_cn_role
+    getNodeIam_cn_roles(filter: Iam_cn_roleInput, options: Options): [Iam_cn_role]
+    getNodeEc2_cn_network_hy_interface(filter: Ec2_cn_network_hy_interfaceInput): Ec2_cn_network_hy_interface
+    getNodeEc2_cn_network_hy_interfaces(filter: Ec2_cn_network_hy_interfaceInput, options: Options): [Ec2_cn_network_hy_interface]
+    getNodeRds_cn_db(filter: Rds_cn_dbInput): Rds_cn_db
+    getNodeRds_cn_dbs(filter: Rds_cn_dbInput, options: Options): [Rds_cn_db]
+    getNodeEc2_cn_instance(filter: Ec2_cn_instanceInput): Ec2_cn_instance
+    getNodeEc2_cn_instances(filter: Ec2_cn_instanceInput, options: Options): [Ec2_cn_instance]
+    getNodeIam_cn_user(filter: Iam_cn_userInput): Iam_cn_user
+    getNodeIam_cn_users(filter: Iam_cn_userInput, options: Options): [Iam_cn_user]
+    getNodeEc2_cn_security_hy_group(filter: Ec2_cn_security_hy_groupInput): Ec2_cn_security_hy_group
+    getNodeEc2_cn_security_hy_groups(filter: Ec2_cn_security_hy_groupInput, options: Options): [Ec2_cn_security_hy_group]
+    getNodeEc2_cn_internet_hy_gateway(filter: Ec2_cn_internet_hy_gatewayInput): Ec2_cn_internet_hy_gateway
+    getNodeEc2_cn_internet_hy_gateways(filter: Ec2_cn_internet_hy_gatewayInput, options: Options): [Ec2_cn_internet_hy_gateway]
+    getNodeEvents_cn_rule(filter: Events_cn_ruleInput): Events_cn_rule
+    getNodeEvents_cn_rules(filter: Events_cn_ruleInput, options: Options): [Events_cn_rule]
+    getNodeEc2_cn_subnet(filter: Ec2_cn_subnetInput): Ec2_cn_subnet
+    getNodeEc2_cn_subnets(filter: Ec2_cn_subnetInput, options: Options): [Ec2_cn_subnet]
+    getNodeIam_cn_instance_hy_profile(filter: Iam_cn_instance_hy_profileInput): Iam_cn_instance_hy_profile
+    getNodeIam_cn_instance_hy_profiles(filter: Iam_cn_instance_hy_profileInput, options: Options): [Iam_cn_instance_hy_profile]
+    getNodeIam_cn_policy(filter: Iam_cn_policyInput): Iam_cn_policy
+    getNodeIam_cn_policys(filter: Iam_cn_policyInput, options: Options): [Iam_cn_policy]
+    getNodeS3_cn_bucket(filter: S3_cn_bucketInput): S3_cn_bucket
+    getNodeS3_cn_buckets(filter: S3_cn_bucketInput, options: Options): [S3_cn_bucket]
+    getNodeTag(filter: TagInput): Tag
+    getNodeTags(filter: TagInput, options: Options): [Tag]
+    getNodeKms_cn_key(filter: Kms_cn_keyInput): Kms_cn_key
+    getNodeKms_cn_keys(filter: Kms_cn_keyInput, options: Options): [Kms_cn_key]
+    getNodeEc2_cn_volume(filter: Ec2_cn_volumeInput): Ec2_cn_volume
+    getNodeEc2_cn_volumes(filter: Ec2_cn_volumeInput, options: Options): [Ec2_cn_volume]
+    getNodeEc2_cn_route_hy_table(filter: Ec2_cn_route_hy_tableInput): Ec2_cn_route_hy_table
+    getNodeEc2_cn_route_hy_tables(filter: Ec2_cn_route_hy_tableInput, options: Options): [Ec2_cn_route_hy_table]
 }
 
 schema {
-query: Query
+    query: Query
 }

--- a/src/test/special-chars-mutations.graphql
+++ b/src/test/special-chars-mutations.graphql
@@ -11,9 +11,9 @@ type Abc_ex__dol_123_amp_efg @alias(property:"abc!$123&efg") {
 
 input Abc_ex__dol_123_amp_efgInput {
   _id: ID @id
-  instance_type: String
-  state: String
-  arn: String
+  instance_type: StringScalarFilters
+  state: StringScalarFilters
+  arn: StringScalarFilters
 }
 
 input Abc_ex__dol_123_amp_efgCreateInput {
@@ -41,9 +41,9 @@ type Abc_op_123_cp__dot_efg_cn_456 @alias(property:"abc(123).efg:456") {
 
 input Abc_op_123_cp__dot_efg_cn_456Input {
   _id: ID @id
-  name: String
-  ip_range_dot_first_ip: String @alias(property: "ip_range.first_ip")
-  ip_range_dot_last_ip: String @alias(property: "ip_range.last_ip")
+  name: StringScalarFilters
+  ip_range_dot_first_ip: StringScalarFilters @alias(property: "ip_range.first_ip")
+  ip_range_dot_last_ip: StringScalarFilters @alias(property: "ip_range.last_ip")
 }
 
 input Abc_op_123_cp__dot_efg_cn_456CreateInput {
@@ -69,9 +69,9 @@ type Abc_eq_123_at__os_efg_cs_456 @alias(property:"abc=123@[efg]456") {
 
 input Abc_eq_123_at__os_efg_cs_456Input {
   _id: ID @id
-  instance_type: String
-  state: String
-  arn: String
+  instance_type: StringScalarFilters
+  state: StringScalarFilters
+  arn: StringScalarFilters
 }
 
 input Abc_eq_123_at__os_efg_cs_456CreateInput {
@@ -97,9 +97,9 @@ type Abc_oc_123_cc__vb_efg_hy_456 @alias(property:"abc{123}|efg-456") {
 
 input Abc_oc_123_cc__vb_efg_hy_456Input {
   _id: ID @id
-  name: String
-  ip_range_dot_first_ip: String @alias(property: "ip_range.first_ip")
-  ip_range_dot_last_ip: String @alias(property: "ip_range.last_ip")
+  name: StringScalarFilters
+  ip_range_dot_first_ip: StringScalarFilters @alias(property: "ip_range.first_ip")
+  ip_range_dot_last_ip: StringScalarFilters @alias(property: "ip_range.last_ip")
 }
 
 input Abc_oc_123_cc__vb_efg_hy_456CreateInput {
@@ -122,6 +122,13 @@ type Resource_link @alias(property:"resource_link") {
 
 input Options {
   limit:Int
+}
+
+input StringScalarFilters {
+  eq: String
+  contains: String
+  endsWith: String
+  startsWith: String
 }
 
 type Query {

--- a/src/test/special-chars.graphql
+++ b/src/test/special-chars.graphql
@@ -1,84 +1,91 @@
-type Abc_ex__dol_123_amp_efg @alias(property:"abc!$123&efg") {
+type Abc_ex__dol_123_amp_efg @alias(property: "abc!$123&efg") {
         _id: ID! @id
-instance_type: String
-state: String
-arn: String
-abc_op_123_cp__dot_efg_cn_456Resource_linkOut: Abc_op_123_cp__dot_efg_cn_456 @relationship(edgeType:"resource_link", direction:OUT)
-        abc_ex__dol_123_amp_efgResource_linkOut: Abc_ex__dol_123_amp_efg @relationship(edgeType:"resource_link", direction:OUT)
-        abc_ex__dol_123_amp_efgResource_linkIn: Abc_ex__dol_123_amp_efg @relationship(edgeType:"resource_link", direction:IN)
-        resource_link:Resource_link
+        instance_type: String
+        state: String
+        arn: String
+        abc_op_123_cp__dot_efg_cn_456Resource_linkOut: Abc_op_123_cp__dot_efg_cn_456 @relationship(edgeType: "resource_link", direction: OUT)
+        abc_ex__dol_123_amp_efgResource_linkOut: Abc_ex__dol_123_amp_efg @relationship(edgeType: "resource_link", direction: OUT)
+        abc_ex__dol_123_amp_efgResource_linkIn: Abc_ex__dol_123_amp_efg @relationship(edgeType: "resource_link", direction: IN)
+        resource_link: Resource_link
 }
 
 input Abc_ex__dol_123_amp_efgInput {
-_id: ID @id
-instance_type: String
-state: String
-arn: String
+        _id: ID @id
+        instance_type: StringScalarFilters
+        state: StringScalarFilters
+        arn: StringScalarFilters
 }
 
-type Abc_op_123_cp__dot_efg_cn_456 @alias(property:"abc(123).efg:456") {
+type Abc_op_123_cp__dot_efg_cn_456 @alias(property: "abc(123).efg:456") {
         _id: ID! @id
-name: String
-ip_range_dot_first_ip: String @alias(property: "ip_range.first_ip")
+        name: String
+        ip_range_dot_first_ip: String @alias(property: "ip_range.first_ip")
         ip_range_dot_last_ip: String @alias(property: "ip_range.last_ip")
-        abc_ex__dol_123_amp_efgResource_linksIn(filter: Abc_ex__dol_123_amp_efgInput, options: Options): [Abc_ex__dol_123_amp_efg] @relationship(edgeType:"resource_link", direction:IN)
-        resource_link:Resource_link
+        abc_ex__dol_123_amp_efgResource_linksIn(filter: Abc_ex__dol_123_amp_efgInput, options: Options): [Abc_ex__dol_123_amp_efg] @relationship(edgeType: "resource_link", direction: IN)
+        resource_link: Resource_link
 }
 
 input Abc_op_123_cp__dot_efg_cn_456Input {
-_id: ID @id
-name: String
-ip_range_dot_first_ip: String @alias(property: "ip_range.first_ip")
-        ip_range_dot_last_ip: String @alias(property: "ip_range.last_ip")
-    }
+        _id: ID @id
+        name: StringScalarFilters
+        ip_range_dot_first_ip: StringScalarFilters @alias(property: "ip_range.first_ip")
+        ip_range_dot_last_ip: StringScalarFilters @alias(property: "ip_range.last_ip")
+}
 
-type Abc_eq_123_at__os_efg_cs_456 @alias(property:"abc=123@[efg]456") {
+type Abc_eq_123_at__os_efg_cs_456 @alias(property: "abc=123@[efg]456") {
         _id: ID! @id
-instance_type: String
-state: String
-arn: String
+        instance_type: String
+        state: String
+        arn: String
 }
 
 input Abc_eq_123_at__os_efg_cs_456Input {
-_id: ID @id
-instance_type: String
-state: String
-arn: String
+        _id: ID @id
+        instance_type: StringScalarFilters
+        state: StringScalarFilters
+        arn: StringScalarFilters
 }
 
-type Abc_oc_123_cc__vb_efg_hy_456 @alias(property:"abc{123}|efg-456") {
+type Abc_oc_123_cc__vb_efg_hy_456 @alias(property: "abc{123}|efg-456") {
         _id: ID! @id
-name: String
-ip_range_dot_first_ip: String @alias(property: "ip_range.first_ip")
+        name: String
+        ip_range_dot_first_ip: String @alias(property: "ip_range.first_ip")
         ip_range_dot_last_ip: String @alias(property: "ip_range.last_ip")
-    }
+}
 
 input Abc_oc_123_cc__vb_efg_hy_456Input {
-_id: ID @id
-name: String
-ip_range_dot_first_ip: String @alias(property: "ip_range.first_ip")
-        ip_range_dot_last_ip: String @alias(property: "ip_range.last_ip")
-    }
+        _id: ID @id
+        name: StringScalarFilters
+        ip_range_dot_first_ip: StringScalarFilters @alias(property: "ip_range.first_ip")
+        ip_range_dot_last_ip: StringScalarFilters @alias(property: "ip_range.last_ip")
+}
 
-type Resource_link @alias(property:"resource_link") {
+type Resource_link @alias(property: "resource_link") {
         _id: ID! @id
 }
 
 input Options {
-limit:Int
+        limit: Int
+}
+
+input StringScalarFilters {
+        eq: String
+        contains: String
+        endsWith: String
+        startsWith: String
 }
 
 type Query {
-getNodeAbc_ex__dol_123_amp_efg(filter: Abc_ex__dol_123_amp_efgInput): Abc_ex__dol_123_amp_efg
-getNodeAbc_ex__dol_123_amp_efgs(filter: Abc_ex__dol_123_amp_efgInput, options: Options): [Abc_ex__dol_123_amp_efg]
-getNodeAbc_op_123_cp__dot_efg_cn_456(filter: Abc_op_123_cp__dot_efg_cn_456Input): Abc_op_123_cp__dot_efg_cn_456
-getNodeAbc_op_123_cp__dot_efg_cn_456s(filter: Abc_op_123_cp__dot_efg_cn_456Input, options: Options): [Abc_op_123_cp__dot_efg_cn_456]
-getNodeAbc_eq_123_at__os_efg_cs_456(filter: Abc_eq_123_at__os_efg_cs_456Input): Abc_eq_123_at__os_efg_cs_456
-getNodeAbc_eq_123_at__os_efg_cs_456s(filter: Abc_eq_123_at__os_efg_cs_456Input, options: Options): [Abc_eq_123_at__os_efg_cs_456]
-getNodeAbc_oc_123_cc__vb_efg_hy_456(filter: Abc_oc_123_cc__vb_efg_hy_456Input): Abc_oc_123_cc__vb_efg_hy_456
-getNodeAbc_oc_123_cc__vb_efg_hy_456s(filter: Abc_oc_123_cc__vb_efg_hy_456Input, options: Options): [Abc_oc_123_cc__vb_efg_hy_456]
+        getNodeAbc_ex__dol_123_amp_efg(filter: Abc_ex__dol_123_amp_efgInput): Abc_ex__dol_123_amp_efg
+        getNodeAbc_ex__dol_123_amp_efgs(filter: Abc_ex__dol_123_amp_efgInput, options: Options): [Abc_ex__dol_123_amp_efg]
+        getNodeAbc_op_123_cp__dot_efg_cn_456(filter: Abc_op_123_cp__dot_efg_cn_456Input): Abc_op_123_cp__dot_efg_cn_456
+        getNodeAbc_op_123_cp__dot_efg_cn_456s(filter: Abc_op_123_cp__dot_efg_cn_456Input, options: Options): [Abc_op_123_cp__dot_efg_cn_456]
+        getNodeAbc_eq_123_at__os_efg_cs_456(filter: Abc_eq_123_at__os_efg_cs_456Input): Abc_eq_123_at__os_efg_cs_456
+        getNodeAbc_eq_123_at__os_efg_cs_456s(filter: Abc_eq_123_at__os_efg_cs_456Input, options: Options): [Abc_eq_123_at__os_efg_cs_456]
+        getNodeAbc_oc_123_cc__vb_efg_hy_456(filter: Abc_oc_123_cc__vb_efg_hy_456Input): Abc_oc_123_cc__vb_efg_hy_456
+        getNodeAbc_oc_123_cc__vb_efg_hy_456s(filter: Abc_oc_123_cc__vb_efg_hy_456Input, options: Options): [Abc_oc_123_cc__vb_efg_hy_456]
 }
 
 schema {
-query: Query
+        query: Query
 }

--- a/src/test/templates/JSResolverOCHTTPS.test.js
+++ b/src/test/templates/JSResolverOCHTTPS.test.js
@@ -13,14 +13,14 @@ schemaDataModel = JSON.stringify(schemaDataModel, null, 2);
 const schemaModel = JSON.parse(schemaDataModel);
 initSchema(schemaModel);
 
-test('should resolve queries with a filter', () => {
+test('should resolve app sync event queries with a filter', () => {
     const result = resolveGraphDBQueryFromAppSyncEvent({
         field: 'getNodeAirport',
-        arguments: { filter: { code: 'SEA' } },
+        arguments: { filter: { code: {eq: 'SEA'} } },
         selectionSetGraphQL: '{ city }'
     });
     expect(result).toEqual({
-        query: 'MATCH (getNodeAirport_Airport:`airport`{code: $getNodeAirport_Airport_code})\n' +
+        query: 'MATCH (getNodeAirport_Airport:`airport`) WHERE getNodeAirport_Airport.code = $getNodeAirport_Airport_code\n' +
             'RETURN {city: getNodeAirport_Airport.`city`} LIMIT 1',
         parameters: { getNodeAirport_Airport_code: 'SEA' },
         language: 'opencypher',
@@ -28,7 +28,7 @@ test('should resolve queries with a filter', () => {
     });
 });
 
-test('should resolve queries with an empty filter object', () => {
+test('should resolve app sync event queries with an empty filter object', () => {
     const result = resolveGraphDBQueryFromAppSyncEvent({
         field: 'getNodeAirport',
         arguments: { filter: {} },
@@ -44,7 +44,7 @@ test('should resolve queries with an empty filter object', () => {
     });
 });
 
-test('should resolve queries without a filter', () => {
+test('should resolve app sync event queries without a filter', () => {
     const result = resolveGraphDBQueryFromAppSyncEvent({
         field: 'getNodeAirport',
         arguments: {},
@@ -60,15 +60,15 @@ test('should resolve queries without a filter', () => {
     });
 });
 
-test('should resolve queries with a filter that contains numeric and string values', () => {
+test('should resolve app sync event queries with a filter that contains numeric and string values', () => {
     const result = resolveGraphDBQueryFromAppSyncEvent({
         field: 'getNodeAirports',
-        arguments: { filter: { country: 'US', runways: 3 } },
+        arguments: { filter: { country: {eq: 'US'}, runways: 3 } },
         selectionSetGraphQL: '{ city }'
     });
 
     expect(result).toEqual({
-        query: 'MATCH (getNodeAirports_Airport:`airport`{country: $getNodeAirports_Airport_country, runways: $getNodeAirports_Airport_runways})\n' +
+        query: 'MATCH (getNodeAirports_Airport:`airport`) WHERE getNodeAirports_Airport.country = $getNodeAirports_Airport_country AND getNodeAirports_Airport.runways = $getNodeAirports_Airport_runways\n' +
             'RETURN collect({city: getNodeAirports_Airport.`city`})',
         parameters: { getNodeAirports_Airport_country: 'US',  getNodeAirports_Airport_runways: 3},
         language: 'opencypher',
@@ -76,7 +76,7 @@ test('should resolve queries with a filter that contains numeric and string valu
     });
 });
 
-test('should resolve queries with a string id filter', () => {
+test('should resolve app sync event queries with a string id filter', () => {
     const result = resolveGraphDBQueryFromAppSyncEvent({
         field: 'getNodeAirport',
         arguments: { filter: { _id: '22' } },
@@ -84,15 +84,15 @@ test('should resolve queries with a string id filter', () => {
     });
 
     expect(result).toEqual({
-        query: 'MATCH (getNodeAirport_Airport:`airport`) WHERE ID(getNodeAirport_Airport) = $getNodeAirport_Airport_whereId\n' +
+        query: 'MATCH (getNodeAirport_Airport:`airport`) WHERE ID(getNodeAirport_Airport) = $getNodeAirport_Airport__id\n' +
             'RETURN {city: getNodeAirport_Airport.`city`} LIMIT 1',
-        parameters: { getNodeAirport_Airport_whereId: '22'},
+        parameters: { getNodeAirport_Airport__id: '22'},
         language: 'opencypher',
         refactorOutput: null
     });
 });
 
-test('should resolve queries with an integer id filter', () => {
+test('should resolve app sync event queries with an integer id filter', () => {
     const result = resolveGraphDBQueryFromAppSyncEvent({
         field: 'getNodeAirport',
         arguments: { filter: { _id: 22 } },
@@ -100,15 +100,15 @@ test('should resolve queries with an integer id filter', () => {
     });
 
     expect(result).toEqual({
-        query: 'MATCH (getNodeAirport_Airport:`airport`) WHERE ID(getNodeAirport_Airport) = $getNodeAirport_Airport_whereId\n' +
+        query: 'MATCH (getNodeAirport_Airport:`airport`) WHERE ID(getNodeAirport_Airport) = $getNodeAirport_Airport__id\n' +
             'RETURN {city: getNodeAirport_Airport.`city`} LIMIT 1',
-        parameters: { getNodeAirport_Airport_whereId: '22'},
+        parameters: { getNodeAirport_Airport__id: '22'},
         language: 'opencypher',
         refactorOutput: null
     });
 });
 
-test('should resolve gremlin query with argument', () => {
+test('should resolve app sync event gremlin query with argument', () => {
     const result = resolveGraphDBQueryFromAppSyncEvent({
         field: 'getAirportWithGremlin',
         arguments: { code: 'YVR' },
@@ -123,7 +123,7 @@ test('should resolve gremlin query with argument', () => {
     });
 });
 
-test('should resolve gremlin query without arguments or selection set', () => {
+test('should resolve app sync event gremlin query without arguments or selection set', () => {
     const result = resolveGraphDBQueryFromAppSyncEvent({
         field: 'getCountriesCount',
         arguments: { },
@@ -134,6 +134,60 @@ test('should resolve gremlin query without arguments or selection set', () => {
         query: "g.V().hasLabel('country').count()",
         parameters: {},
         language: 'gremlin',
+        refactorOutput: null
+    });
+});
+
+test('should resolve app sync event with nested edge filters and variables', () => {
+    const result = resolveGraphDBQueryFromAppSyncEvent({
+        field: 'getNodeAirports',
+        arguments: {
+            filter: {
+                country: {
+                    eq: 'CA'
+                }
+            },
+            options: {
+                limit: 6
+            }
+        },
+        variables: {
+            filter: {
+                country: {
+                    eq: 'CA'
+                }
+            },
+            options: {
+                limit: 6
+            },
+            nestedFilter: {
+                country: {
+                    startsWith: "M"
+                }
+            },
+            nestedOptions: {
+                limit: 2
+            }
+        },
+        selectionSetGraphQL: '{ _id city, code, airportRoutesOut(filter: $nestedFilter, options: $nestedOptions) { _id, city, code } }'
+    });
+
+    expect(result).toMatchObject({
+        query: "MATCH (getNodeAirports_Airport:`airport`) " +
+            "WHERE getNodeAirports_Airport.country = $getNodeAirports_Airport_country " +
+            "WITH getNodeAirports_Airport LIMIT 6\n" +
+            "OPTIONAL MATCH (getNodeAirports_Airport)-[getNodeAirports_Airport_airportRoutesOut_route:route]->(getNodeAirports_Airport_airportRoutesOut:`airport`) " +
+            "WHERE getNodeAirports_Airport_airportRoutesOut.country STARTS WITH $getNodeAirports_Airport_airportRoutesOut_country\n" +
+            "WITH getNodeAirports_Airport, " +
+            "CASE WHEN getNodeAirports_Airport_airportRoutesOut IS NULL THEN [] " +
+            "ELSE COLLECT({_id:ID(getNodeAirports_Airport_airportRoutesOut), city: getNodeAirports_Airport_airportRoutesOut.`city`, code: getNodeAirports_Airport_airportRoutesOut.`code`})[..2] " +
+            "END AS getNodeAirports_Airport_airportRoutesOut_collect\n" +
+            "RETURN collect({_id:ID(getNodeAirports_Airport), city: getNodeAirports_Airport.`city`, code: getNodeAirports_Airport.`code`, airportRoutesOut: getNodeAirports_Airport_airportRoutesOut_collect})[..6]",
+        parameters: {
+            "getNodeAirports_Airport_country": "CA",
+            "getNodeAirports_Airport_airportRoutesOut_country": "M"
+        },
+        language: 'opencypher',
         refactorOutput: null
     });
 });
@@ -175,7 +229,7 @@ test('should inference query with nested types single and array, references in a
             'OPTIONAL MATCH (getAirport_Airport)<-[getAirport_Airport_continentContainsIn_contains:contains]-(getAirport_Airport_continentContainsIn:`continent`)\n' +
             'OPTIONAL MATCH (getAirport_Airport)<-[getAirport_Airport_countryContainsIn_contains:contains]-(getAirport_Airport_countryContainsIn:`country`)\n' +
             'OPTIONAL MATCH (getAirport_Airport)-[getAirport_Airport_airportRoutesOut_route:route]->(getAirport_Airport_airportRoutesOut:`airport`)\n' +
-            'WITH getAirport_Airport, getAirport_Airport_continentContainsIn, getAirport_Airport_countryContainsIn, collect({code: getAirport_Airport_airportRoutesOut.`code`}) AS getAirport_Airport_airportRoutesOut_collect\n' +
+            'WITH getAirport_Airport, getAirport_Airport_continentContainsIn, getAirport_Airport_countryContainsIn, CASE WHEN getAirport_Airport_airportRoutesOut IS NULL THEN [] ELSE COLLECT({code: getAirport_Airport_airportRoutesOut.`code`}) END AS getAirport_Airport_airportRoutesOut_collect\n' +
             'WITH getAirport_Airport, getAirport_Airport_continentContainsIn, getAirport_Airport_airportRoutesOut_collect, {desc: getAirport_Airport_countryContainsIn.`desc`} AS getAirport_Airport_countryContainsIn_one\n' +
             'WITH getAirport_Airport, getAirport_Airport_countryContainsIn_one, getAirport_Airport_airportRoutesOut_collect, {desc: getAirport_Airport_continentContainsIn.`desc`} AS getAirport_Airport_continentContainsIn_one\n' +
             'RETURN {city: getAirport_Airport.`city`, continentContainsIn: getAirport_Airport_continentContainsIn_one, countryContainsIn: getAirport_Airport_countryContainsIn_one, airportRoutesOut: getAirport_Airport_airportRoutesOut_collect} LIMIT 1',
@@ -193,7 +247,7 @@ test('should get edge properties in nested array (Query0004)', () => {
         query: "MATCH (getAirport_Airport:`airport`{code:'SEA'})\n" +
             'OPTIONAL MATCH (getAirport_Airport)-[getAirport_Airport_airportRoutesOut_route:route]->(getAirport_Airport_airportRoutesOut:`airport`)\n' +
             'WITH getAirport_Airport, getAirport_Airport_airportRoutesOut, {dist: getAirport_Airport_airportRoutesOut_route.`dist`} AS getAirport_Airport_airportRoutesOut_route_one\n' +
-            'WITH getAirport_Airport, collect({code: getAirport_Airport_airportRoutesOut.`code`, route: getAirport_Airport_airportRoutesOut_route_one}) AS getAirport_Airport_airportRoutesOut_collect\n' +
+            'WITH getAirport_Airport, CASE WHEN getAirport_Airport_airportRoutesOut IS NULL THEN [] ELSE COLLECT({code: getAirport_Airport_airportRoutesOut.`code`, route: getAirport_Airport_airportRoutesOut_route_one}) END AS getAirport_Airport_airportRoutesOut_collect\n' +
             'RETURN {airportRoutesOut: getAirport_Airport_airportRoutesOut_collect} LIMIT 1',
         parameters: {},
         language: 'opencypher',
@@ -311,10 +365,10 @@ test('should resolve query using Gremlin returning a scalar (Query0010)', () => 
 
 // Query0011
 test('should inference query using filter (Query0011)', () => {
-    const result = resolveGraphDBQuery('query MyQuery {\n getNodeAirport(filter: {code: \"SEA\"}) {\n city \n }\n}');
+    const result = resolveGraphDBQuery('query MyQuery {\n getNodeAirport(filter: {code: {eq: \"SEA\"}}) {\n city \n }\n}');
 
     expect(result).toMatchObject({
-        query: 'MATCH (getNodeAirport_Airport:`airport`{code: $getNodeAirport_Airport_code})\n' +
+        query: 'MATCH (getNodeAirport_Airport:`airport`) WHERE getNodeAirport_Airport.code = $getNodeAirport_Airport_code\n' +
             'RETURN {city: getNodeAirport_Airport.`city`} LIMIT 1',
         parameters: { getNodeAirport_Airport_code: 'SEA' },
         language: 'opencypher',
@@ -324,12 +378,12 @@ test('should inference query using filter (Query0011)', () => {
 
 // Query0012
 test('should apply limit to results returned from a nested edge (Query0012)', () => {
-    const result = resolveGraphDBQuery('query MyQuery {\n getNodeAirport(filter: {code: \"SEA\"}) {\n airportRoutesOut(options: {limit: 2}) {\n code\n }\n }\n }');
+    const result = resolveGraphDBQuery('query MyQuery {\n getNodeAirport(filter: {code: {eq: \"SEA\"}}) {\n airportRoutesOut(options: {limit: 2}) {\n code\n }\n }\n }');
 
     expect(result).toMatchObject({
-        query: 'MATCH (getNodeAirport_Airport:`airport`{code: $getNodeAirport_Airport_code})\n' +
+        query: 'MATCH (getNodeAirport_Airport:`airport`) WHERE getNodeAirport_Airport.code = $getNodeAirport_Airport_code\n' +
             'OPTIONAL MATCH (getNodeAirport_Airport)-[getNodeAirport_Airport_airportRoutesOut_route:route]->(getNodeAirport_Airport_airportRoutesOut:`airport`)\n' +
-            'WITH getNodeAirport_Airport, collect({code: getNodeAirport_Airport_airportRoutesOut.`code`})[..2] AS getNodeAirport_Airport_airportRoutesOut_collect\n' +
+            'WITH getNodeAirport_Airport, CASE WHEN getNodeAirport_Airport_airportRoutesOut IS NULL THEN [] ELSE COLLECT({code: getNodeAirport_Airport_airportRoutesOut.`code`})[..2] END AS getNodeAirport_Airport_airportRoutesOut_collect\n' +
             'RETURN {airportRoutesOut: getNodeAirport_Airport_airportRoutesOut_collect} LIMIT 1',
         parameters: { getNodeAirport_Airport_code: 'SEA' },
         language: 'opencypher',
@@ -339,12 +393,12 @@ test('should apply limit to results returned from a nested edge (Query0012)', ()
 
 // Query0013
 test('should inference query with filter in nested edge (Query0013)', () => {
-    const result = resolveGraphDBQuery('query MyQuery {\n getNodeAirport(filter: {code: \"SEA\"}) {\n airportRoutesOut(filter: {code: \"LAX\"}) {\n city\n }\n city\n }\n }');
+    const result = resolveGraphDBQuery('query MyQuery {\n getNodeAirport(filter: {code: {eq: \"SEA\"}}) {\n airportRoutesOut(filter: {code: {eq: \"LAX\"}}) {\n city\n }\n city\n }\n }');
 
     expect(result).toMatchObject({
-        query: 'MATCH (getNodeAirport_Airport:`airport`{code: $getNodeAirport_Airport_code})\n' +
-            'OPTIONAL MATCH (getNodeAirport_Airport)-[getNodeAirport_Airport_airportRoutesOut_route:route]->(getNodeAirport_Airport_airportRoutesOut:`airport`{code: $getNodeAirport_Airport_airportRoutesOut_code})\n' +
-            'WITH getNodeAirport_Airport, collect({city: getNodeAirport_Airport_airportRoutesOut.`city`}) AS getNodeAirport_Airport_airportRoutesOut_collect\n' +
+        query: 'MATCH (getNodeAirport_Airport:`airport`) WHERE getNodeAirport_Airport.code = $getNodeAirport_Airport_code\n' +
+            'OPTIONAL MATCH (getNodeAirport_Airport)-[getNodeAirport_Airport_airportRoutesOut_route:route]->(getNodeAirport_Airport_airportRoutesOut:`airport`) WHERE getNodeAirport_Airport_airportRoutesOut.code = $getNodeAirport_Airport_airportRoutesOut_code\n' +
+            'WITH getNodeAirport_Airport, CASE WHEN getNodeAirport_Airport_airportRoutesOut IS NULL THEN [] ELSE COLLECT({city: getNodeAirport_Airport_airportRoutesOut.`city`}) END AS getNodeAirport_Airport_airportRoutesOut_collect\n' +
             'RETURN {airportRoutesOut: getNodeAirport_Airport_airportRoutesOut_collect, city: getNodeAirport_Airport.`city`} LIMIT 1',
         parameters: {
             getNodeAirport_Airport_code: 'SEA',
@@ -357,10 +411,10 @@ test('should inference query with filter in nested edge (Query0013)', () => {
 
 // Query0014
 test('should inference query using field graphQuery outboundRoutesCount (Query0014)', () => {
-    const result = resolveGraphDBQuery('query MyQuery {\n getNodeAirport(filter: {code: \"SEA\"}) {\n outboundRoutesCount\n }\n }');
+    const result = resolveGraphDBQuery('query MyQuery {\n getNodeAirport(filter: {code: {eq: \"SEA\"}}) {\n outboundRoutesCount\n }\n }');
 
     expect(result).toMatchObject({
-        query: 'MATCH (getNodeAirport_Airport:`airport`{code: $getNodeAirport_Airport_code})\n' +
+        query: 'MATCH (getNodeAirport_Airport:`airport`) WHERE getNodeAirport_Airport.code = $getNodeAirport_Airport_code\n' +
             'OPTIONAL MATCH (getNodeAirport_Airport)-[getNodeAirport_Airport_outboundRoutesCount_r:route]->(getNodeAirport_Airport_outboundRoutesCount_a)\n' +
             'WITH getNodeAirport_Airport, count(getNodeAirport_Airport_outboundRoutesCount_r) AS getNodeAirport_Airport_outboundRoutesCount\n' +
             'RETURN {outboundRoutesCount:getNodeAirport_Airport_outboundRoutesCount} LIMIT 1',
@@ -375,7 +429,7 @@ test('should inference query with mutation create node (Query0015)', () => {
     const result = resolveGraphDBQuery('mutation MyMutation {\n createNodeAirport(input: {code: \"NAX\", city: \"Reggio Emilia\"}) {\n code\n }\n }');
 
     expect(result).toMatchObject({
-        query: 'CREATE (createNodeAirport_Airport:`airport` {city: $createNodeAirport_Airport_city, code: $createNodeAirport_Airport_code})\n' +
+        query: 'CREATE (createNodeAirport_Airport:`airport` {code: $createNodeAirport_Airport_code, city: $createNodeAirport_Airport_city})\n' +
             'RETURN {code: createNodeAirport_Airport.`code`}',
         parameters: {
             createNodeAirport_Airport_code: 'NAX',
@@ -392,12 +446,81 @@ test('should inference query with mutation update node (Query0016)', () => {
 
     expect(result).toMatchObject({
         query: 'MATCH (updateNodeAirport_Airport)\n' +
-            'WHERE ID(updateNodeAirport_Airport) = $updateNodeAirport_Airport_whereId\n' +
-            'SET  updateNodeAirport_Airport.city = $updateNodeAirport_Airport_city\n' +
+            'WHERE ID(updateNodeAirport_Airport) = $updateNodeAirport_Airport__id\n' +
+            'SET updateNodeAirport_Airport.city = $updateNodeAirport_Airport_city\n' +
             'RETURN {city: updateNodeAirport_Airport.`city`}',
         parameters: {
             updateNodeAirport_Airport_city: 'Seattle',
-            updateNodeAirport_Airport_whereId: '22'
+            updateNodeAirport_Airport__id: '22'
+        },
+        language: 'opencypher',
+        refactorOutput: null
+    });
+});
+
+test('should resolve mutation to connect nodes', () => {
+    const query = 'mutation ConnectCountryToAirport {\n' +
+        '  connectNodeCountryToNodeAirportEdgeContains(from_id: \"ee71c547-ea32-4573-88bc-6ecb31942a1e\", to_id: \"99cb3321-9cda-41b6-b760-e88ead3e1ea1\") {\n' +
+        '    _id\n' +
+        '  }\n' +
+        '}';
+    const result = resolveGraphDBQuery(query);
+
+    expect(result).toMatchObject({
+        query: 'MATCH (from), (to)\n' +
+            'WHERE ID(from) = $connectNodeCountryToNodeAirportEdgeContains_Contains_whereFromId ' +
+            'AND ID(to) = $connectNodeCountryToNodeAirportEdgeContains_Contains_whereToId\n' +
+            'CREATE (from)-[connectNodeCountryToNodeAirportEdgeContains_Contains:`contains`]->(to)\n' +
+            'RETURN {_id:ID(connectNodeCountryToNodeAirportEdgeContains_Contains)}',
+        parameters: {
+            connectNodeCountryToNodeAirportEdgeContains_Contains_whereFromId: 'ee71c547-ea32-4573-88bc-6ecb31942a1e',
+            connectNodeCountryToNodeAirportEdgeContains_Contains_whereToId: '99cb3321-9cda-41b6-b760-e88ead3e1ea1'
+        },
+        language: 'opencypher',
+        refactorOutput: null
+    });
+});
+
+test('should resolve mutation to delete edge between nodes', () => {
+    const query = 'mutation DeleteEdgeContainsFromCountryToAirport {\n' +
+        '  deleteEdgeContainsFromCountryToAirport(from_id: \"ee71c547-ea32-4573-88bc-6ecb31942a1e\", to_id: \"99cb3321-9cda-41b6-b760-e88ead3e1ea1\")\n' +
+        '}';
+    const result = resolveGraphDBQuery(query);
+
+    expect(result).toMatchObject({
+        query: 'MATCH (from)-[deleteEdgeContainsFromCountryToAirport_Boolean]->(to)\n' +
+            'WHERE ID(from) = $deleteEdgeContainsFromCountryToAirport_Boolean_whereFromId ' +
+            'AND ID(to) = $deleteEdgeContainsFromCountryToAirport_Boolean_whereToId\n' +
+            'DELETE deleteEdgeContainsFromCountryToAirport_Boolean\n' +
+            'RETURN true',
+        parameters: {
+            deleteEdgeContainsFromCountryToAirport_Boolean_whereFromId: 'ee71c547-ea32-4573-88bc-6ecb31942a1e',
+            deleteEdgeContainsFromCountryToAirport_Boolean_whereToId: '99cb3321-9cda-41b6-b760-e88ead3e1ea1'
+        },
+        language: 'opencypher',
+        refactorOutput: null
+    });
+});
+
+test('should resolve mutation to update edge between nodes', () => {
+    const query = 'mutation UpdateEdgeRouteFromAirportToAirport {\n' +
+        '  updateEdgeRouteFromAirportToAirport(from_id: \"99\", to_id: \"48\", edge: { dist: 123 }) {\n' +
+        '    _id\n' +
+        '    dist\n' +
+        '  }\n' +
+        '}';
+    const result = resolveGraphDBQuery(query);
+
+    expect(result).toMatchObject({
+        query: 'MATCH (from)-[updateEdgeRouteFromAirportToAirport_Route:`route`]->(to)\n' +
+            'WHERE ID(from) = $updateEdgeRouteFromAirportToAirport_Route_whereFromId ' +
+            'AND ID(to) = $updateEdgeRouteFromAirportToAirport_Route_whereToId\n' +
+            'SET updateEdgeRouteFromAirportToAirport_Route.dist = $updateEdgeRouteFromAirportToAirport_Route_dist\n' +
+            'RETURN {_id:ID(updateEdgeRouteFromAirportToAirport_Route), dist: updateEdgeRouteFromAirportToAirport_Route.`dist`}',
+        parameters: {
+            updateEdgeRouteFromAirportToAirport_Route_whereFromId: '99',
+            updateEdgeRouteFromAirportToAirport_Route_whereToId: '48',
+            updateEdgeRouteFromAirportToAirport_Route_dist: 123
         },
         language: 'opencypher',
         refactorOutput: null
@@ -409,9 +532,9 @@ test('should inference query using _id as filter (Query0017)', () => {
     const result = resolveGraphDBQuery('query MyQuery {\n getNodeAirport(filter: {_id: \"22\"}) {\n city\n }\n }');
 
     expect(result).toMatchObject({
-        query: 'MATCH (getNodeAirport_Airport:`airport`) WHERE ID(getNodeAirport_Airport) = $getNodeAirport_Airport_whereId\n' +
+        query: 'MATCH (getNodeAirport_Airport:`airport`) WHERE ID(getNodeAirport_Airport) = $getNodeAirport_Airport__id\n' +
             'RETURN {city: getNodeAirport_Airport.`city`} LIMIT 1',
-        parameters: { getNodeAirport_Airport_whereId: '22' },
+        parameters: { getNodeAirport_Airport__id: '22' },
         language: 'opencypher',
         refactorOutput: null
     });
@@ -419,11 +542,9 @@ test('should inference query using _id as filter (Query0017)', () => {
 
 // Query0018
 test('should control number of result using limit option (Query0018)', () => {
-    const result = resolveGraphDBQuery('query MyQuery {\n getNodeAirports(options: {limit: 1}, filter: {code: \"SEA\"}) {\n city }\n }');
-
+    const result = resolveGraphDBQuery('query MyQuery {\n getNodeAirports(options: {limit: 1}, filter: {code: {eq: \"SEA\"}}) {\n city }\n }');
     expect(result).toMatchObject({
-        query: 'MATCH (getNodeAirports_Airport:`airport`{code: $getNodeAirports_Airport_code})\n' +
-            'WITH getNodeAirports_Airport LIMIT 1\n' +
+        query: 'MATCH (getNodeAirports_Airport:`airport`) WHERE getNodeAirports_Airport.code = $getNodeAirports_Airport_code WITH getNodeAirports_Airport LIMIT 1\n' +
             'RETURN collect({city: getNodeAirports_Airport.`city`})[..1]',
         parameters: { getNodeAirports_Airport_code: 'SEA' },
         language: 'opencypher',
@@ -433,10 +554,10 @@ test('should control number of result using limit option (Query0018)', () => {
 
 // Query0019
 test('should resolve query that gets multiple different type of fields (Query0019)', () => {
-    const result = resolveGraphDBQuery('query MyQuery {\n getNodeAirport(filter: {code: \"SEA\"}) {\n _id\n city\n elev\n runways\n lat\n lon\n }\n }');
+    const result = resolveGraphDBQuery('query MyQuery {\n getNodeAirport(filter: {code: {eq: \"SEA\"}}) {\n _id\n city\n elev\n runways\n lat\n lon\n }\n }');
 
     expect(result).toMatchObject({
-        query: 'MATCH (getNodeAirport_Airport:`airport`{code: $getNodeAirport_Airport_code})\n' +
+        query: 'MATCH (getNodeAirport_Airport:`airport`) WHERE getNodeAirport_Airport.code = $getNodeAirport_Airport_code\n' +
             'RETURN {_id:ID(getNodeAirport_Airport), city: getNodeAirport_Airport.`city`, elev: getNodeAirport_Airport.`elev`, runways: getNodeAirport_Airport.`runways`, lat: getNodeAirport_Airport.`lat`, lon: getNodeAirport_Airport.`lon`} LIMIT 1',
         parameters: { getNodeAirport_Airport_code: 'SEA' },
         language: 'opencypher',
@@ -446,10 +567,10 @@ test('should resolve query that gets multiple different type of fields (Query001
 
 // Query0020
 test('should filter by parameter with numeric value and return mix of numeric value types (Query0020)', () => {
-    const result = resolveGraphDBQuery('query MyQuery {\n getNodeAirports(filter: { city: \"Seattle\", runways: 3 }) {\n code\n lat\n lon\n elev\n}\n }');
+    const result = resolveGraphDBQuery('query MyQuery {\n getNodeAirports(filter: { city: {eq: \"Seattle\"}, runways: 3 }) {\n code\n lat\n lon\n elev\n}\n }');
 
     expect(result).toMatchObject({
-        query: 'MATCH (getNodeAirports_Airport:`airport`{city: $getNodeAirports_Airport_city, runways: $getNodeAirports_Airport_runways})\n' +
+        query: 'MATCH (getNodeAirports_Airport:`airport`) WHERE getNodeAirports_Airport.city = $getNodeAirports_Airport_city AND getNodeAirports_Airport.runways = $getNodeAirports_Airport_runways\n' +
             'RETURN collect({code: getNodeAirports_Airport.`code`, lat: getNodeAirports_Airport.`lat`, lon: getNodeAirports_Airport.`lon`, elev: getNodeAirports_Airport.`elev`})',
         parameters: {
             getNodeAirports_Airport_city: 'Seattle',
@@ -473,14 +594,232 @@ test('should resolve query with no parameters', () => {
 });
 
 test('should resolve query with parameters that have constant values', () => {
-    const result = resolveGraphDBQuery('query MyQuery {\n getNodeCountry(filter: {_id: \"3541\", code: \"CA\"}) {\n desc\n }\n }\n');
+    const result = resolveGraphDBQuery('query MyQuery {\n getNodeCountry(filter: {_id: \"3541\", code: {eq: \"CA\"}}) {\n desc\n }\n }\n');
 
     expect(result).toMatchObject({
-        query: 'MATCH (getNodeCountry_Country:`country`{code: $getNodeCountry_Country_code}) WHERE ID(getNodeCountry_Country) = $getNodeCountry_Country_whereId\n' +
+        query: 'MATCH (getNodeCountry_Country:`country`) WHERE ID(getNodeCountry_Country) = $getNodeCountry_Country__id AND getNodeCountry_Country.code = $getNodeCountry_Country_code\n' +
             'RETURN {desc: getNodeCountry_Country.`desc`} LIMIT 1',
         parameters: {
             getNodeCountry_Country_code: 'CA',
-            getNodeCountry_Country_whereId: '3541'
+            getNodeCountry_Country__id: '3541'
+        },
+        language: 'opencypher',
+        refactorOutput: null
+    });
+});
+
+test('should resolve query with filter that uses various string comparison operators', () => {
+    const query = 'query GetNodeAirports {\n' +
+        '  getNodeAirports(filter: {\n' +
+        '    country: {\n' +
+        '      eq: "CA"\n' +
+        '    },\n' +
+        '    code: {\n' +
+        '      startsWith: "Y"\n' +
+        '    },\n' +
+        '    city:  {\n' +
+        '        endsWith: "n"\n' +
+        '    },\n' +
+        '    desc: {\n' +
+        '      contains: "Airport"\n' +
+        '    }\n' +
+        '    runways: 3\n' +
+        '  }, options: {limit: 5}) {\n' +
+        '    _id\n' +
+        '    code\n' +
+        '    city\n' +
+        '    country\n' +
+        '    runways\n' +
+        '    desc\n' +
+        '  }\n' +
+        '}\n';
+    const result = resolveGraphDBQuery(query);
+
+    expect(result).toMatchObject({
+        query: 'MATCH (getNodeAirports_Airport:`airport`) ' +
+            'WHERE getNodeAirports_Airport.country = $getNodeAirports_Airport_country ' +
+            'AND getNodeAirports_Airport.code STARTS WITH $getNodeAirports_Airport_code ' +
+            'AND getNodeAirports_Airport.city ENDS WITH $getNodeAirports_Airport_city ' +
+            'AND getNodeAirports_Airport.desc CONTAINS $getNodeAirports_Airport_desc ' +
+            'AND getNodeAirports_Airport.runways = $getNodeAirports_Airport_runways ' +
+            'WITH getNodeAirports_Airport LIMIT 5\n' +
+            'RETURN collect({' +
+            '_id:ID(getNodeAirports_Airport), ' +
+            'code: getNodeAirports_Airport.`code`, ' +
+            'city: getNodeAirports_Airport.`city`, ' +
+            'country: getNodeAirports_Airport.`country`, ' +
+            'runways: getNodeAirports_Airport.`runways`, ' +
+            'desc: getNodeAirports_Airport.`desc`' +
+            '})[..5]',
+        parameters: {
+            getNodeAirports_Airport_city: "n",
+            getNodeAirports_Airport_code: "Y",
+            getNodeAirports_Airport_country: "CA",
+            getNodeAirports_Airport_runways: 3,
+            getNodeAirports_Airport_desc: "Airport"
+        },
+        language: 'opencypher',
+        refactorOutput: null
+    });
+});
+
+test('should resolve query with nested edge filter that uses string comparison operator', () => {
+    const query = 'query GetNodeAirports {\n' +
+        '  getNodeAirports(filter:  {\n' +
+        '     country:  {\n' +
+        '        eq: "CA"\n' +
+        '     }\n' +
+        '  }, options:  {\n' +
+        '     limit: 5\n' +
+        '  }) {\n' +
+        '    _id\n' +
+        '    code\n' +
+        '    city\n' +
+        '    country\n' +
+        '    airportRoutesOut(filter: {\n' +
+        '       country:  {\n' +
+        '          startsWith: "M"\n' +
+        '       },\n' +
+        '       code:  {\n' +
+        '          contains: "M"\n' +
+        '       }\n' +
+        '    }, options:  {\n' +
+        '       limit: 3\n' +
+        '    }) {\n' +
+        '      _id\n' +
+        '      code\n' +
+        '      city\n' +
+        '      country\n' +
+        '    }\n' +
+        '  }\n' +
+        '}\n';
+    const result = resolveGraphDBQuery(query);
+
+    expect(result).toMatchObject({
+        query: 'MATCH (getNodeAirports_Airport:`airport`) ' +
+            'WHERE getNodeAirports_Airport.country = $getNodeAirports_Airport_country ' +
+            'WITH getNodeAirports_Airport LIMIT 5\n' +
+            'OPTIONAL MATCH (getNodeAirports_Airport)-[getNodeAirports_Airport_airportRoutesOut_route:route]->(getNodeAirports_Airport_airportRoutesOut:`airport`) ' +
+            'WHERE getNodeAirports_Airport_airportRoutesOut.country STARTS WITH $getNodeAirports_Airport_airportRoutesOut_country ' +
+            'AND getNodeAirports_Airport_airportRoutesOut.code CONTAINS $getNodeAirports_Airport_airportRoutesOut_code\n' +
+            'WITH getNodeAirports_Airport, ' +
+            'CASE WHEN getNodeAirports_Airport_airportRoutesOut IS NULL THEN [] ' +
+            'ELSE COLLECT({' +
+            '_id:ID(getNodeAirports_Airport_airportRoutesOut), ' +
+            'code: getNodeAirports_Airport_airportRoutesOut.`code`, ' +
+            'city: getNodeAirports_Airport_airportRoutesOut.`city`, ' +
+            'country: getNodeAirports_Airport_airportRoutesOut.`country`' +
+            '})[..3] ' +
+            'END AS getNodeAirports_Airport_airportRoutesOut_collect\n' +
+            'RETURN collect({' +
+            '_id:ID(getNodeAirports_Airport), ' +
+            'code: getNodeAirports_Airport.`code`, ' +
+            'city: getNodeAirports_Airport.`city`, ' +
+            'country: getNodeAirports_Airport.`country`, ' +
+            'airportRoutesOut: getNodeAirports_Airport_airportRoutesOut_collect' +
+            '})[..5]',
+        parameters: {
+            getNodeAirports_Airport_country: "CA",
+            getNodeAirports_Airport_airportRoutesOut_code: "M",
+            getNodeAirports_Airport_airportRoutesOut_country: "M"
+        },
+        language: 'opencypher',
+        refactorOutput: null
+    });
+});
+
+test('should resolve query with nested edge filter and variables', () => {
+    const query = 'query GetNodeAirports($filter: AirportInput, $options: Options, $nestedFilter: AirportInput, $nestedOptions: Options) {\n' +
+        '  getNodeAirports(filter: $filter, options: $options) {\n' +
+        '    _id\n' +
+        '    city\n' +
+        '    code\n' +
+        '    airportRoutesOut(filter: $nestedFilter, options: $nestedOptions) {\n' +
+        '      _id\n' +
+        '      city\n' +
+        '      code\n' +
+        '    }\n' +
+        '  }\n' +
+        '}';
+    const variables = {
+        "filter": {
+            "country": {
+                "eq": "CA"
+            }
+        },
+        "options": {
+            "limit": 6
+        },
+        "nestedFilter": {
+            "country": {
+                "startsWith": "M"
+            }
+        },
+        "nestedOptions": {
+            "limit": 2
+        }
+    }
+    const result = resolveGraphDBQuery(query, variables);
+
+    expect(result).toMatchObject({
+        query: 'MATCH (getNodeAirports_Airport:`airport`) ' +
+            'WHERE getNodeAirports_Airport.country = $getNodeAirports_Airport_country ' +
+            'WITH getNodeAirports_Airport LIMIT 6\n' +
+            'OPTIONAL MATCH (getNodeAirports_Airport)-[getNodeAirports_Airport_airportRoutesOut_route:route]->(getNodeAirports_Airport_airportRoutesOut:`airport`) ' +
+            'WHERE getNodeAirports_Airport_airportRoutesOut.country STARTS WITH $getNodeAirports_Airport_airportRoutesOut_country\n' +
+            'WITH getNodeAirports_Airport, ' +
+            'CASE WHEN getNodeAirports_Airport_airportRoutesOut IS NULL THEN [] ' +
+            'ELSE COLLECT({' +
+            '_id:ID(getNodeAirports_Airport_airportRoutesOut), ' +
+            'city: getNodeAirports_Airport_airportRoutesOut.`city`, ' +
+            'code: getNodeAirports_Airport_airportRoutesOut.`code`' +
+            '})[..2] ' +
+            'END AS getNodeAirports_Airport_airportRoutesOut_collect\n' +
+            'RETURN collect({' +
+            '_id:ID(getNodeAirports_Airport), ' +
+            'city: getNodeAirports_Airport.`city`, ' +
+            'code: getNodeAirports_Airport.`code`, ' +
+            'airportRoutesOut: getNodeAirports_Airport_airportRoutesOut_collect' +
+            '})[..6]',
+        parameters: {
+            getNodeAirports_Airport_country: "CA",
+            getNodeAirports_Airport_airportRoutesOut_country: "M"
+        },
+        language: 'opencypher',
+        refactorOutput: null
+    });
+});
+
+test('should resolve custom mutation with @graphQuery directive and $input parameter', () => {
+    const query = 'mutation MyMutation {\n' +
+        '  createAirport(\n' +
+        '    input: {city: \"Test\", code: \"TEST\", country: \"CA\", desc: \"Test Airport\"}\n' +
+        '  ) {\n' +
+        '    _id\n' +
+        '    city\n' +
+        '    code\n' +
+        '    country\n' +
+        '  }\n' +
+        '}';
+    const result = resolveGraphDBQuery(query);
+
+    expect(result).toMatchObject({
+        query: 'CREATE (createAirport_Airport:airport {' +
+            'city: $createAirport_Airport_city, ' +
+            'code: $createAirport_Airport_code, ' +
+            'country: $createAirport_Airport_country, ' +
+            'desc: $createAirport_Airport_desc})\n' +
+            'RETURN {' +
+            '_id:ID(createAirport_Airport), ' +
+            'city: createAirport_Airport.`city`, ' +
+            'code: createAirport_Airport.`code`, ' +
+            'country: createAirport_Airport.`country`' +
+            '}',
+        parameters: {
+            createAirport_Airport_city: "Test",
+            createAirport_Airport_code: "TEST",
+            createAirport_Airport_country: "CA",
+            createAirport_Airport_desc: "Test Airport"
         },
         language: 'opencypher',
         refactorOutput: null

--- a/src/test/user-group-validated.graphql
+++ b/src/test/user-group-validated.graphql
@@ -89,6 +89,13 @@ input Options {
   limit: Int
 }
 
+input StringScalarFilters {
+  eq: String
+  contains: String
+  endsWith: String
+  startsWith: String
+}
+
 type Query {
   getNodeUser(filter: UserInput): User
   getNodeUsers(filter: UserInput, options: Options): [User]

--- a/templates/ApolloServer/index.mjs
+++ b/templates/ApolloServer/index.mjs
@@ -36,7 +36,8 @@ function resolve(info, args) {
     const event = {
         field: info.fieldName,
         arguments: args,
-        selectionSet: info.fieldNodes[0].selectionSet
+        selectionSet: info.fieldNodes[0].selectionSet,
+        variables: info.variableValues,
     };
 
     return resolveEvent(event).then((result) => {

--- a/templates/JSResolverOCHTTPS.js
+++ b/templates/JSResolverOCHTTPS.js
@@ -10,7 +10,7 @@ express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 */
 
-import { astFromValue, buildASTSchema, typeFromAST, GraphQLID, GraphQLInputObjectType } from 'graphql';
+import { astFromValue, buildASTSchema, GraphQLID, GraphQLInputObjectType, typeFromAST } from 'graphql';
 import { gql } from 'graphql-tag'; // GraphQL library to parse the GraphQL query
 
 const useCallSubquery = false;
@@ -40,6 +40,7 @@ export function resolveGraphDBQueryFromAppSyncEvent(event) {
     return resolveGraphDBQueryFromEvent({
         field: event.field,
         arguments: event.arguments,
+        variables: event.variables,
         selectionSet: event.selectionSetGraphQL ? gql`${event.selectionSetGraphQL}`.definitions[0].selectionSet : {}
     });
 }
@@ -50,6 +51,7 @@ export function resolveGraphDBQueryFromAppSyncEvent(event) {
  * @param {string} event.field the graphQL field being queried
  * @param {object} event.arguments arguments that were passed into the query
  * @param {object} event.selectionSet the graphQL AST selection set
+ * @param {object} event.variables optional query variables
  * @returns {string} the resolved graph db query
  */
 export function resolveGraphDBQueryFromEvent(event) {
@@ -103,15 +105,15 @@ export function resolveGraphDBQueryFromEvent(event) {
         ]
     };
 
-    const graphQuery = resolveGraphDBQuery(obj);
+    const graphQuery = resolveGraphDBQuery(obj, event.variables);
     return graphQuery;
 }
-    
+
 const matchStatements = []; // openCypher match statements
 const withStatements = [];  // openCypher with statements
 const returnString = [];    // openCypher return statements
 let parameters = {};      // openCypher query parameters
- 
+
 
 function getRootTypeDefs() {
     return getTypeDefs(['Query', 'Mutation']);
@@ -165,14 +167,14 @@ function getTypeAlias(typeName) {
 }
 
 function getSchemaInputTypeArgs (inputType, schemaInfo) {
-    
+
     schemaDataModel.definitions.forEach(def => {
         if (def.kind === 'InputObjectTypeDefinition') {
             if (def.name.value == inputType) {
                 def.fields.forEach(field => {
-                    let arg = {name: '', type:''};                    
+                    let arg = {name: '', type:''};
                     let alias = null;
-                    
+
                     arg.name = field.name.value;
 
                     if (field.type.kind === 'ListType') {
@@ -180,11 +182,11 @@ function getSchemaInputTypeArgs (inputType, schemaInfo) {
                     }
 
                     if (field.type.kind === 'NamedType') {
-                        arg.type = field.type.name.value;                    
+                        arg.type = field.type.name.value;
                     }
-                    
-                    if (field.type.kind === 'NonNullType') {    
-                        arg.type = field.type.type.name.value;                                 
+
+                    if (field.type.kind === 'NonNullType') {
+                        arg.type = field.type.type.name.value;
                     }
 
                     if (field.directives.length > 0) {
@@ -200,15 +202,15 @@ function getSchemaInputTypeArgs (inputType, schemaInfo) {
 
                     if (alias != null)
                         Object.assign(arg, {alias: alias});
-                                        
-                        schemaInfo.args.push(arg);
-                });            
+
+                    schemaInfo.args.push(arg);
+                });
             }
         }
-    });   
+    });
 }
-  
-  
+
+
 function getSchemaQueryInfo(name) {
     const r = {
         type: '', // rename functionType
@@ -229,10 +231,10 @@ function getSchemaQueryInfo(name) {
         if (def.kind != 'ObjectTypeDefinition') {
             return;
         }
-        
+
         if (!(def.name.value === 'Query' || def.name.value === 'Mutation')) {
             return;
-        }            
+        }
 
         def.fields.forEach(field => {
             if (field.name.value != name) {
@@ -241,11 +243,11 @@ function getSchemaQueryInfo(name) {
 
             r.type = def.name.value;
             r.name = field.name.value;
-                        
+
             // Return type              
             if (field.type.kind === 'ListType') {
                 r.returnIsArray = true;
-                r.returnType = field.type.type.name.value; 
+                r.returnType = field.type.type.name.value;
             }
 
             if (field.type.kind === 'NamedType') {
@@ -253,16 +255,16 @@ function getSchemaQueryInfo(name) {
                 r.returnType = field.type.name.value;
             }
 
-            if (field.type.kind === 'NonNullType') {                
+            if (field.type.kind === 'NonNullType') {
                 if (field.type.type.kind === 'NamedType') {
                     r.returnIsArray = false;
                     r.returnType = field.type.type.name.value;
-                }                
+                }
             }
-            
-            r.returnTypeAlias = getTypeAlias(r.returnType);              
+
+            r.returnTypeAlias = getTypeAlias(r.returnType);
             r.pathName = r.name + '_' + r.returnType;
-            
+
             // graphQuery
             if (field.directives.length > 0) {
                 field.directives.forEach(directive => {
@@ -270,7 +272,7 @@ function getSchemaQueryInfo(name) {
                         r.graphQuery = directive.arguments[0].value.value;
                 });
             }
-            
+
             // args
             if (field.arguments.length > 0) {
                 field.arguments.forEach(arg => {
@@ -281,12 +283,12 @@ function getSchemaQueryInfo(name) {
                     } else if (arg.type.type.name.value === 'String' || arg.type.type.name.value === 'Int' || arg.type.type.name.value === 'ID') {
                         r.args.push({name: arg.name.value, type: arg.type.type.name.value});
                     } else {
-                    // GraphQL type input                        
-                    }                   
+                        // GraphQL type input                        
+                    }
                 });
             }
         });
-                
+
     });
 
     if (r.returnType == '') {
@@ -296,8 +298,8 @@ function getSchemaQueryInfo(name) {
 
     return r;
 }
-  
-  
+
+
 function getSchemaTypeInfo(lastTypeName, typeName, pathName) {
     const r = {
         name: typeName,
@@ -342,7 +344,7 @@ function getSchemaTypeInfo(lastTypeName, typeName, pathName) {
                         }
                     }
                 });
-            
+
             }
         }
     });
@@ -351,10 +353,10 @@ function getSchemaTypeInfo(lastTypeName, typeName, pathName) {
 
     return r;
 }
-  
-  
+
+
 function getSchemaFieldInfo(typeName, fieldName, pathName) {
-    const r = { 
+    const r = {
         name: fieldName,
         alias: '',
         type: '',
@@ -362,7 +364,7 @@ function getSchemaFieldInfo(typeName, fieldName, pathName) {
         pathName: '',
         isId: false,
         isArray: false,
-        isRequired: false,   
+        isRequired: false,
         graphQuery: null,
         relationship: null,
         args:[],
@@ -378,14 +380,14 @@ function getSchemaFieldInfo(typeName, fieldName, pathName) {
                 def.fields.forEach(field => {
                     if (field.name.value === fieldName) {
                         r.name = field.name.value;
-                        r.alias = r.name;                        
+                        r.alias = r.name;
                         if (field.type.kind === 'ListType') {
                             r.isArray = true;
                             r.type = field.type.type.name.value;
                         }
                         if (field.type.kind === 'NamedType') {
                             r.isArray = false;
-                            r.type = field.type.name.value;    
+                            r.type = field.type.name.value;
                         }
                         if (field.type.kind === 'NonNullType') {
                             r.isArray = false;
@@ -396,13 +398,13 @@ function getSchemaFieldInfo(typeName, fieldName, pathName) {
                             field.directives.forEach(directive => {
                                 if (directive.name.value === 'alias') {
                                     r.alias = directive.arguments[0].value.value;
-                                }                                
+                                }
                                 if (directive.name.value === 'graphQuery' || directive.name.value === 'Cypher' || directive.name.value === 'cypher') {
                                     r.graphQuery = directive.arguments[0].value.value;
-                                    if (fieldName == 'id') { 
+                                    if (fieldName == 'id') {
                                         r.graphQuery = r.graphQuery.replace(' as id', '');
                                         r.graphQuery = r.graphQuery.replace(' AS id', '');
-                                    }                 
+                                    }
                                 }
                                 if (directive.name.value === 'id')
                                     r.graphDBIdArgName = r.name;
@@ -418,25 +420,25 @@ function getSchemaFieldInfo(typeName, fieldName, pathName) {
                                 } else if (arg.type.type.name.value === 'String' || arg.type.type.name.value === 'Int' || arg.type.type.name.value === 'ID') {
                                     r.args.push({name: arg.name.value, type: arg.type.type.name.value});
                                 } else {
-                                // GraphQL type input                        
-                                }                   
+                                    // GraphQL type input                        
+                                }
                             });
                         }
 
                     }
                 });
-            
+
             }
         }
     });
-    
+
     schemaDataModel.definitions.forEach(def => {
         if (def.kind === 'ObjectTypeDefinition') {
             if (def.name.value === r.type) {
                 r.isSchemaType = true;
             }
         }
-    }); 
+    });
 
     if (r.type == '') {
         console.error('GraphQL field not found.');
@@ -448,7 +450,7 @@ function getSchemaFieldInfo(typeName, fieldName, pathName) {
 
 function getOptionsInSchemaInfo(fields, schemaInfo) {
     fields.forEach( field => {
-        if (field.name.value == 'limit') {            
+        if (field.name.value == 'limit') {
             schemaInfo.argOptionsLimit = field.value.value;
         }
         /* TODO        
@@ -458,61 +460,76 @@ function getOptionsInSchemaInfo(fields, schemaInfo) {
         if (field.name.value == 'orderBy') {            
             schemaInfo.argOptionsOrderBy = field.value.value;
         }
-        */        
-    });    
+        */
+    });
 }
 
-  
-function createQueryFunctionMatchStatement(obj, matchStatements, querySchemaInfo) {        
+
+function createQueryFunctionMatchStatement(obj, matchStatements, querySchemaInfo) {
     if (querySchemaInfo.graphQuery != null) {
         var gq = querySchemaInfo.graphQuery.replaceAll('this', querySchemaInfo.pathName);
         obj.definitions[0].selectionSet.selections[0].arguments.forEach(arg => {
             gq = gq.replace('$' + arg.name.value, arg.value.value);
         });
-                
+
         matchStatements.push(gq);
-            
+
     } else {
-
-        let { queryArguments, where } = getQueryArguments(obj.definitions[0].selectionSet.selections[0].arguments, querySchemaInfo);
-        
-        if  (queryArguments.length > 0) {
-            matchStatements.push(`MATCH (${querySchemaInfo.pathName}:\`${querySchemaInfo.returnTypeAlias}\`{${queryArguments}})${where}`);
-        } else {
-            matchStatements.push(`MATCH (${querySchemaInfo.pathName}:\`${querySchemaInfo.returnTypeAlias}\`)${where}`);
-        }
-
-        if (querySchemaInfo.argOptionsLimit != null)
-            matchStatements.push(`WITH ${querySchemaInfo.pathName} LIMIT ${querySchemaInfo.argOptionsLimit}`);
+        const selection = obj.definitions[0].selectionSet.selections[0];
+        replaceVariableArgsWithValues(selection, querySchemaInfo.variables);
+        const argsAndWhereClauses = extractQueryArgsAndWhereClauses(selection.arguments, querySchemaInfo);
+        const queryArgs = argsAndWhereClauses?.queryArguments.length > 0 ? `{${argsAndWhereClauses.queryArguments.join(',')}}` : '';
+        const whereClause = argsAndWhereClauses?.whereClauses.length > 0 ? ` WHERE ${argsAndWhereClauses.whereClauses.join(' AND ')}` : '';
+        const withClause = querySchemaInfo.argOptionsLimit ? ` WITH ${querySchemaInfo.pathName} LIMIT ${querySchemaInfo.argOptionsLimit}` : '';
+        matchStatements.push(`MATCH (${querySchemaInfo.pathName}:\`${querySchemaInfo.returnTypeAlias}\`${queryArgs})${whereClause}${withClause}`);
     }
 
     withStatements.push({carryOver: querySchemaInfo.pathName, inLevel:'', content:''});
 }
 
 
-function getQueryArguments(args, querySchemaInfo) {
-    let where = '';
-    let queryArguments = '';    
-    args.forEach(arg => {
-        if (arg.name.value == 'filter') {
-            let inputFields = transformFunctionInputParameters(arg.value.fields, querySchemaInfo);
-            queryArguments = queryArguments + inputFields.fields + ",";
-
-            if (inputFields.graphIdValue != null) {                
-                let param = querySchemaInfo.pathName + '_' + 'whereId';
-                Object.assign(parameters, { [param]: inputFields.graphIdValue });
-                where = ` WHERE ID(${querySchemaInfo.pathName}) = $${param}`;
+/**
+ * Extracts cypher query arguments and where clauses from given graphQL selection arguments and schema information.
+ * Will also set querySchemaInfo.argOptionsLimit if the selection arguments contain a query limit.
+ * 
+ * @param selectionArguments array of graphQL selection arguments
+ * @param querySchemaInfo schema information for the query
+ * @returns {{queryArguments: *[], whereClauses: *[]}}
+ */
+function extractQueryArgsAndWhereClauses(selectionArguments, querySchemaInfo) {
+    const operationMap = new Map();
+    operationMap.set('eq', '=');
+    operationMap.set('contains', 'CONTAINS');
+    operationMap.set('startsWith', 'STARTS WITH');
+    operationMap.set('endsWith', 'ENDS WITH');
+    
+    const queryArguments = [];
+    const whereClauses = [];
+    selectionArguments.forEach(selectionArgument => {
+        if (selectionArgument.name?.value === 'filter') {
+            const filters = extractFiltersFromQueryArgumentFields(selectionArgument.value.fields, querySchemaInfo);
+            // create a WHERE clause for each filter
+            for (const filter of filters) {
+                const paramName = querySchemaInfo.pathName + '_' + filter.name;
+                Object.assign(parameters, { [paramName]: filter.value });
+                let operation = '=';
+                if (filter.operator && operationMap.has(filter.operator)) {
+                    operation = operationMap.get(filter.operator);
+                }
+                if (filter.name === querySchemaInfo.graphDBIdArgName) {
+                    whereClauses.push(`ID(${querySchemaInfo.pathName}) ${operation} $${paramName}`);
+                } else {
+                    whereClauses.push(`${querySchemaInfo.pathName}.${filter.name} ${operation} $${paramName}`);
+                }
             }
-
-        } else if (arg.name.value == 'options') {
-            if (arg.value.kind === 'ObjectValue')
-                getOptionsInSchemaInfo(arg.value.fields, querySchemaInfo);
-        } else {
-            queryArguments = queryArguments + arg.name.value + ":'" + arg.value.value + "',";
+        } else if (selectionArgument.name?.value === 'options' && selectionArgument.value?.kind === 'ObjectValue') {
+            // TODO change to set limit value on the returned object instead of mutating the querySchemaInfo
+            getOptionsInSchemaInfo(selectionArgument.value.fields, querySchemaInfo);
+        } else if (selectionArgument.name?.value && selectionArgument.value?.value) {
+            queryArguments.push(`${selectionArgument.name.value}:'${selectionArgument.value.value}'`);
         }
     });
-    queryArguments = queryArguments.substring(0, queryArguments.length - 1);
-    return { queryArguments, where };
+    return { queryArguments: queryArguments, whereClauses: whereClauses };
 }
 
 
@@ -524,29 +541,29 @@ function extractTextBetweenParentheses(str) {
 
 function modifyVariableNames(query, name) {
     return query.replace(/\b(\w+)\b/g, function (match, p1, offset, string) {
-      // Check if the matched word is preceded by '(', '[', '[:', or '(:'
-      if (
-        string[offset - 1] === '(' ||
-        string[offset - 1] === '[' ||
-        (string[offset - 2] === '[' && string[offset - 1] === ':') ||
-        (string[offset - 2] === '(' && string[offset - 1] === ':')
-      ) {
-        return name + '_' + p1;
-      }
-      return match;
+        // Check if the matched word is preceded by '(', '[', '[:', or '(:'
+        if (
+            string[offset - 1] === '(' ||
+            string[offset - 1] === '[' ||
+            (string[offset - 2] === '[' && string[offset - 1] === ':') ||
+            (string[offset - 2] === '(' && string[offset - 1] === ':')
+        ) {
+            return name + '_' + p1;
+        }
+        return match;
     });
-  }
+}
 
 
 function graphQueryRefactoring(lastNamePath, fieldSchemaInfo) {
-    const r = { queryMatch:'', returnCarryOver: '', inLevel : '', returnAggregation: ''}    
+    const r = { queryMatch:'', returnCarryOver: '', inLevel : '', returnAggregation: ''}
     const name = lastNamePath + '_' + fieldSchemaInfo.name;
-    
+
     const statementParts = fieldSchemaInfo.graphQuery.split(' RETURN ');
     const returnStatement = statementParts[1];
     r.queryMatch = statementParts[0];
-    
-    r.queryMatch = modifyVariableNames(r.queryMatch, name);    
+
+    r.queryMatch = modifyVariableNames(r.queryMatch, name);
     r.queryMatch = r.queryMatch.replace(name +'_this', lastNamePath);
 
     let returningName = '';
@@ -557,7 +574,7 @@ function graphQueryRefactoring(lastNamePath, fieldSchemaInfo) {
         returningName = extractTextBetweenParentheses(returnStatement);
         isAggregation = true;
     } else {
-        returningName = returnStatement;        
+        returningName = returnStatement;
     }
 
     if (isAggregation) {
@@ -571,23 +588,23 @@ function graphQueryRefactoring(lastNamePath, fieldSchemaInfo) {
     return r;
 }
 
-  
+
 function createQueryFieldMatchStatement(fieldSchemaInfo, lastNamePath) {
     // solution until CALL subquery is supported in Neptune openCypher
-    
+
     const refactored = graphQueryRefactoring(lastNamePath, fieldSchemaInfo);
 
     if (refactored.queryMatch.toUpperCase().includes('MATCH'))
-        refactored.queryMatch = 'OPTIONAL ' + refactored.queryMatch;            
+        refactored.queryMatch = 'OPTIONAL ' + refactored.queryMatch;
     matchStatements.push(refactored.queryMatch);
 
     if ( refactored.returnAggregation != '' ) {
-        const thisWithId = withStatements.push({carryOver: refactored.returnCarryOver, inLevel: '', content: `${refactored.returnAggregation} AS ${refactored.inLevel}`}) -1;        
-        let i = withStatements.findIndex(({carryOver}) => carryOver.startsWith(lastNamePath));        
-        
+        const thisWithId = withStatements.push({carryOver: refactored.returnCarryOver, inLevel: '', content: `${refactored.returnAggregation} AS ${refactored.inLevel}`}) -1;
+        let i = withStatements.findIndex(({carryOver}) => carryOver.startsWith(lastNamePath));
+
         withStatements[i].content += refactored.inLevel;
 
-        for (let p = thisWithId -1; p > i; p--) {          
+        for (let p = thisWithId -1; p > i; p--) {
             withStatements[p].inLevel += refactored.inLevel + ', ';
         }
 
@@ -595,123 +612,125 @@ function createQueryFieldMatchStatement(fieldSchemaInfo, lastNamePath) {
         // no new with, just add it to lastnamepath content
         // maybe not needed
     }
-        
+
 }
 
 
-function createQueryFieldLeafStatement(fieldSchemaInfo, lastNamePath) {      
-    
+function createQueryFieldLeafStatement(fieldSchemaInfo, lastNamePath) {
+
     let i = withStatements.findIndex(({carryOver}) => carryOver.startsWith(lastNamePath));
-    
+
     if (withStatements[i].content.slice(-2) != ', ' && withStatements[i].content.slice(-1) != '{' && withStatements[i].content != '' )
         withStatements[i].content += ', ';
-    
+
     withStatements[i].content += fieldSchemaInfo.name + ':';
 
-    if (fieldSchemaInfo.graphDBIdArgName === fieldSchemaInfo.name && fieldSchemaInfo.graphQuery == null) {          
+    if (fieldSchemaInfo.graphDBIdArgName === fieldSchemaInfo.name && fieldSchemaInfo.graphQuery == null) {
         withStatements[i].content += 'ID(' + lastNamePath + ')';
     } else {
-    
+
         if (fieldSchemaInfo.graphQuery !=null ) {
             if (useCallSubquery) {
-                matchStatements.push(` CALL { WITH ${lastNamePath} ${fieldSchemaInfo.graphQuery.replaceAll('this', lastNamePath)} AS ${lastNamePath + '_' + fieldSchemaInfo.name} }`);                  
+                matchStatements.push(` CALL { WITH ${lastNamePath} ${fieldSchemaInfo.graphQuery.replaceAll('this', lastNamePath)} AS ${lastNamePath + '_' + fieldSchemaInfo.name} }`);
                 withStatements[i].content += ' ' + lastNamePath + '_' + fieldSchemaInfo.name;
             } else {
                 createQueryFieldMatchStatement(fieldSchemaInfo, lastNamePath);
             }
-        } else {              
+        } else {
             withStatements[i].content += ' ' + lastNamePath + '.' + `\`${fieldSchemaInfo.alias}\``;
         }
-    }        
+    }
 }
-  
-  
-function createTypeFieldStatementAndRecurse(e, fieldSchemaInfo, lastNamePath, lastType) {
+
+
+function createTypeFieldStatementAndRecurse(selection, fieldSchemaInfo, lastNamePath, lastType, variables = {}) {
     const schemaTypeInfo = getSchemaTypeInfo(lastType, fieldSchemaInfo.name, lastNamePath);
-    
+
     // check if the field has is a function with parameters, look for filters and options
-    if (e.arguments !== undefined) {
-        e.arguments.forEach(arg => {
+    if (selection.arguments !== undefined) {
+        selection.arguments.forEach(arg => {
             if (arg.value.kind === 'ObjectValue' && arg.name.value === 'options')
                 getOptionsInSchemaInfo(arg.value.fields, fieldSchemaInfo);
         });
     }
-   
+    
+    const argsAndWhereClauses = extractQueryArgsAndWhereClauses(selection.arguments, fieldSchemaInfo);
+    const queryArgs = argsAndWhereClauses.queryArguments?.length > 0 ? `{${argsAndWhereClauses.queryArguments.join(',')}}` : '';
+    const whereClause = argsAndWhereClauses.whereClauses?.length > 0 ? ` WHERE ${argsAndWhereClauses.whereClauses.join(' AND ')}` : '';
 
-    let { queryArguments, where } = getQueryArguments(e.arguments, fieldSchemaInfo);
-    if (queryArguments != '')
-        queryArguments = '{' + queryArguments + '}';
-
-
-    if (schemaTypeInfo.isRelationship) {        
+    if (schemaTypeInfo.isRelationship) {
         if (schemaTypeInfo.relationship.direction === 'IN') {
-            matchStatements.push(`OPTIONAL MATCH (${lastNamePath})<-[${schemaTypeInfo.pathName}_${schemaTypeInfo.relationship.edgeType}:${schemaTypeInfo.relationship.edgeType}]-(${schemaTypeInfo.pathName}:\`${schemaTypeInfo.typeAlias}\`${queryArguments})`);
+            matchStatements.push(`OPTIONAL MATCH (${lastNamePath})<-[${schemaTypeInfo.pathName}_${schemaTypeInfo.relationship.edgeType}:${schemaTypeInfo.relationship.edgeType}]-(${schemaTypeInfo.pathName}:\`${schemaTypeInfo.typeAlias}\`${queryArgs})${whereClause}`);
         } else {
-            matchStatements.push(`OPTIONAL MATCH (${lastNamePath})-[${schemaTypeInfo.pathName}_${schemaTypeInfo.relationship.edgeType}:${schemaTypeInfo.relationship.edgeType}]->(${schemaTypeInfo.pathName}:\`${schemaTypeInfo.typeAlias}\`${queryArguments})`);
+            matchStatements.push(`OPTIONAL MATCH (${lastNamePath})-[${schemaTypeInfo.pathName}_${schemaTypeInfo.relationship.edgeType}:${schemaTypeInfo.relationship.edgeType}]->(${schemaTypeInfo.pathName}:\`${schemaTypeInfo.typeAlias}\`${queryArgs})${whereClause}`);
         }
-    } 
+    }
     const thisWithId = withStatements.push({carryOver: schemaTypeInfo.pathName, inLevel: '', content: ''}) - 1;
 
-    if (schemaTypeInfo.isArray) {        
-        withStatements[thisWithId].content += 'collect(';
-    }
-    
-    withStatements[thisWithId].content += '{';
-    selectionsRecurse(e.selectionSet.selections, schemaTypeInfo.pathName, schemaTypeInfo.type);        
-    withStatements[thisWithId].content += '}';
-  
     if (schemaTypeInfo.isArray) {
-        if (fieldSchemaInfo.argOptionsLimit != null) {                            
-            withStatements[thisWithId].content += `)[..${fieldSchemaInfo.argOptionsLimit}] AS ${schemaTypeInfo.pathName}_collect`;
-        } else {
-            withStatements[thisWithId].content += ') AS ' + schemaTypeInfo.pathName + '_collect';
-        }
-        let i = withStatements.findIndex(({carryOver}) => carryOver.startsWith(lastNamePath));
-        
-        if (withStatements[i].content.slice(-2) != ', ' && withStatements[i].content.slice(-1) != '{')
-            withStatements[i].content += ', ';    
+        // if the nested selection (optional match) did not produce results, return empty array
+        // otherwise collect the results in an array
+        withStatements[thisWithId].content += `CASE WHEN ${schemaTypeInfo.pathName} IS NULL THEN [] ELSE COLLECT(`;
+    }
 
-        withStatements[i].content += schemaTypeInfo.name + ': ' + schemaTypeInfo.pathName + '_collect';
-                
-        for (let p = thisWithId -1; p > i; p--) {          
-            withStatements[p].inLevel += schemaTypeInfo.pathName + '_collect, ';
+    withStatements[thisWithId].content += '{';
+    selectionsRecurse(selection.selectionSet.selections, schemaTypeInfo.pathName, schemaTypeInfo.type, variables);
+    withStatements[thisWithId].content += '}';
+
+    if (schemaTypeInfo.isArray) {
+        if (fieldSchemaInfo.argOptionsLimit != null) {
+            withStatements[thisWithId].content += `)[..${fieldSchemaInfo.argOptionsLimit}] END AS ${schemaTypeInfo.pathName}_collect`;
+        } else {
+            withStatements[thisWithId].content += ') END AS ' + schemaTypeInfo.pathName + '_collect';
         }
-          
-    } else {        
-        withStatements[thisWithId].content += ' AS ' + schemaTypeInfo.pathName + '_one';        
         let i = withStatements.findIndex(({carryOver}) => carryOver.startsWith(lastNamePath));
 
         if (withStatements[i].content.slice(-2) != ', ' && withStatements[i].content.slice(-1) != '{')
             withStatements[i].content += ', ';
-        
+
+        withStatements[i].content += schemaTypeInfo.name + ': ' + schemaTypeInfo.pathName + '_collect';
+
+        for (let p = thisWithId -1; p > i; p--) {
+            withStatements[p].inLevel += schemaTypeInfo.pathName + '_collect, ';
+        }
+
+    } else {
+        withStatements[thisWithId].content += ' AS ' + schemaTypeInfo.pathName + '_one';
+        let i = withStatements.findIndex(({carryOver}) => carryOver.startsWith(lastNamePath));
+
+        if (withStatements[i].content.slice(-2) != ', ' && withStatements[i].content.slice(-1) != '{')
+            withStatements[i].content += ', ';
+
         withStatements[i].content += schemaTypeInfo.name + ': ' + schemaTypeInfo.pathName + '_one';
-                
-        for (let p = thisWithId -1; p > i; p--) {          
+
+        for (let p = thisWithId -1; p > i; p--) {
             withStatements[p].inLevel += schemaTypeInfo.pathName + '_one, ';
         }
     }
-    
+
 }
-  
-  
-function selectionsRecurse(s, lastNamePath, lastType) {
-        
-    s.forEach(e => {
-        
-        const fieldSchemaInfo = getSchemaFieldInfo(lastType, e.name.value, lastNamePath);
+
+
+
+function selectionsRecurse(selections, lastNamePath, lastType, variables = {}) {
+
+    selections.forEach(selection => {
+        // replace any selection references to variables with the variable values
+        replaceVariableArgsWithValues(selection, variables);
+        const fieldSchemaInfo = getSchemaFieldInfo(lastType, selection.name.value, lastNamePath);
 
         // check if is schema type
-        if (!fieldSchemaInfo.isSchemaType) {             
-            createQueryFieldLeafStatement(fieldSchemaInfo, lastNamePath);            
+        if (!fieldSchemaInfo.isSchemaType) {
+            createQueryFieldLeafStatement(fieldSchemaInfo, lastNamePath);
             // exit terminating recursion branch
             return
         }
-        
-        createTypeFieldStatementAndRecurse(e, fieldSchemaInfo, lastNamePath, lastType)                          
-    });    
+
+        createTypeFieldStatementAndRecurse(selection, fieldSchemaInfo, lastNamePath, lastType, variables)
+    });
 };
-    
-    
+
+
 function finalizeGraphQuery(matchStatements, withStatements, returnString) {
     // make a string out of match statements
     let ocMatchStatements = '';
@@ -719,141 +738,251 @@ function finalizeGraphQuery(matchStatements, withStatements, returnString) {
         ocMatchStatements += e + '\n';
     });
     ocMatchStatements = ocMatchStatements.substring(0, ocMatchStatements.length - 1);
-    
+
     let ocWithStatements = '';
     let carryOvers = '';
     let withToReverse = [];
-    for (let i = 1; i < withStatements.length; i++) {        
+    for (let i = 1; i < withStatements.length; i++) {
         carryOvers += withStatements[i - 1].carryOver + ', ';
-        withToReverse.push('\n' + 'WITH ' + carryOvers + withStatements[i].inLevel + withStatements[i].content);        
+        withToReverse.push('\n' + 'WITH ' + carryOvers + withStatements[i].inLevel + withStatements[i].content);
     }
 
     for(let i = withToReverse.length - 1; i >= 0; i--) {
         ocWithStatements += withToReverse[i];
     }
-    
+
     // make a string out of return statement
     let ocReturnStatement = '';
     returnString.forEach(e => {
-        ocReturnStatement = ocReturnStatement + e;    
+        ocReturnStatement = ocReturnStatement + e;
     });
 
     // make the oc query string
     return ocMatchStatements + ocWithStatements + '\nRETURN ' + ocReturnStatement;
 }
-    
-  
+
+
 function resolveGrapgDBqueryForGraphQLQuery (obj, querySchemaInfo) {
-                          
+
     createQueryFunctionMatchStatement(obj, matchStatements, querySchemaInfo);
-    
+
     // start processing the given query
     if (querySchemaInfo.returnIsArray) {
         returnString.push('collect(');
-    }        
-    
+    }
+
     withStatements[0].content = '{';
-    
-    selectionsRecurse(obj.definitions[0].selectionSet.selections[0].selectionSet.selections, querySchemaInfo.pathName, querySchemaInfo.returnType);
-    
+
+    selectionsRecurse(obj.definitions[0].selectionSet.selections[0].selectionSet.selections, querySchemaInfo.pathName, querySchemaInfo.returnType, querySchemaInfo.variables);
+
     if (withStatements[0].content.slice(-2) == ', ')
         withStatements[0].content = withStatements[0].content.substring(0, withStatements[0].content.length - 2);
 
     withStatements[0].content += '}';
-    
+
     returnString.push(withStatements[0].content);
-        
+
     if (querySchemaInfo.returnIsArray) {
         returnString.push(')');
         if (querySchemaInfo.argOptionsLimit != null)
             //returnString.push(` LIMIT ${querySchemaInfo.argOptionsLimit}`);
             returnString.push(`[..${querySchemaInfo.argOptionsLimit}]`);
     } else {
-        returnString.push(' LIMIT 1');   
+        returnString.push(' LIMIT 1');
     }
-    
+
     return finalizeGraphQuery(matchStatements, withStatements, returnString);
 }
-  
-  
-function transformFunctionInputParameters(fields, schemaInfo) {
-    let r = { fields:'', graphIdValue: null };
-    schemaInfo.args.forEach(arg => {
-        fields.forEach(field => {
-            if (field.name.value === arg.name) {
-                let value = field.value.value;
-                if (field.value.kind === 'IntValue' || field.value.kind === 'FloatValue') {
-                    value = Number(value);
-                }
-                if (arg.name === schemaInfo.graphDBIdArgName) {
-                    r.graphIdValue = value
-                } else if (arg.alias != null) {
-                    let param = schemaInfo.pathName + '_' + arg.alias;
-                    r.fields += `${arg.alias}: $${param}, `;
-                    Object.assign(parameters, { [param]: value });
-                } else  {
-                    let param = schemaInfo.pathName + '_' + arg.name;
-                    r.fields += `${arg.name}: $${param}, `;
-                    Object.assign(parameters, { [param]: value });
-                }
-            }
-        });
-    });
 
-    r.fields = r.fields.substring(0, r.fields.length - 2);
-    
-    return r;
+/**
+ * Converts JavaScript values to GraphQL AST value nodes.
+ * Handles primitive types, arrays, and objects by converting them into
+ * their corresponding GraphQL AST representation.
+ *
+ * @param {*} value - The value to convert to a GraphQL AST node
+ * @returns {Object} A GraphQL AST value node
+ *
+ * @example
+ * // Convert a string
+ * convertToValueNode('hello')
+ * // Returns: { kind: 'StringValue', value: 'hello' }
+ *
+ * @example
+ * // Convert a number
+ * convertToValueNode(42)
+ * // Returns: { kind: 'IntValue', value: '42' }
+ */
+function convertToValueNode(value) {
+    if (!value) {
+        return { kind: 'NullValue' };
+    }
+
+    if (typeof value === 'string') {
+        return {
+            kind: 'StringValue',
+            value: value
+        };
+    }
+
+    if (typeof value === 'number') {
+        if (Number.isInteger(value)) {
+            return {
+                kind: 'IntValue',
+                value: String(value)
+            };
+        }
+        return {
+            kind: 'FloatValue',
+            value: String(value)
+        };
+    }
+
+    if (typeof value === 'boolean') {
+        return {
+            kind: 'BooleanValue',
+            value: value
+        };
+    }
+
+    if (Array.isArray(value)) {
+        return {
+            kind: 'ListValue',
+            values: value.map(item => convertToValueNode(item))
+        };
+    }
+
+    if (typeof value === 'object') {
+        return {
+            kind: 'ObjectValue',
+            fields: Object.entries(value).map(([key, val]) => ({
+                kind: 'ObjectField',
+                name: { kind: 'Name', value: key },
+                value: convertToValueNode(val)
+            }))
+        };
+    }
+
+    return { kind: 'NullValue' };
 }
-  
-  
+
+/**
+ * Replaces any variable references in the selection with the actual value from the variables object.
+ * @param selection the graphQL selection to replace variable references in
+ * @param variables the variables object
+ */
+function replaceVariableArgsWithValues(selection, variables) {
+    const variableArgs = selection.arguments?.filter(arg => arg.value?.kind === 'Variable' 
+        && arg.value?.name?.value && variables.hasOwnProperty(arg.value.name.value));
+    variableArgs.forEach(arg => {
+        // replace variable reference with actual value
+        arg.value = convertToValueNode(variables[arg.value.name.value]);
+    });
+}
+
+
+/**
+ * Extracts an array of cypher field name and value from the graphQL query argument fields.
+ * @param queryArgumentFields the graphQL query argument fields
+ * @param schemaInfo the schema info for the query
+ * @returns {object[]}
+ */
+function extractCypherFieldsFromArgumentFields(queryArgumentFields, schemaInfo) {
+    return queryArgumentFields.reduce((cypherFields, field) => {
+        const matchingArg = schemaInfo.args?.find(arg => field.name?.value === arg.name)
+        if (matchingArg) {
+            let value = field.value?.value;
+            if (field.value?.kind === 'IntValue' || field.value?.kind === 'FloatValue') {
+                value = Number(value);
+            }
+            cypherFields.push({name: matchingArg.alias ?? matchingArg.name, value: value});
+        }
+        return cypherFields;
+    }, []);
+}
+
+/**
+ * Extracts an array of cypher filter name, value, operator from the graphQL query argument fields.
+ * @param queryArgumentFields the graphQL query argument fields
+ * @param schemaInfo the schema info for the query
+ * @returns {object[]}
+ */
+function extractFiltersFromQueryArgumentFields(queryArgumentFields, schemaInfo) {
+    return queryArgumentFields.reduce((filters, field) => {
+        const matchingArg = schemaInfo.args?.find(arg => field.name?.value === arg.name)
+        if (matchingArg) {
+            let argValue = field.value?.value;
+            let operator = 'eq';
+            if (matchingArg.type === 'StringScalarFilters') {
+                const stringScalarFilterValue = field.value?.fields?.find(f => f.kind === 'ObjectField' && f.value?.kind === 'StringValue');
+                if (stringScalarFilterValue) {
+                    argValue = stringScalarFilterValue.value.value;
+                    operator = stringScalarFilterValue.name.value;
+                }
+            } else if (field.value?.kind === 'IntValue' || field.value?.kind === 'FloatValue') {
+                argValue = Number(argValue);
+            }
+            filters.push({name: matchingArg.alias ?? matchingArg.name, value: argValue, operator: operator})
+        }
+        return filters;
+    }, []);
+}
+
+
 function returnStringOnly(selections, querySchemaInfo) {
-    withStatements.push({carryOver: querySchemaInfo.pathName, inLevel:'', content:''});    
-    selectionsRecurse(selections, querySchemaInfo.pathName, querySchemaInfo.returnType);
+    withStatements.push({carryOver: querySchemaInfo.pathName, inLevel:'', content:''});
+    selectionsRecurse(selections, querySchemaInfo.pathName, querySchemaInfo.returnType, querySchemaInfo.variables);
     return `{${withStatements[0].content}}`
 }
-  
-        
+
+
 function resolveGrapgDBqueryForGraphQLMutation (obj, querySchemaInfo) {
-    
+
     // createNode
-    if (querySchemaInfo.name.startsWith('createNode') && querySchemaInfo.graphQuery == null) {
-        const inputFields = transformFunctionInputParameters(obj.definitions[0].selectionSet.selections[0].arguments[0].value.fields, querySchemaInfo);
+    if (querySchemaInfo.name.startsWith('createNode') && !querySchemaInfo.graphQuery) {
+        const queryFields = extractCypherFieldsFromArgumentFields(obj.definitions[0].selectionSet.selections[0].arguments[0].value.fields, querySchemaInfo);
+        const formattedQueryFields = queryFields.map(arg => {
+            const param = querySchemaInfo.pathName + '_' + arg.name;
+            Object.assign(parameters, { [param]: arg.value });
+            return `${arg.name}: $${param}`;
+        }).join(', ');
+        
         const nodeName = querySchemaInfo.name + '_' + querySchemaInfo.returnType;
         let returnBlock = `ID(${nodeName})`;
-        if (obj.definitions[0].selectionSet.selections[0].selectionSet != undefined) {        
+        if (obj.definitions[0].selectionSet.selections[0].selectionSet) {
             returnBlock = returnStringOnly(obj.definitions[0].selectionSet.selections[0].selectionSet.selections, querySchemaInfo);
         }
-        const ocQuery = `CREATE (${nodeName}:\`${querySchemaInfo.returnTypeAlias}\` {${inputFields.fields}})\nRETURN ${returnBlock}`;
-        return ocQuery;
+        return `CREATE (${nodeName}:\`${querySchemaInfo.returnTypeAlias}\` {${formattedQueryFields}})\nRETURN ${returnBlock}`;
     }
-    
+
     // updateNode
-    if (querySchemaInfo.name.startsWith('updateNode') && querySchemaInfo.graphQuery == null) {
-        const inputFields = transformFunctionInputParameters(obj.definitions[0].selectionSet.selections[0].arguments[0].value.fields, querySchemaInfo);
-        const nodeID = inputFields.graphIdValue;
+    if (querySchemaInfo.name.startsWith('updateNode') && !querySchemaInfo.graphQuery) {
+        const queryFields = extractCypherFieldsFromArgumentFields(obj.definitions[0].selectionSet.selections[0].arguments[0].value.fields, querySchemaInfo);
+        
+        const idField = queryFields.find(arg => arg.name === querySchemaInfo.graphDBIdArgName);
+        const nodeID = idField.value;
         const nodeName = querySchemaInfo.name + '_' + querySchemaInfo.returnType;
+        const idParam  = `${nodeName}_${idField.name}`;
+        Object.assign(parameters, {[idParam]: nodeID});
+        
         let returnBlock = `ID(${nodeName})`;
-        if (obj.definitions[0].selectionSet.selections[0].selectionSet != undefined) {        
+        if (obj.definitions[0].selectionSet.selections[0].selectionSet) {
             returnBlock = returnStringOnly(obj.definitions[0].selectionSet.selections[0].selectionSet.selections, querySchemaInfo);
         }
         // :( SET += is not working, so let's work around it.
         //let ocQuery = `MATCH (${nodeName}) WHERE ID(${nodeName}) = '${nodeID}' SET ${nodeName} += {${inputFields}} RETURN ${returnBlock}`;
         // workaround:
-        const propertyList = inputFields.fields.split(', ');
-        let setString = '';
-        propertyList.forEach(property => {
-            let kv = property.split(': ');
-            setString = setString + ` ${nodeName}.${kv[0]} = ${kv[1]},`;
-        });
-        setString = setString.substring(0, setString.length - 1);
-        let param  = nodeName + '_' + 'whereId';
-        Object.assign(parameters, {[param]: nodeID});
-        const ocQuery = `MATCH (${nodeName})\nWHERE ID(${nodeName}) = $${param}\nSET ${setString}\nRETURN ${returnBlock}`;
-        return ocQuery;
+        const formattedFields = queryFields.filter(arg => {
+           return arg.name !== querySchemaInfo.graphDBIdArgName;
+        }).map(arg => {
+            const param = querySchemaInfo.pathName + '_' + arg.name;
+            Object.assign(parameters, { [param]: arg.value });
+            return `${nodeName}.${arg.name} = $${param}`;
+        }).join(', ');
+        return `MATCH (${nodeName})\nWHERE ID(${nodeName}) = $${idParam}\nSET ${formattedFields}\nRETURN ${returnBlock}`;
     }
-    
+
     // deleteNode
-    if (querySchemaInfo.name.startsWith('deleteNode') && querySchemaInfo.graphQuery == null) {    
+    if (querySchemaInfo.name.startsWith('deleteNode') && !querySchemaInfo.graphQuery) {
         const nodeID = obj.definitions[0].selectionSet.selections[0].arguments[0].value.value;
         const nodeName = querySchemaInfo.name + '_' + querySchemaInfo.returnType;
         let param  = nodeName + '_' + 'whereId';
@@ -861,7 +990,7 @@ function resolveGrapgDBqueryForGraphQLMutation (obj, querySchemaInfo) {
         const ocQuery = `MATCH (${nodeName})\nWHERE ID(${nodeName}) = $${param}\nDETACH DELETE ${nodeName}\nRETURN true`;
         return ocQuery;
     }
-    
+
     // connect
     if (querySchemaInfo.name.startsWith('connectNode') && querySchemaInfo.graphQuery == null) {
         let fromID = obj.definitions[0].selectionSet.selections[0].arguments[0].value.value;
@@ -870,80 +999,78 @@ function resolveGrapgDBqueryForGraphQLMutation (obj, querySchemaInfo) {
         const edgeName = querySchemaInfo.name + '_' + querySchemaInfo.returnType;
         const egdgeTypeAlias = getTypeAlias(edgeType);
         const returnBlock = returnStringOnly(obj.definitions[0].selectionSet.selections[0].selectionSet.selections, querySchemaInfo);
-        
+
         let paramFromId  = edgeName + '_' + 'whereFromId';
         let paramToId  = edgeName + '_' + 'whereToId';
         Object.assign(parameters, {[paramFromId]: fromID});
         Object.assign(parameters, {[paramToId]: toID});
+        
+        const ocQuery = `MATCH (from), (to)\nWHERE ID(from) = $${paramFromId} AND ID(to) = $${paramToId}\nCREATE (from)-[${edgeName}:\`${egdgeTypeAlias}\`]->(to)\nRETURN ${returnBlock}`;
+        return ocQuery;
+    }
 
-        if (obj.definitions[0].selectionSet.selections[0].arguments.length > 2) {            
-            const inputFields = transformFunctionInputParameters(obj.definitions[0].selectionSet.selections[0].arguments[2].value.fields, querySchemaInfo);
-            const ocQuery = `MATCH (from), (to)\nWHERE ID(from) = $${paramFromId} AND ID(to) = $${paramToId}\nCREATE (from)-[${edgeName}:\`${egdgeTypeAlias}\`{${inputFields.fields}}]->(to)\nRETURN ${returnBlock}`;
-            return ocQuery;
-        } else {
-            const ocQuery = `MATCH (from), (to)\nWHERE ID(from) = $${paramFromId} AND ID(to) = $${paramToId}\nCREATE (from)-[${edgeName}:\`${egdgeTypeAlias}\`]->(to)\nRETURN ${returnBlock}`;
-            return ocQuery;
-        }       
-    } 
-    
     // updateEdge
-    if (querySchemaInfo.name.startsWith('updateEdge') && querySchemaInfo.graphQuery == null) {        
+    if (querySchemaInfo.name.startsWith('updateEdge') && querySchemaInfo.graphQuery == null) {
         let fromID = obj.definitions[0].selectionSet.selections[0].arguments[0].value.value;
         let toID = obj.definitions[0].selectionSet.selections[0].arguments[1].value.value;
         let edgeType = querySchemaInfo.name.match(new RegExp('updateEdge' + "(.*)" + 'From'))[1];
         let egdgeTypeAlias = getTypeAlias(edgeType);
-        const inputFields = transformFunctionInputParameters(obj.definitions[0].selectionSet.selections[0].arguments[2].value.fields, querySchemaInfo);
         const edgeName = querySchemaInfo.name + '_' + querySchemaInfo.returnType;
         let returnBlock = `ID(${edgeName})`;
-        if (obj.definitions[0].selectionSet.selections[0].selectionSet != undefined) {        
+        if (obj.definitions[0].selectionSet.selections[0].selectionSet != undefined) {
             returnBlock = returnStringOnly(obj.definitions[0].selectionSet.selections[0].selectionSet.selections, querySchemaInfo);
-        }    
-        const propertyList = inputFields.fields.split(', ');
-        let setString = '';
-        propertyList.forEach(property => {
-            let kv = property.split(': ');
-            setString = setString + ` ${edgeName}.${kv[0]} = ${kv[1]},`;
-        });
-        setString = setString.substring(0, setString.length - 1);
+        }
+        const fields = extractCypherFieldsFromArgumentFields(obj.definitions[0].selectionSet.selections[0].arguments[2].value.fields, querySchemaInfo);
+        const formattedFields = fields.map(field => {
+            const param = querySchemaInfo.pathName + '_' + field.name;
+            Object.assign(parameters, { [param]: field.value });
+            return `${edgeName}.${field.name} = $${param}`;
+        }).join(',');
 
         const paramFromId  = edgeName + '_' + 'whereFromId';
         const paramToId  = edgeName + '_' + 'whereToId';
         Object.assign(parameters, {[paramFromId]: fromID});
         Object.assign(parameters, {[paramToId]: toID});
 
-        const ocQuery = `MATCH (from)-[${edgeName}:$\`${egdgeTypeAlias}\`]->(to)\nWHERE ID(from) = $${paramFromId} AND ID(to) = $${paramToId}\nSET ${setString}\nRETURN ${returnBlock}`;
+        const ocQuery = `MATCH (from)-[${edgeName}:\`${egdgeTypeAlias}\`]->(to)\nWHERE ID(from) = $${paramFromId} AND ID(to) = $${paramToId}\nSET ${formattedFields}\nRETURN ${returnBlock}`;
         return  ocQuery;
     }
-    
+
     // deleteEdge
     if (querySchemaInfo.name.startsWith('deleteEdge') && querySchemaInfo.graphQuery == null) {
         let fromID = obj.definitions[0].selectionSet.selections[0].arguments[0].value.value;
-        let toID = obj.definitions[0].selectionSet.selections[0].arguments[1].value.value;   
+        let toID = obj.definitions[0].selectionSet.selections[0].arguments[1].value.value;
         const edgeName = querySchemaInfo.name + '_' + querySchemaInfo.returnType;
 
         const paramFromId  = edgeName + '_' + 'whereFromId';
         const paramToId  = edgeName + '_' + 'whereToId';
         Object.assign(parameters, {[paramFromId]: fromID});
-        Object.assign(parameters, {[paramToId]: toID});                
-        
+        Object.assign(parameters, {[paramToId]: toID});
+
         const ocQuery = `MATCH (from)-[${edgeName}]->(to)\nWHERE ID(from) = $${paramFromId} AND ID(to) = $${paramToId}\nDELETE ${edgeName}\nRETURN true`;
         return  ocQuery;
     }
-            
+
     // graph query directive
     if (querySchemaInfo.graphQuery != null) {
-        
+
         let ocQuery = querySchemaInfo.graphQuery;
-        
+
         if (ocQuery.includes('$input')) {
-            const inputFields = transformFunctionInputParameters(obj.definitions[0].selectionSet.selections[0].arguments[0].value.fields, querySchemaInfo);
-            ocQuery = ocQuery.replace('$input', inputFields.fields);
+            const inputFields = extractCypherFieldsFromArgumentFields(obj.definitions[0].selectionSet.selections[0].arguments[0].value.fields, querySchemaInfo);
+            const formattedFields = inputFields.map(field => {
+                const param = querySchemaInfo.pathName + '_' + field.name;
+                Object.assign(parameters, { [param]: field.value });
+                return `${field.name}: $${param}`;
+            }).join(', ');
+            
+            ocQuery = ocQuery.replace('$input', formattedFields);
         } else {
             obj.definitions[0].selectionSet.selections[0].arguments.forEach(arg => {
                 ocQuery = ocQuery.replace('$' + arg.name.value, arg.value.value);
             });
         }
-        
+
         if (ocQuery.includes('RETURN')) {
             const statements = ocQuery.split(' RETURN ');
             const entityName = querySchemaInfo.name + '_' + querySchemaInfo.returnType;
@@ -951,14 +1078,14 @@ function resolveGrapgDBqueryForGraphQLMutation (obj, querySchemaInfo) {
             const returnBlock = returnStringOnly(obj.definitions[0].selectionSet.selections[0].selectionSet.selections, querySchemaInfo);
             ocQuery = body + '\nRETURN ' + returnBlock;
         }
-        
+
         return ocQuery;
     }
-            
+
     return '';
 }
-     
-    
+
+
 function resolveOpenCypherQuery(obj, querySchemaInfo) {
     let ocQuery = '';
 
@@ -975,25 +1102,25 @@ function resolveOpenCypherQuery(obj, querySchemaInfo) {
     if (querySchemaInfo.type === 'Mutation') {
         ocQuery = resolveGrapgDBqueryForGraphQLMutation(obj, querySchemaInfo);
     }
-    
+
     return ocQuery;
 }
 
 
 function gremlinElementToJson(o, fieldsAlias) {
-    let data = '';        
+    let data = '';
     let isKey = true;
     data += '{';
     o['@value'].forEach(v => {
         if (v['@value'] != undefined) {
             if (v['@value'] == 'label')
                 data += '"type":';
-            if (v['@value'] == 'id') 
+            if (v['@value'] == 'id')
                 //data += '"id":';
                 data += '"' + fieldsAlias["id"] + '":';
             if (v['@type'] == 'g:Int32' || v['@type'] == 'g:Double' || v['@type'] == 'g:Int64')
                 data += v['@value'] + ', ';
-            isKey = !isKey;            
+            isKey = !isKey;
         } else {
             if (isKey) {
                 data += '"' + fieldsAlias[v] + '":';
@@ -1005,13 +1132,13 @@ function gremlinElementToJson(o, fieldsAlias) {
         }
     });
     data = data.substring(0, data.length - 2);
-    data += '}';        
+    data += '}';
     return data;
 }
 
 
 export function refactorGremlinqueryOutput(queryResult, fieldsAlias) {
-  
+
     //const r = JSON.parse(queryResult).result.data;
     const r = queryResult;
 
@@ -1026,12 +1153,12 @@ export function refactorGremlinqueryOutput(queryResult, fieldsAlias) {
         else if (r['@value'][0]['@type'] == 'g:List')
             isArray = true;
         else
-            isScalar = true    
-    }    
-        
+            isScalar = true
+    }
+
     if (isScalar) {
         data =  r['@value'][0]['@value'];
-    } else if (isOneElement) {        
+    } else if (isOneElement) {
         data += gremlinElementToJson(r['@value'][0], fieldsAlias);
     } else {
         data += '[';
@@ -1042,7 +1169,7 @@ export function refactorGremlinqueryOutput(queryResult, fieldsAlias) {
                 data +=',\n';
             } catch {}
         });
-        
+
         data = data.substring(0, data.length - 2);
         data += ']';
     }
@@ -1057,21 +1184,21 @@ function getFieldsAlias(typeName) {
     schemaDataModel.definitions.forEach(def => {
         if (def.kind === 'ObjectTypeDefinition') {
             if (def.name.value === typeName) {
-                def.fields.forEach(field => {                    
+                def.fields.forEach(field => {
                     let alias = field.name.value;
                     if (field.directives.length > 0) {
                         field.directives.forEach(directive => {
                             if (directive.name.value === 'alias') {
-                                alias = directive.arguments[0].value.value;                                
+                                alias = directive.arguments[0].value.value;
                             }
                             if (directive.name.value === 'id') {
-                                alias = 'id';                            
-                            }                                                            
+                                alias = 'id';
+                            }
                         });
                     }
                     r[alias] = field.name.value;
                 });
-            
+
             }
         }
     });
@@ -1081,11 +1208,11 @@ function getFieldsAlias(typeName) {
 
 
 function resolveGremlinQuery(obj, querySchemaInfo) {
-    let gremlinQuery = { 
-        query:'', 
+    let gremlinQuery = {
+        query:'',
         language: 'gremlin',
-        parameters: {}, 
-        refactorOutput: null, 
+        parameters: {},
+        refactorOutput: null,
         fieldsAlias: getFieldsAlias(querySchemaInfo.returnType) };
 
     // replace values from input parameters
@@ -1113,29 +1240,31 @@ function parseQueryInput(queryObjOrStr) {
  * Accepts a GraphQL document or query string and outputs the graphDB query.
  *
  * @param {(Object|string)} queryObjOrStr the GraphQL document containing an operation to resolve
+ * @param variables optional query variables
  * @returns {string}
  */
-export function resolveGraphDBQuery(queryObjOrStr) {
+export function resolveGraphDBQuery(queryObjOrStr, variables = {}) {
     let executeQuery =  { query:'', parameters: {}, language: 'opencypher', refactorOutput: null };
 
     const obj = parseQueryInput(queryObjOrStr);
 
     const querySchemaInfo = getSchemaQueryInfo(obj.definitions[0].selectionSet.selections[0].name.value);
+    querySchemaInfo.variables = variables;
 
     if (querySchemaInfo.graphQuery != null) {
-        if (querySchemaInfo.graphQuery.startsWith('g.V')) {            
+        if (querySchemaInfo.graphQuery.startsWith('g.V')) {
             executeQuery.language = 'gremlin'
         }
     }
-            
+
     if (executeQuery.language == 'opencypher') {
         executeQuery.query = resolveOpenCypherQuery(obj, querySchemaInfo);
         executeQuery.parameters = parameters;
     }
-     
+
     if (executeQuery.language == 'gremlin') {
         executeQuery = resolveGremlinQuery(obj, querySchemaInfo);
     }
-    
+
     return executeQuery;
 }


### PR DESCRIPTION
This changeset modifies the `filter` query argument to support string comparison operators `eq`, `contains`, `startsWith`, and `endsWith`:
* added `StringScalarFilters` type which replaces `String` fields for query input types (mutation input types not affected)
* refactored the resolver to extract filters and arguments as objects from a given graphQL query instead of using string concatenation to increase code reusability
* added logic to resolver to convert filter string comparison operators to cypher equivalent syntax
* fixed usage of variables for nested edge subqueries by passing along query variables as part of apollo and app sync event handling - this is required to support the usage of string comparison operators via variables on the subqueries
* fixed nested edge subqueries to return an empty array if no results were produced using `CASE` - previously null values would be returned, producing an invalid graphQL response
* changed `graphdb.test.js` to use `prettier` graphQL formatter to account for whitespace differences between expected and actual schemas

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
