### PR TITLE
Offset option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ This release contains new support for Apollo Server integration.
 
 * Support output of zip package of Apollo Server artifacts (([#70](https://github.com/aws/amazon-neptune-for-graphql/pull/70)), ([#72](https://github.com/aws/amazon-neptune-for-graphql/pull/72)), ([#73](https://github.com/aws/amazon-neptune-for-graphql/pull/73)), ([#75](https://github.com/aws/amazon-neptune-for-graphql/pull/75)), ([#76](https://github.com/aws/amazon-neptune-for-graphql/pull/76)))
 * Allow filtering using string comparison operators `eq`, `contains`, `startsWith`, `endsWith` (([#100](https://github.com/aws/amazon-neptune-for-graphql/pull/100))
+* Added pagination support through the addition of an `offset` argument in query options which can be used in combination with the existing `limit` (([#102](https://github.com/aws/amazon-neptune-for-graphql/pull/102))
+
 
 ### Improvements
 

--- a/src/graphdb.js
+++ b/src/graphdb.js
@@ -290,6 +290,7 @@ function graphDBInferenceSchema (graphbSchema, addMutations) {
     // input options
     r += `input Options {\n`;
     r += `\tlimit:Int\n`;
+    r += `\toffset:Int\n`;
     r += '}\n\n';
     
     r += 'input StringScalarFilters {\n' +

--- a/src/schemaModelValidator.js
+++ b/src/schemaModelValidator.js
@@ -383,7 +383,10 @@ function inferGraphDatabaseDirectives(schemaModel) {
         }
     });
 
-    typesToAdd.push(`input Options {\n  limit: Int\n}\n`);
+    typesToAdd.push('input Options {\n' +
+        '\tlimit: Int\n' +
+        '\toffset: Int\n' +
+        '}\n');
     typesToAdd.push('input StringScalarFilters {\n' +
         '\teq: String\n' +
         '\tcontains: String\n' +

--- a/src/test/airports-mutations.graphql
+++ b/src/test/airports-mutations.graphql
@@ -179,6 +179,7 @@ input RouteInput {
 
 input Options {
   limit:Int
+  offset: Int
 }
 
 input StringScalarFilters {

--- a/src/test/airports.customized.graphql
+++ b/src/test/airports.customized.graphql
@@ -102,6 +102,7 @@ dist: Int
 
 input Options {
 limit:Int
+offset:Int
 }
 
 input StringScalarFilters {

--- a/src/test/airports.graphql
+++ b/src/test/airports.graphql
@@ -101,6 +101,7 @@ input RouteInput {
 
 input Options {
     limit: Int
+    offset: Int
 }
 
 input StringScalarFilters {

--- a/src/test/dining.graphql
+++ b/src/test/dining.graphql
@@ -120,6 +120,7 @@ type Friends @alias(property: "friends") {
 
 input Options {
     limit: Int
+    offset: Int
 }
 
 input StringScalarFilters {

--- a/src/test/epl.graphql
+++ b/src/test/epl.graphql
@@ -74,6 +74,7 @@ type Stadium_edge @alias(property: "STADIUM_EDGE") {
 
 input Options {
     limit: Int
+    offset: Int
 }
 
 input StringScalarFilters {

--- a/src/test/fraud.graphql
+++ b/src/test/fraud.graphql
@@ -133,6 +133,7 @@ type Merchant_edge @alias(property: "MERCHANT_EDGE") {
 
 input Options {
     limit: Int
+    offset: Int
 }
 
 input StringScalarFilters {

--- a/src/test/knowledge.graphql
+++ b/src/test/knowledge.graphql
@@ -148,6 +148,7 @@ type Written_by @alias(property: "written_by") {
 
 input Options {
     limit: Int
+    offset: Int
 }
 
 input StringScalarFilters {

--- a/src/test/node-edge-same-label.graphql
+++ b/src/test/node-edge-same-label.graphql
@@ -31,6 +31,7 @@ input _authorInput {
 
 input Options {
     limit: Int
+    offset: Int
 }
 
 input StringScalarFilters {

--- a/src/test/security.graphql
+++ b/src/test/security.graphql
@@ -489,6 +489,7 @@ type Transient_resource_link @alias(property: "transient_resource_link") {
 
 input Options {
     limit: Int
+    offset: Int
 }
 
 input StringScalarFilters {

--- a/src/test/special-chars-mutations.graphql
+++ b/src/test/special-chars-mutations.graphql
@@ -122,6 +122,7 @@ type Resource_link @alias(property:"resource_link") {
 
 input Options {
   limit:Int
+  offset: Int
 }
 
 input StringScalarFilters {

--- a/src/test/special-chars.graphql
+++ b/src/test/special-chars.graphql
@@ -66,6 +66,7 @@ type Resource_link @alias(property: "resource_link") {
 
 input Options {
         limit: Int
+        offset: Int
 }
 
 input StringScalarFilters {

--- a/src/test/user-group-validated.graphql
+++ b/src/test/user-group-validated.graphql
@@ -87,6 +87,7 @@ type GroupEdge {
 
 input Options {
   limit: Int
+  offset: Int
 }
 
 input StringScalarFilters {


### PR DESCRIPTION
Added support for setting an `offset` value as part of query `options` which can be used in combination with the existing `limit` for pagination purposes. The `offset` is translated to open cypher's `SKIP` by the resolver. If `offset` and `limit` are specified for nested edge queries, the values are translated to open cypher's list slice lower and upper bounds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
