### PR TITLE
Support for query fragments with Apollo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,3 +56,4 @@ This release contains new support for Apollo Server integration.
 * Added distinct input types for create and update mutations ([#93](https://github.com/aws/amazon-neptune-for-graphql/pull/93))
 * Enabled mutations for the Apollo Server ([#98](https://github.com/aws/amazon-neptune-for-graphql/pull/98))
 * Refactored integration tests to be less vulnerable to resolver logic changes ([#99](https://github.com/aws/amazon-neptune-for-graphql/pull/99))
+* Enabled usage of query fragments with Apollo Server ([#103](https://github.com/aws/amazon-neptune-for-graphql/pull/103))

--- a/README.md
+++ b/README.md
@@ -311,6 +311,8 @@ When using custom scalars in your schema (specified via `--input-schema-file`), 
 - Querying Neptune via SDK is not yet supported for Apollo Server, only HTTPS is supported.
 - Schemas specified by `--input-schema-file` with `--create-update-aws-pipeline` may not contain custom scalars. See [AWS App Sync Scalar types in GraphQL](https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html) for more information.
 - Schemas specified by `--input-schema-file` with `--create-update-apollo-server` or `--create-update-apollo-server-subgraph` which contain custom scalars require manual steps to add custom scalar resolvers for additional query validation.
+- Query fragments are supported for Apollo Server but not yet for App Sync
+- Inline fragments are not yet supported
   <br>
 
 # Roadmap

--- a/src/pipelineResources.js
+++ b/src/pipelineResources.js
@@ -579,9 +579,9 @@ export function request(ctx) {
     
 export function response(ctx) {
     const { error, result } = ctx;
-      if (error) {
+    if (error) {
         util.appendError(error.message, error.type, result);
-      }
+    }
     return result;
 }`
 

--- a/src/pipelineResources.js
+++ b/src/pipelineResources.js
@@ -578,7 +578,11 @@ export function request(ctx) {
 }
     
 export function response(ctx) {
-    return ctx.result;
+    const { error, result } = ctx;
+      if (error) {
+        util.appendError(error.message, error.type, result);
+      }
+    return result;
 }`
 
     };

--- a/src/test/airports.customized.graphql
+++ b/src/test/airports.customized.graphql
@@ -14,6 +14,20 @@ code: StringScalarFilters
 desc: StringScalarFilters
 }
 
+input ContinentCreateInput {
+  _id: ID @id
+  type: String
+  code: String
+  desc: String
+}
+
+input ContinentUpdateInput {
+  _id: ID! @id
+  type: String
+  code: String
+  desc: String
+}
+
 type Country @alias(property:"country") {
 _id: ID! @id
 type: String
@@ -28,6 +42,20 @@ _id: ID @id
 type: StringScalarFilters
 code: StringScalarFilters
 desc: StringScalarFilters
+}
+
+input CountryCreateInput {
+  _id: ID @id
+  type: String
+  code: String
+  desc: String
+}
+
+input CountryUpdateInput {
+  _id: ID! @id
+  type: String
+  code: String
+  desc: String
 }
 
 type Version @alias(property:"version") {
@@ -46,6 +74,24 @@ desc: StringScalarFilters
 author: StringScalarFilters
 type: StringScalarFilters
 code: StringScalarFilters
+}
+
+input VersionCreateInput {
+  _id: ID @id
+  date: String
+  desc: String
+  author: String
+  type: String
+  code: String
+}
+
+input VersionUpdateInput {
+  _id: ID! @id
+  date: String
+  desc: String
+  author: String
+  type: String
+  code: String
 }
 
 type Airport @alias(property:"airport") {
@@ -85,6 +131,38 @@ desc: StringScalarFilters
 lon: Float
 region: StringScalarFilters
 elev: Int
+}
+
+input AirportCreateInput {
+  _id: ID @id
+  type: String
+  city: String
+  icao: String
+  code: String
+  country: String
+  lat: Float
+  longest: Int
+  runways: Int
+  desc: String
+  lon: Float
+  region: String
+  elev: Int
+}
+
+input AirportUpdateInput {
+  _id: ID! @id
+  type: String
+  city: String
+  icao: String
+  code: String
+  country: String
+  lat: Float
+  longest: Int
+  runways: Int
+  desc: String
+  lon: Float
+  region: String
+  elev: Int
 }
 
 type Contains @alias(property:"contains") {
@@ -130,12 +208,12 @@ getCountriesCount: Int @graphQuery(statement: "g.V().hasLabel('country').count()
 }
 
 type Mutation {
-createNodeAirport(input: AirportInput!): Airport
-updateNodeAirport(input: AirportInput!): Airport
+createNodeAirport(input: AirportCreateInput!): Airport
+updateNodeAirport(input: AirportUpdateInput!): Airport
 connectNodeCountryToNodeAirportEdgeContains(from_id: ID!, to_id: ID!): Contains
 deleteEdgeContainsFromCountryToAirport(from_id: ID!, to_id: ID!): Boolean
 updateEdgeRouteFromAirportToAirport(from_id: ID!, to_id: ID!, edge: RouteInput!): Route
-createAirport(input: AirportInput!): Airport @graphQuery(statement: "CREATE (this:airport {$input}) RETURN this")
+createAirport(input: AirportCreateInput!): Airport @graphQuery(statement: "CREATE (this:airport {$input}) RETURN this")
 }
 
 schema {

--- a/templates/ApolloServer/index.mjs
+++ b/templates/ApolloServer/index.mjs
@@ -38,6 +38,7 @@ function resolve(info, args) {
         arguments: args,
         selectionSet: info.fieldNodes[0].selectionSet,
         variables: info.variableValues,
+        fragments: info.fragments
     };
 
     return resolveEvent(event).then((result) => {

--- a/templates/CDKTemplate.js
+++ b/templates/CDKTemplate.js
@@ -205,7 +205,11 @@ export function request(ctx) {
 }
     
 export function response(ctx) {
-    return ctx.result;
+    const { error, result } = ctx;
+      if (error) {
+        util.appendError(error.message, error.type, result);
+      }
+    return result;
 }`
         });        
 

--- a/templates/CDKTemplate.js
+++ b/templates/CDKTemplate.js
@@ -206,9 +206,9 @@ export function request(ctx) {
     
 export function response(ctx) {
     const { error, result } = ctx;
-      if (error) {
+    if (error) {
         util.appendError(error.message, error.type, result);
-      }
+    }
     return result;
 }`
         });        

--- a/templates/JSResolverOCHTTPS.js
+++ b/templates/JSResolverOCHTTPS.js
@@ -40,6 +40,8 @@ export function resolveGraphDBQueryFromAppSyncEvent(event) {
     return resolveGraphDBQueryFromEvent({
         field: event.field,
         arguments: event.arguments,
+        // fragments not yet supported in app sync - see https://github.com/aws-samples/appsync-with-postgraphile-rds/issues/18
+        fragments: {},
         variables: event.variables,
         selectionSet: event.selectionSetGraphQL ? gql`${event.selectionSetGraphQL}`.definitions[0].selectionSet : {}
     });
@@ -52,6 +54,7 @@ export function resolveGraphDBQueryFromAppSyncEvent(event) {
  * @param {object} event.arguments arguments that were passed into the query
  * @param {object} event.selectionSet the graphQL AST selection set
  * @param {object} event.variables optional query variables
+ * @param {object} event.fragments optional query fragments
  * @returns {string} the resolved graph db query
  */
 export function resolveGraphDBQueryFromEvent(event) {
@@ -91,7 +94,7 @@ export function resolveGraphDBQueryFromEvent(event) {
         arguments: args,
         selectionSet: event.selectionSet
     };
-    const obj = {
+    const queryDocument = {
         kind: 'Document',
         definitions: [
             {
@@ -105,7 +108,11 @@ export function resolveGraphDBQueryFromEvent(event) {
         ]
     };
 
-    const graphQuery = resolveGraphDBQuery(obj, event.variables);
+    const graphQuery = resolveGraphDBQuery({
+        queryObjOrStr: queryDocument, 
+        variables: event.variables, 
+        fragments: event.fragments
+    });
     return graphQuery;
 }
 
@@ -487,6 +494,7 @@ function createQueryFunctionMatchStatement(obj, matchStatements, querySchemaInfo
     } else {
         const selection = obj.definitions[0].selectionSet.selections[0];
         replaceVariableArgsWithValues(selection, querySchemaInfo.variables);
+        replaceFragmentSelections(selection, querySchemaInfo.fragments);
         const argsAndWhereClauses = extractQueryArgsAndWhereClauses(selection.arguments, querySchemaInfo);
         const queryArgs = argsAndWhereClauses?.queryArguments.length > 0 ? `{${argsAndWhereClauses.queryArguments.join(',')}}` : '';
         const whereClause = argsAndWhereClauses?.whereClauses.length > 0 ? ` WHERE ${argsAndWhereClauses.whereClauses.join(' AND ')}` : '';
@@ -655,7 +663,7 @@ function createQueryFieldLeafStatement(fieldSchemaInfo, lastNamePath) {
 }
 
 
-function createTypeFieldStatementAndRecurse(selection, fieldSchemaInfo, lastNamePath, lastType, variables = {}) {
+function createTypeFieldStatementAndRecurse({selection, fieldSchemaInfo, lastNamePath, lastType, variables = {}, fragments = {}}) {
     const schemaTypeInfo = getSchemaTypeInfo(lastType, fieldSchemaInfo.name, lastNamePath);
 
     // check if the field has is a function with parameters, look for filters and options
@@ -686,7 +694,13 @@ function createTypeFieldStatementAndRecurse(selection, fieldSchemaInfo, lastName
     }
 
     withStatements[thisWithId].content += '{';
-    selectionsRecurse(selection.selectionSet.selections, schemaTypeInfo.pathName, schemaTypeInfo.type, variables);
+    selectionsRecurse({
+        selections: selection.selectionSet.selections,
+        lastNamePath: schemaTypeInfo.pathName,
+        lastType: schemaTypeInfo.type,
+        variables: variables,
+        fragments: fragments
+    });
     withStatements[thisWithId].content += '}';
 
     if (schemaTypeInfo.isArray) {
@@ -726,12 +740,20 @@ function createTypeFieldStatementAndRecurse(selection, fieldSchemaInfo, lastName
 }
 
 
-
-function selectionsRecurse(selections, lastNamePath, lastType, variables = {}) {
+/**
+ * Recursively processes query selections
+ * @param selections the query selections to process
+ * @param lastNamePath the last name path of the parent selection
+ * @param lastType the last type of the parent selection
+ * @param variables optional variables referenced in the query
+ * @param fragments optional fragment definitions referenced in the query
+ */
+function selectionsRecurse({selections, lastNamePath, lastType, variables = {}, fragments = {}}) {
 
     selections.forEach(selection => {
         // replace any selection references to variables with the variable values
         replaceVariableArgsWithValues(selection, variables);
+        replaceFragmentSelections(selection, fragments);
         const fieldSchemaInfo = getSchemaFieldInfo(lastType, selection.name.value, lastNamePath);
 
         // check if is schema type
@@ -741,7 +763,14 @@ function selectionsRecurse(selections, lastNamePath, lastType, variables = {}) {
             return
         }
 
-        createTypeFieldStatementAndRecurse(selection, fieldSchemaInfo, lastNamePath, lastType, variables)
+        createTypeFieldStatementAndRecurse({
+            selection: selection,
+            fieldSchemaInfo: fieldSchemaInfo,
+            lastNamePath: lastNamePath,
+            lastType: lastType,
+            variables: variables,
+            fragments: fragments
+        })
     });
 };
 
@@ -788,7 +817,13 @@ function resolveGrapgDBqueryForGraphQLQuery (obj, querySchemaInfo) {
 
     withStatements[0].content = '{';
 
-    selectionsRecurse(obj.definitions[0].selectionSet.selections[0].selectionSet.selections, querySchemaInfo.pathName, querySchemaInfo.returnType, querySchemaInfo.variables);
+    selectionsRecurse({
+        selections: obj.definitions[0].selectionSet.selections[0].selectionSet.selections,
+        lastNamePath: querySchemaInfo.pathName,
+        lastType: querySchemaInfo.returnType,
+        variables: querySchemaInfo.variables,
+        fragments: querySchemaInfo.fragments
+    });
 
     if (withStatements[0].content.slice(-2) == ', ')
         withStatements[0].content = withStatements[0].content.substring(0, withStatements[0].content.length - 2);
@@ -886,14 +921,47 @@ function convertToValueNode(value) {
  * @param variables the variables object
  */
 function replaceVariableArgsWithValues(selection, variables) {
-    const variableArgs = selection.arguments?.filter(arg => arg.value?.kind === 'Variable' 
-        && arg.value?.name?.value && variables.hasOwnProperty(arg.value.name.value));
-    variableArgs.forEach(arg => {
+    selection.arguments?.filter(arg => arg.value?.kind === 'Variable' 
+        && arg.value?.name?.value && variables.hasOwnProperty(arg.value.name.value))
+        .forEach(arg => {
         // replace variable reference with actual value
         arg.value = convertToValueNode(variables[arg.value.name.value]);
     });
 }
 
+/**
+ * Replaces any fragment references in the selection with the actual fragment selections.
+ * @param selection the graphQL selection to replace fragment references in
+ * @param fragments the fragment definitions object
+ */
+function replaceFragmentSelections(selection, fragments) {
+    // Early return if no selection set or selections
+    if (!selection?.selectionSet?.selections) {
+        return;
+    }
+
+    // Find all fragment spreads referenced in query selection
+    const fragmentSpreads = selection.selectionSet.selections.reduce((acc, fragmentSelection, index) => {
+        if (fragmentSelection?.kind === 'FragmentSpread' && fragmentSelection?.name?.value) {
+            if (fragments[fragmentSelection.name.value]) {
+                acc.push({ fragmentSelection, index });
+            } else {
+                throw new GraphQLError(`Fragment ${fragmentSelection.name.value} not found`);
+            }
+        }
+        return acc;
+    }, []);
+
+    // Process fragments in reverse order to maintain correct indices
+    fragmentSpreads.reverse().forEach(({ fragmentSelection, index }) => {
+        const fragment = fragments[fragmentSelection.name.value];
+        if (!fragment?.selectionSet?.selections) {
+            return;
+        }
+        // Replace fragment spread with actual fragment selections
+        selection.selectionSet.selections.splice(index, 1, ...fragment.selectionSet.selections);
+    });
+}
 
 /**
  * Extracts an array of cypher field name and value from the graphQL query argument fields.
@@ -945,16 +1013,32 @@ function extractFiltersFromQueryArgumentFields(queryArgumentFields, schemaInfo) 
 
 function returnStringOnly(selections, querySchemaInfo) {
     withStatements.push({carryOver: querySchemaInfo.pathName, inLevel:'', content:''});
-    selectionsRecurse(selections, querySchemaInfo.pathName, querySchemaInfo.returnType, querySchemaInfo.variables);
+    selectionsRecurse({
+        selections: selections,
+        lastNamePath: querySchemaInfo.pathName,
+        lastType: querySchemaInfo.returnType,
+        variables: querySchemaInfo.variables,
+        fragments: querySchemaInfo.fragments
+    });
     return `{${withStatements[0].content}}`
 }
 
+/**
+ * Processes a query selection and returns a string representation of the cypher return block.
+ * @param selection the query selection to process
+ * @param querySchemaInfo the schema info for the query
+ * @returns {string} the cypher return block string
+ */
+function getReturnBlockFromSelection(selection, querySchemaInfo) {
+    replaceFragmentSelections(selection, querySchemaInfo.fragments);
+    return returnStringOnly(selection.selectionSet.selections, querySchemaInfo);
+}
 
-function resolveGrapgDBqueryForGraphQLMutation (obj, querySchemaInfo) {
+function resolveGrapgDBqueryForGraphQLMutation (queryAst, querySchemaInfo) {
 
     // createNode
     if (querySchemaInfo.name.startsWith('createNode') && !querySchemaInfo.graphQuery) {
-        const queryFields = extractCypherFieldsFromArgumentFields(obj.definitions[0].selectionSet.selections[0].arguments[0].value.fields, querySchemaInfo);
+        const queryFields = extractCypherFieldsFromArgumentFields(queryAst.definitions[0].selectionSet.selections[0].arguments[0].value.fields, querySchemaInfo);
         const formattedQueryFields = queryFields.map(arg => {
             const param = querySchemaInfo.pathName + '_' + arg.name;
             Object.assign(parameters, { [param]: arg.value });
@@ -963,15 +1047,15 @@ function resolveGrapgDBqueryForGraphQLMutation (obj, querySchemaInfo) {
         
         const nodeName = querySchemaInfo.name + '_' + querySchemaInfo.returnType;
         let returnBlock = `ID(${nodeName})`;
-        if (obj.definitions[0].selectionSet.selections[0].selectionSet) {
-            returnBlock = returnStringOnly(obj.definitions[0].selectionSet.selections[0].selectionSet.selections, querySchemaInfo);
+        if (queryAst.definitions[0].selectionSet.selections[0].selectionSet) {
+            returnBlock = getReturnBlockFromSelection(queryAst.definitions[0].selectionSet.selections[0], querySchemaInfo);
         }
         return `CREATE (${nodeName}:\`${querySchemaInfo.returnTypeAlias}\` {${formattedQueryFields}})\nRETURN ${returnBlock}`;
     }
 
     // updateNode
     if (querySchemaInfo.name.startsWith('updateNode') && !querySchemaInfo.graphQuery) {
-        const queryFields = extractCypherFieldsFromArgumentFields(obj.definitions[0].selectionSet.selections[0].arguments[0].value.fields, querySchemaInfo);
+        const queryFields = extractCypherFieldsFromArgumentFields(queryAst.definitions[0].selectionSet.selections[0].arguments[0].value.fields, querySchemaInfo);
         
         const idField = queryFields.find(arg => arg.name === querySchemaInfo.graphDBIdArgName);
         const nodeID = idField.value;
@@ -980,8 +1064,8 @@ function resolveGrapgDBqueryForGraphQLMutation (obj, querySchemaInfo) {
         Object.assign(parameters, {[idParam]: nodeID});
         
         let returnBlock = `ID(${nodeName})`;
-        if (obj.definitions[0].selectionSet.selections[0].selectionSet) {
-            returnBlock = returnStringOnly(obj.definitions[0].selectionSet.selections[0].selectionSet.selections, querySchemaInfo);
+        if (queryAst.definitions[0].selectionSet.selections[0].selectionSet) {
+            returnBlock = getReturnBlockFromSelection(queryAst.definitions[0].selectionSet.selections[0], querySchemaInfo);
         }
         // :( SET += is not working, so let's work around it.
         //let ocQuery = `MATCH (${nodeName}) WHERE ID(${nodeName}) = '${nodeID}' SET ${nodeName} += {${inputFields}} RETURN ${returnBlock}`;
@@ -993,12 +1077,20 @@ function resolveGrapgDBqueryForGraphQLMutation (obj, querySchemaInfo) {
             Object.assign(parameters, { [param]: arg.value });
             return `${nodeName}.${arg.name} = $${param}`;
         }).join(', ');
+        // FIXME handle update mutations with selection set that contains an edge
+        // example:
+        // updateNodeAirport(input: $input) {
+        //     id
+        //     airportRoutesIn {
+        //       code
+        //     }
+        //   }
         return `MATCH (${nodeName})\nWHERE ID(${nodeName}) = $${idParam}\nSET ${formattedFields}\nRETURN ${returnBlock}`;
     }
 
     // deleteNode
     if (querySchemaInfo.name.startsWith('deleteNode') && !querySchemaInfo.graphQuery) {
-        const nodeID = obj.definitions[0].selectionSet.selections[0].arguments[0].value.value;
+        const nodeID = queryAst.definitions[0].selectionSet.selections[0].arguments[0].value.value;
         const nodeName = querySchemaInfo.name + '_' + querySchemaInfo.returnType;
         let param  = nodeName + '_' + 'whereId';
         Object.assign(parameters, {[param]: nodeID});
@@ -1008,12 +1100,12 @@ function resolveGrapgDBqueryForGraphQLMutation (obj, querySchemaInfo) {
 
     // connect
     if (querySchemaInfo.name.startsWith('connectNode') && querySchemaInfo.graphQuery == null) {
-        let fromID = obj.definitions[0].selectionSet.selections[0].arguments[0].value.value;
-        let toID = obj.definitions[0].selectionSet.selections[0].arguments[1].value.value;
+        let fromID = queryAst.definitions[0].selectionSet.selections[0].arguments[0].value.value;
+        let toID = queryAst.definitions[0].selectionSet.selections[0].arguments[1].value.value;
         const edgeType = querySchemaInfo.name.match(new RegExp('Edge' + "(.*)" + ''))[1];
         const edgeName = querySchemaInfo.name + '_' + querySchemaInfo.returnType;
         const egdgeTypeAlias = getTypeAlias(edgeType);
-        const returnBlock = returnStringOnly(obj.definitions[0].selectionSet.selections[0].selectionSet.selections, querySchemaInfo);
+        const returnBlock = getReturnBlockFromSelection(queryAst.definitions[0].selectionSet.selections[0], querySchemaInfo);
 
         let paramFromId  = edgeName + '_' + 'whereFromId';
         let paramToId  = edgeName + '_' + 'whereToId';
@@ -1026,16 +1118,16 @@ function resolveGrapgDBqueryForGraphQLMutation (obj, querySchemaInfo) {
 
     // updateEdge
     if (querySchemaInfo.name.startsWith('updateEdge') && querySchemaInfo.graphQuery == null) {
-        let fromID = obj.definitions[0].selectionSet.selections[0].arguments[0].value.value;
-        let toID = obj.definitions[0].selectionSet.selections[0].arguments[1].value.value;
+        let fromID = queryAst.definitions[0].selectionSet.selections[0].arguments[0].value.value;
+        let toID = queryAst.definitions[0].selectionSet.selections[0].arguments[1].value.value;
         let edgeType = querySchemaInfo.name.match(new RegExp('updateEdge' + "(.*)" + 'From'))[1];
         let egdgeTypeAlias = getTypeAlias(edgeType);
         const edgeName = querySchemaInfo.name + '_' + querySchemaInfo.returnType;
         let returnBlock = `ID(${edgeName})`;
-        if (obj.definitions[0].selectionSet.selections[0].selectionSet != undefined) {
-            returnBlock = returnStringOnly(obj.definitions[0].selectionSet.selections[0].selectionSet.selections, querySchemaInfo);
+        if (queryAst.definitions[0].selectionSet.selections[0].selectionSet) {
+            returnBlock = getReturnBlockFromSelection(queryAst.definitions[0].selectionSet.selections[0], querySchemaInfo);
         }
-        const fields = extractCypherFieldsFromArgumentFields(obj.definitions[0].selectionSet.selections[0].arguments[2].value.fields, querySchemaInfo);
+        const fields = extractCypherFieldsFromArgumentFields(queryAst.definitions[0].selectionSet.selections[0].arguments[2].value.fields, querySchemaInfo);
         const formattedFields = fields.map(field => {
             const param = querySchemaInfo.pathName + '_' + field.name;
             Object.assign(parameters, { [param]: field.value });
@@ -1053,8 +1145,8 @@ function resolveGrapgDBqueryForGraphQLMutation (obj, querySchemaInfo) {
 
     // deleteEdge
     if (querySchemaInfo.name.startsWith('deleteEdge') && querySchemaInfo.graphQuery == null) {
-        let fromID = obj.definitions[0].selectionSet.selections[0].arguments[0].value.value;
-        let toID = obj.definitions[0].selectionSet.selections[0].arguments[1].value.value;
+        let fromID = queryAst.definitions[0].selectionSet.selections[0].arguments[0].value.value;
+        let toID = queryAst.definitions[0].selectionSet.selections[0].arguments[1].value.value;
         const edgeName = querySchemaInfo.name + '_' + querySchemaInfo.returnType;
 
         const paramFromId  = edgeName + '_' + 'whereFromId';
@@ -1072,7 +1164,7 @@ function resolveGrapgDBqueryForGraphQLMutation (obj, querySchemaInfo) {
         let ocQuery = querySchemaInfo.graphQuery;
 
         if (ocQuery.includes('$input')) {
-            const inputFields = extractCypherFieldsFromArgumentFields(obj.definitions[0].selectionSet.selections[0].arguments[0].value.fields, querySchemaInfo);
+            const inputFields = extractCypherFieldsFromArgumentFields(queryAst.definitions[0].selectionSet.selections[0].arguments[0].value.fields, querySchemaInfo);
             const formattedFields = inputFields.map(field => {
                 const param = querySchemaInfo.pathName + '_' + field.name;
                 Object.assign(parameters, { [param]: field.value });
@@ -1081,7 +1173,7 @@ function resolveGrapgDBqueryForGraphQLMutation (obj, querySchemaInfo) {
             
             ocQuery = ocQuery.replace('$input', formattedFields);
         } else {
-            obj.definitions[0].selectionSet.selections[0].arguments.forEach(arg => {
+            queryAst.definitions[0].selectionSet.selections[0].arguments.forEach(arg => {
                 ocQuery = ocQuery.replace('$' + arg.name.value, arg.value.value);
             });
         }
@@ -1090,7 +1182,7 @@ function resolveGrapgDBqueryForGraphQLMutation (obj, querySchemaInfo) {
             const statements = ocQuery.split(' RETURN ');
             const entityName = querySchemaInfo.name + '_' + querySchemaInfo.returnType;
             const body = statements[0].replace("this", entityName);
-            const returnBlock = returnStringOnly(obj.definitions[0].selectionSet.selections[0].selectionSet.selections, querySchemaInfo);
+            const returnBlock = returnStringOnly(queryAst.definitions[0].selectionSet.selections[0].selectionSet.selections, querySchemaInfo);
             ocQuery = body + '\nRETURN ' + returnBlock;
         }
 
@@ -1255,16 +1347,18 @@ function parseQueryInput(queryObjOrStr) {
  * Accepts a GraphQL document or query string and outputs the graphDB query.
  *
  * @param {(Object|string)} queryObjOrStr the GraphQL document containing an operation to resolve
- * @param variables optional query variables
- * @returns {string}
+ * @param {object} variables optional query variables
+ * @param {object} fragments optional query fragments
+ * @returns {string} resolved graph db query
  */
-export function resolveGraphDBQuery(queryObjOrStr, variables = {}) {
+export function resolveGraphDBQuery({queryObjOrStr, variables = {}, fragments = {}}) {
     let executeQuery =  { query:'', parameters: {}, language: 'opencypher', refactorOutput: null };
 
     const obj = parseQueryInput(queryObjOrStr);
 
     const querySchemaInfo = getSchemaQueryInfo(obj.definitions[0].selectionSet.selections[0].name.value);
     querySchemaInfo.variables = variables;
+    querySchemaInfo.fragments = fragments;
 
     if (querySchemaInfo.graphQuery != null) {
         if (querySchemaInfo.graphQuery.startsWith('g.V')) {

--- a/templates/JSResolverOCHTTPS.js
+++ b/templates/JSResolverOCHTTPS.js
@@ -742,11 +742,11 @@ function createTypeFieldStatementAndRecurse({selection, fieldSchemaInfo, lastNam
 
 /**
  * Recursively processes query selections
- * @param selections the query selections to process
- * @param lastNamePath the last name path of the parent selection
- * @param lastType the last type of the parent selection
- * @param variables optional variables referenced in the query
- * @param fragments optional fragment definitions referenced in the query
+ * @param {object} selections the query selections to process
+ * @param {string} lastNamePath the last name path of the parent selection
+ * @param {string} lastType the last type of the parent selection
+ * @param {object} variables optional variables referenced in the query
+ * @param {object} fragments optional fragment definitions referenced in the query
  */
 function selectionsRecurse({selections, lastNamePath, lastType, variables = {}, fragments = {}}) {
 

--- a/templates/Lambda4AppSyncGraphSDK/index.mjs
+++ b/templates/Lambda4AppSyncGraphSDK/index.mjs
@@ -68,6 +68,9 @@ function resolveGraphQuery(event) {
  * Converts incoming graphQL query into open cypher format and sends the query to neptune analytics query API.
  */
 export const handler = async (event) => {
+    if (event.selectionSetGraphQL.includes('...')) {
+        throw new Error('Fragments are not supported');
+    }
     let resolver = resolveGraphQuery(event);
 
     try {

--- a/templates/Lambda4AppSyncHTTP/index.mjs
+++ b/templates/Lambda4AppSyncHTTP/index.mjs
@@ -41,9 +41,12 @@ if (process.env.NEPTUNE_IAM_AUTH_ENABLED === 'true') {
 rax.attach();
 
 export const handler = async (event) => {
-    // Create Neptune query from GraphQL query
+    if (LOGGING_ENABLED) console.log("Event: ", event);
+    if (event.selectionSetGraphQL.includes('...')) {
+        throw new Error('Fragments are not supported');
+    }
     try {
-        if (LOGGING_ENABLED) console.log("Event: ", event);
+        // Create Neptune query from GraphQL query
         const schemaDataModelJSON = readFileSync('output.resolver.schema.json', 'utf-8');
         let schemaModel = JSON.parse(schemaDataModelJSON);
         initSchema(schemaModel);
@@ -51,10 +54,8 @@ export const handler = async (event) => {
         if (LOGGING_ENABLED) console.log("Resolver: ", resolver);
         return queryNeptune(`https://${process.env.NEPTUNE_HOST}:${process.env.NEPTUNE_PORT}`, resolver, {loggingEnabled: LOGGING_ENABLED})
     } catch (err) {
-        if (LOGGING_ENABLED) console.error(err);
-        return {
-            "error": [{ "message": err}]
-        };
+        console.error(err);
+        throw err;
     }
 
 };

--- a/templates/Lambda4AppSyncSDK/index.mjs
+++ b/templates/Lambda4AppSyncSDK/index.mjs
@@ -26,9 +26,7 @@ function getClient() {
 
 function onError (location, error) {
     console.error(location, ': ', error.message);
-    return {             
-        "error": [{ "message": error.message}]
-    };
+    throw error;
 }
     
 
@@ -37,6 +35,9 @@ export const handler = async(event) => {
     let result = null;
 
     if (LOGGING_ENABLED) console.log(event);
+    if (event.selectionSetGraphQL.includes('...')) {
+        throw new Error('Fragments are not supported');
+    }
 
     let resolver = { query:'', parameters:{}, language: 'opencypher', fieldsAlias: {} };
 

--- a/test/testLib.js
+++ b/test/testLib.js
@@ -142,7 +142,7 @@ async function testResolverQueriesResults(resolverFile, queriesReferenceFolder, 
     for (const queryFile of queryFiles) {
         const query = JSON.parse(fs.readFileSync(queriesReferenceFolder + "/" +queryFile));
         if (query.graphql) {
-            const result = resolverModule.resolveGraphDBQuery(gql(query.graphql));
+            const result = resolverModule.resolveGraphDBQuery({queryObjOrStr: gql(query.graphql)});
             const httpResult = await queryNeptune(result.query, result.language, host, port, result.parameters);
                 
             let data = null;


### PR DESCRIPTION
https://github.com/aws/amazon-neptune-for-graphql/issues/84

This changeset enables the use of graphQL query fragments with Apollo Server:
* changed Apollo event handler to pass along any query fragments to the resolver
* added logic to the resolver to detect referenced fragments in the query AST and replace them with the appropriate fragment's selection set
* changed App Sync event handlers to throw an Error if a fragment is detected in the query so that the user is presented with an appropriate error message 'Fragments are not supported' instead of failing downstream and presenting a cryptic error message
* changed functions in the resolver which require fragments data to accept a single object argument instead of multiple arguments for easier readability when calling the function
* updated `airports.customized.graphql` test schema to have separate input types for create and update mutations so that the resolver unit test could verify test cases for mutations with fragments
* fixed a couple resolver unit tests that were not correctly wrapping the function call when using `expect().toThrow(msg)`
* note that this changeset does not address inline fragments

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
