### PR TITLE
Added support for queries with sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This release contains new support for Apollo Server integration.
 * Support output of zip package of Apollo Server artifacts (([#70](https://github.com/aws/amazon-neptune-for-graphql/pull/70)), ([#72](https://github.com/aws/amazon-neptune-for-graphql/pull/72)), ([#73](https://github.com/aws/amazon-neptune-for-graphql/pull/73)), ([#75](https://github.com/aws/amazon-neptune-for-graphql/pull/75)), ([#76](https://github.com/aws/amazon-neptune-for-graphql/pull/76)))
 * Allow filtering using string comparison operators `eq`, `contains`, `startsWith`, `endsWith` (([#100](https://github.com/aws/amazon-neptune-for-graphql/pull/100))
 * Added pagination support through the addition of an `offset` argument in query options which can be used in combination with the existing `limit` (([#102](https://github.com/aws/amazon-neptune-for-graphql/pull/102))
+* Added support for queries with sorting ([#105](https://github.com/aws/amazon-neptune-for-graphql/pull/105))
 
 
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -312,8 +312,9 @@ When using custom scalars in your schema (specified via `--input-schema-file`), 
 - Schemas specified by `--input-schema-file` with `--create-update-aws-pipeline` may not contain custom scalars. See [AWS App Sync Scalar types in GraphQL](https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html) for more information.
 - Schemas specified by `--input-schema-file` with `--create-update-apollo-server` or `--create-update-apollo-server-subgraph` which contain custom scalars require manual steps to add custom scalar resolvers for additional query validation.
 - Query fragments are supported for Apollo Server but not yet for App Sync
-- Inline fragments are not yet supported
-  <br>
+- Inline fragments are not yet supported 
+- When working with sort values as variables, Apollo Server may not support an array variable but will accept variables inside an array. For example ```sort: $test``` with variable ```{"test": [{"country": "ASC"}]}``` may produce an error but can be modified to ```sort: [$test]``` with variable ```{"test": {"country": "ASC"}}```.  
+<br>
 
 # Roadmap
 - Gremlin resolver.

--- a/src/test/airports-mutations.graphql
+++ b/src/test/airports-mutations.graphql
@@ -1,9 +1,14 @@
+enum SortingDirection {
+  ASC
+  DESC
+}
+
 type Continent @alias(property:"continent") {
   _id: ID! @id
   type: String
   code: String
   desc: String
-  airportContainssOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType:"contains", direction:OUT)
+  airportContainssOut(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport] @relationship(edgeType:"contains", direction:OUT)
   contains:Contains
 }
 
@@ -28,12 +33,19 @@ input ContinentUpdateInput {
   desc: String
 }
 
+input ContinentSort {
+  _id: SortingDirection
+  type: SortingDirection
+  code: SortingDirection
+  desc: SortingDirection
+}
+
 type Country @alias(property:"country") {
   _id: ID! @id
   type: String
   code: String
   desc: String
-  airportContainssOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType:"contains", direction:OUT)
+  airportContainssOut(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport] @relationship(edgeType:"contains", direction:OUT)
   contains:Contains
 }
 
@@ -56,6 +68,13 @@ input CountryUpdateInput {
   type: String
   code: String
   desc: String
+}
+
+input CountrySort {
+  _id: SortingDirection
+  type: SortingDirection
+  code: SortingDirection
+  desc: SortingDirection
 }
 
 type Version @alias(property:"version") {
@@ -94,6 +113,15 @@ input VersionUpdateInput {
   code: String
 }
 
+input VersionSort {
+  _id: SortingDirection
+  date: SortingDirection
+  desc: SortingDirection
+  author: SortingDirection
+  type: SortingDirection
+  code: SortingDirection
+}
+
 type Airport @alias(property:"airport") {
   _id: ID! @id
   type: String
@@ -110,8 +138,8 @@ type Airport @alias(property:"airport") {
   elev: Int
   continentContainsIn: Continent @relationship(edgeType:"contains", direction:IN)
   countryContainsIn: Country @relationship(edgeType:"contains", direction:IN)
-  airportRoutesOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType:"route", direction:OUT)
-  airportRoutesIn(filter: AirportInput, options: Options): [Airport] @relationship(edgeType:"route", direction:IN)
+  airportRoutesOut(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport] @relationship(edgeType:"route", direction:OUT)
+  airportRoutesIn(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport] @relationship(edgeType:"route", direction:IN)
   contains:Contains
   route:Route
 }
@@ -164,6 +192,22 @@ input AirportUpdateInput {
   elev: Int
 }
 
+input AirportSort {
+  _id: SortingDirection
+  type: SortingDirection
+  city: SortingDirection
+  icao: SortingDirection
+  code: SortingDirection
+  country: SortingDirection
+  lat: SortingDirection
+  longest: SortingDirection
+  runways: SortingDirection
+  desc: SortingDirection
+  lon: SortingDirection
+  region: SortingDirection
+  elev: SortingDirection
+}
+
 type Contains @alias(property:"contains") {
   _id: ID! @id
 }
@@ -191,13 +235,13 @@ input StringScalarFilters {
 
 type Query {
   getNodeContinent(filter: ContinentInput): Continent
-  getNodeContinents(filter: ContinentInput, options: Options): [Continent]
+  getNodeContinents(filter: ContinentInput, options: Options, sort: [ContinentSort!]): [Continent]
   getNodeCountry(filter: CountryInput): Country
-  getNodeCountrys(filter: CountryInput, options: Options): [Country]
+  getNodeCountrys(filter: CountryInput, options: Options, sort: [CountrySort!]): [Country]
   getNodeVersion(filter: VersionInput): Version
-  getNodeVersions(filter: VersionInput, options: Options): [Version]
+  getNodeVersions(filter: VersionInput, options: Options, sort: [VersionSort!]): [Version]
   getNodeAirport(filter: AirportInput): Airport
-  getNodeAirports(filter: AirportInput, options: Options): [Airport]
+  getNodeAirports(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport]
 }
 
 type Mutation {

--- a/src/test/airports.customized.graphql
+++ b/src/test/airports.customized.graphql
@@ -1,10 +1,15 @@
-type Continent @alias(property:"continent") {
-_id: ID! @id
-type: String
-code: String
-desc: String
-airportContainssOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType:"contains", direction:OUT)
-contains:Contains
+enum SortingDirection {
+  ASC
+  DESC
+}
+
+type Continent @alias(property: "continent") {
+  _id: ID! @id
+  type: String
+  code: String
+  desc: String
+  airportContainssOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "contains", direction: OUT)
+  contains: Contains
 }
 
 input ContinentInput {
@@ -28,13 +33,20 @@ input ContinentUpdateInput {
   desc: String
 }
 
-type Country @alias(property:"country") {
-_id: ID! @id
-type: String
-code: String
-desc: String
-airportContainssOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType:"contains", direction:OUT)
-contains:Contains
+input ContinentSort {
+  _id: SortingDirection
+  type: SortingDirection
+  code: SortingDirection
+  desc: SortingDirection
+}
+
+type Country @alias(property: "country") {
+  _id: ID! @id
+  type: String
+  code: String
+  desc: String
+  airportContainssOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "contains", direction: OUT)
+  contains: Contains
 }
 
 input CountryInput {
@@ -58,13 +70,20 @@ input CountryUpdateInput {
   desc: String
 }
 
-type Version @alias(property:"version") {
-_id: ID! @id
-date: String
-desc: String
-author: String
-type: String
-code: String
+input CountrySort {
+  _id: SortingDirection
+  type: SortingDirection
+  code: SortingDirection
+  desc: SortingDirection
+}
+
+type Version @alias(property: "version") {
+  _id: ID! @id
+  date: String
+  desc: String
+  author: String
+  type: String
+  code: String
 }
 
 input VersionInput {
@@ -94,27 +113,36 @@ input VersionUpdateInput {
   code: String
 }
 
-type Airport @alias(property:"airport") {
-_id: ID! @id
-type: String
-city: String
-icao: String
-code: String
-country: String
-lat: Float
-longest: Int
-runways: Int
-desc: String
-lon: Float
-region: String
-elev: Int
-outboundRoutesCount: Int @graphQuery(statement: "MATCH (this)-[r:route]->(a) RETURN count(r)")
-continentContainsIn: Continent @relationship(edgeType:"contains", direction:IN)
-countryContainsIn: Country @relationship(edgeType:"contains", direction:IN)
-airportRoutesOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType:"route", direction:OUT)
-airportRoutesIn(filter: AirportInput, options: Options): [Airport] @relationship(edgeType:"route", direction:IN)
-contains:Contains
-route:Route
+input VersionSort {
+  _id: SortingDirection
+  date: SortingDirection
+  desc: SortingDirection
+  author: SortingDirection
+  type: SortingDirection
+  code: SortingDirection
+}
+
+type Airport @alias(property: "airport") {
+  _id: ID! @id
+  type: String
+  city: String
+  icao: String
+  code: String
+  country: String
+  lat: Float
+  longest: Int
+  runways: Int
+  desc: String
+  lon: Float
+  region: String
+  elev: Int
+  outboundRoutesCount: Int @graphQuery(statement: "MATCH (this)-[r:route]->(a) RETURN count(r)")
+  continentContainsIn: Continent @relationship(edgeType:"contains", direction:IN)
+  countryContainsIn: Country @relationship(edgeType:"contains", direction:IN)
+  airportRoutesOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType:"route", direction:OUT)
+  airportRoutesIn(filter: AirportInput, options: Options): [Airport] @relationship(edgeType:"route", direction:IN)
+  contains:Contains
+  route:Route
 }
 
 input AirportInput {
@@ -165,6 +193,22 @@ input AirportUpdateInput {
   elev: Int
 }
 
+input AirportSort {
+  _id: SortingDirection
+  type: SortingDirection
+  city: SortingDirection
+  icao: SortingDirection
+  code: SortingDirection
+  country: SortingDirection
+  lat: SortingDirection
+  longest: SortingDirection
+  runways: SortingDirection
+  desc: SortingDirection
+  lon: SortingDirection
+  region: SortingDirection
+  elev: SortingDirection
+}
+
 type Contains @alias(property:"contains") {
 _id: ID! @id
 }
@@ -196,13 +240,13 @@ getAirportConnection(fromCode: String!, toCode: String!): Airport @cypher(statem
 getContinentsWithGremlin: [Continent] @graphQuery(statement: "g.V().hasLabel('continent').elementMap().fold()")
 getCountriesCountGremlin: Int @graphQuery(statement: "g.V().hasLabel('country').count()")
 getNodeContinent(filter: ContinentInput): Continent
-getNodeContinents(filter: ContinentInput, options: Options): [Continent]
+getNodeContinents(filter: ContinentInput, options: Options, sort: [ContinentSort!]): [Continent]
 getNodeCountry(filter: CountryInput): Country
-getNodeCountrys(filter: CountryInput, options: Options): [Country]
+getNodeCountrys(filter: CountryInput, options: Options, sort: [CountrySort!]): [Country]
 getNodeVersion(filter: VersionInput): Version
-getNodeVersions(filter: VersionInput, options: Options): [Version]
+getNodeVersions(filter: VersionInput, options: Options, sort: [VersionSort!]): [Version]
 getNodeAirport(filter: AirportInput): Airport
-getNodeAirports(filter: AirportInput, options: Options): [Airport]
+getNodeAirports(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport]
 getAirportWithGremlin(code: String): Airport @graphQuery(statement: "g.V().has('airport', 'code', '$code').elementMap()")
 getCountriesCount: Int @graphQuery(statement: "g.V().hasLabel('country').count()")
 }

--- a/src/test/airports.graphql
+++ b/src/test/airports.graphql
@@ -1,9 +1,14 @@
+enum SortingDirection {
+    ASC
+    DESC
+}
+
 type Continent @alias(property: "continent") {
     _id: ID! @id
     type: String
     code: String
     desc: String
-    airportContainssOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "contains", direction: OUT)
+    airportContainssOut(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport] @relationship(edgeType: "contains", direction: OUT)
     contains: Contains
 }
 
@@ -14,12 +19,19 @@ input ContinentInput {
     desc: StringScalarFilters
 }
 
+input ContinentSort {
+    _id: SortingDirection
+    type: SortingDirection
+    code: SortingDirection
+    desc: SortingDirection
+}
+
 type Country @alias(property: "country") {
     _id: ID! @id
     type: String
     code: String
     desc: String
-    airportContainssOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "contains", direction: OUT)
+    airportContainssOut(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport] @relationship(edgeType: "contains", direction: OUT)
     contains: Contains
 }
 
@@ -28,6 +40,13 @@ input CountryInput {
     type: StringScalarFilters
     code: StringScalarFilters
     desc: StringScalarFilters
+}
+
+input CountrySort {
+    _id: SortingDirection
+    type: SortingDirection
+    code: SortingDirection
+    desc: SortingDirection
 }
 
 type Version @alias(property: "version") {
@@ -48,6 +67,15 @@ input VersionInput {
     code: StringScalarFilters
 }
 
+input VersionSort {
+    _id: SortingDirection
+    date: SortingDirection
+    desc: SortingDirection
+    author: SortingDirection
+    type: SortingDirection
+    code: SortingDirection
+}
+
 type Airport @alias(property: "airport") {
     _id: ID! @id
     type: String
@@ -64,8 +92,8 @@ type Airport @alias(property: "airport") {
     elev: Int
     continentContainsIn: Continent @relationship(edgeType: "contains", direction: IN)
     countryContainsIn: Country @relationship(edgeType: "contains", direction: IN)
-    airportRoutesOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "route", direction: OUT)
-    airportRoutesIn(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "route", direction: IN)
+    airportRoutesOut(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport] @relationship(edgeType: "route", direction: OUT)
+    airportRoutesIn(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport] @relationship(edgeType: "route", direction: IN)
     contains: Contains
     route: Route
 }
@@ -84,6 +112,22 @@ input AirportInput {
     lon: Float
     region: StringScalarFilters
     elev: Int
+}
+
+input AirportSort {
+    _id: SortingDirection
+    type: SortingDirection
+    city: SortingDirection
+    icao: SortingDirection
+    code: SortingDirection
+    country: SortingDirection
+    lat: SortingDirection
+    longest: SortingDirection
+    runways: SortingDirection
+    desc: SortingDirection
+    lon: SortingDirection
+    region: SortingDirection
+    elev: SortingDirection
 }
 
 type Contains @alias(property: "contains") {
@@ -113,13 +157,13 @@ input StringScalarFilters {
 
 type Query {
     getNodeContinent(filter: ContinentInput): Continent
-    getNodeContinents(filter: ContinentInput, options: Options): [Continent]
+    getNodeContinents(filter: ContinentInput, options: Options, sort: [ContinentSort!]): [Continent]
     getNodeCountry(filter: CountryInput): Country
-    getNodeCountrys(filter: CountryInput, options: Options): [Country]
+    getNodeCountrys(filter: CountryInput, options: Options, sort: [CountrySort!]): [Country]
     getNodeVersion(filter: VersionInput): Version
-    getNodeVersions(filter: VersionInput, options: Options): [Version]
+    getNodeVersions(filter: VersionInput, options: Options, sort: [VersionSort!]): [Version]
     getNodeAirport(filter: AirportInput): Airport
-    getNodeAirports(filter: AirportInput, options: Options): [Airport]
+    getNodeAirports(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport]
 }
 
 schema {

--- a/src/test/dining.graphql
+++ b/src/test/dining.graphql
@@ -1,8 +1,13 @@
+enum SortingDirection {
+    ASC
+    DESC
+}
+
 type City @alias(property: "city") {
     _id: ID! @id
     name: String
-    personLivessIn(filter: PersonInput, options: Options): [Person] @relationship(edgeType: "lives", direction: IN)
-    restaurantWithinsIn(filter: RestaurantInput, options: Options): [Restaurant] @relationship(edgeType: "within", direction: IN)
+    personLivessIn(filter: PersonInput, options: Options, sort: [PersonSort!]): [Person] @relationship(edgeType: "lives", direction: IN)
+    restaurantWithinsIn(filter: RestaurantInput, options: Options, sort: [RestaurantSort!]): [Restaurant] @relationship(edgeType: "within", direction: IN)
     lives: Lives
     within: Within
 }
@@ -10,6 +15,11 @@ type City @alias(property: "city") {
 input CityInput {
     _id: ID @id
     name: StringScalarFilters
+}
+
+input CitySort {
+    _id: SortingDirection
+    name: SortingDirection
 }
 
 type Review @alias(property: "review") {
@@ -30,15 +40,22 @@ input ReviewInput {
     rating: Int
 }
 
+input ReviewSort {
+    _id: SortingDirection
+    body: SortingDirection
+    created_date: SortingDirection
+    rating: SortingDirection
+}
+
 type Person @alias(property: "person") {
     _id: ID! @id
     first_name: String
     last_name: String
     person_id: Int
     cityLivesOut: City @relationship(edgeType: "lives", direction: OUT)
-    reviewWrotesOut(filter: ReviewInput, options: Options): [Review] @relationship(edgeType: "wrote", direction: OUT)
-    personFriendssOut(filter: PersonInput, options: Options): [Person] @relationship(edgeType: "friends", direction: OUT)
-    personFriendssIn(filter: PersonInput, options: Options): [Person] @relationship(edgeType: "friends", direction: IN)
+    reviewWrotesOut(filter: ReviewInput, options: Options, sort: [ReviewSort!]): [Review] @relationship(edgeType: "wrote", direction: OUT)
+    personFriendssOut(filter: PersonInput, options: Options, sort: [PersonSort!]): [Person] @relationship(edgeType: "friends", direction: OUT)
+    personFriendssIn(filter: PersonInput, options: Options, sort: [PersonSort!]): [Person] @relationship(edgeType: "friends", direction: IN)
     lives: Lives
     wrote: Wrote
     friends: Friends
@@ -51,6 +68,13 @@ input PersonInput {
     person_id: Int
 }
 
+input PersonSort {
+    _id: SortingDirection
+    first_name: SortingDirection
+    last_name: SortingDirection
+    person_id: SortingDirection
+}
+
 type Restaurant @alias(property: "restaurant") {
     _id: ID! @id
     restaurant_id: Int
@@ -58,7 +82,7 @@ type Restaurant @alias(property: "restaurant") {
     address: String
     cityWithinOut: City @relationship(edgeType: "within", direction: OUT)
     cuisineServesOut: Cuisine @relationship(edgeType: "serves", direction: OUT)
-    reviewAboutsIn(filter: ReviewInput, options: Options): [Review] @relationship(edgeType: "about", direction: IN)
+    reviewAboutsIn(filter: ReviewInput, options: Options, sort: [ReviewSort!]): [Review] @relationship(edgeType: "about", direction: IN)
     within: Within
     serves: Serves
     about: About
@@ -71,16 +95,28 @@ input RestaurantInput {
     address: StringScalarFilters
 }
 
+input RestaurantSort {
+    _id: SortingDirection
+    restaurant_id: SortingDirection
+    name: SortingDirection
+    address: SortingDirection
+}
+
 type Cuisine @alias(property: "cuisine") {
     _id: ID! @id
     name: String
-    restaurantServessIn(filter: RestaurantInput, options: Options): [Restaurant] @relationship(edgeType: "serves", direction: IN)
+    restaurantServessIn(filter: RestaurantInput, options: Options, sort: [RestaurantSort!]): [Restaurant] @relationship(edgeType: "serves", direction: IN)
     serves: Serves
 }
 
 input CuisineInput {
     _id: ID @id
     name: StringScalarFilters
+}
+
+input CuisineSort {
+    _id: SortingDirection
+    name: SortingDirection
 }
 
 type State @alias(property: "state") {
@@ -92,6 +128,11 @@ type State @alias(property: "state") {
 input StateInput {
     _id: ID @id
     name: StringScalarFilters
+}
+
+input StateSort {
+    _id: SortingDirection
+    name: SortingDirection
 }
 
 type Lives @alias(property: "lives") {
@@ -132,17 +173,17 @@ input StringScalarFilters {
 
 type Query {
     getNodeCity(filter: CityInput): City
-    getNodeCitys(filter: CityInput, options: Options): [City]
+    getNodeCitys(filter: CityInput, options: Options, sort: [CitySort!]): [City]
     getNodeReview(filter: ReviewInput): Review
-    getNodeReviews(filter: ReviewInput, options: Options): [Review]
+    getNodeReviews(filter: ReviewInput, options: Options, sort: [ReviewSort!]): [Review]
     getNodePerson(filter: PersonInput): Person
-    getNodePersons(filter: PersonInput, options: Options): [Person]
+    getNodePersons(filter: PersonInput, options: Options, sort: [PersonSort!]): [Person]
     getNodeRestaurant(filter: RestaurantInput): Restaurant
-    getNodeRestaurants(filter: RestaurantInput, options: Options): [Restaurant]
+    getNodeRestaurants(filter: RestaurantInput, options: Options, sort: [RestaurantSort!]): [Restaurant]
     getNodeCuisine(filter: CuisineInput): Cuisine
-    getNodeCuisines(filter: CuisineInput, options: Options): [Cuisine]
+    getNodeCuisines(filter: CuisineInput, options: Options, sort: [CuisineSort!]): [Cuisine]
     getNodeState(filter: StateInput): State
-    getNodeStates(filter: StateInput, options: Options): [State]
+    getNodeStates(filter: StateInput, options: Options, sort: [StateSort!]): [State]
 }
 
 schema {

--- a/src/test/epl.graphql
+++ b/src/test/epl.graphql
@@ -1,3 +1,8 @@
+enum SortingDirection {
+    ASC
+    DESC
+}
+
 type Stadium {
     _id: ID! @id
     opened: Int
@@ -15,11 +20,18 @@ input StadiumInput {
     name: StringScalarFilters
 }
 
+input StadiumSort {
+    _id: SortingDirection
+    opened: SortingDirection
+    capacity: SortingDirection
+    name: SortingDirection
+}
+
 type League {
     _id: ID! @id
     nickname: String
     name: String
-    teamCurrent_leaguesIn(filter: TeamInput, options: Options): [Team] @relationship(edgeType: "CURRENT_LEAGUE", direction: IN)
+    teamCurrent_leaguesIn(filter: TeamInput, options: Options, sort: [TeamSort!]): [Team] @relationship(edgeType: "CURRENT_LEAGUE", direction: IN)
     CURRENT_LEAGUE: Current_league
 }
 
@@ -27,6 +39,12 @@ input LeagueInput {
     _id: ID @id
     nickname: StringScalarFilters
     name: StringScalarFilters
+}
+
+input LeagueSort {
+    _id: SortingDirection
+    nickname: SortingDirection
+    name: SortingDirection
 }
 
 type Team {
@@ -48,16 +66,29 @@ input TeamInput {
     founded: Int
 }
 
+input TeamSort {
+    _id: SortingDirection
+    nickname: SortingDirection
+    name: SortingDirection
+    fullName: SortingDirection
+    founded: SortingDirection
+}
+
 type City {
     _id: ID! @id
     name: String
-    stadiumCity_edgesIn(filter: StadiumInput, options: Options): [Stadium] @relationship(edgeType: "CITY_EDGE", direction: IN)
+    stadiumCity_edgesIn(filter: StadiumInput, options: Options, sort: [StadiumSort!]): [Stadium] @relationship(edgeType: "CITY_EDGE", direction: IN)
     CITY_EDGE: City_edge
 }
 
 input CityInput {
     _id: ID @id
     name: StringScalarFilters
+}
+
+input CitySort {
+    _id: SortingDirection
+    name: SortingDirection
 }
 
 type City_edge @alias(property: "CITY_EDGE") {
@@ -86,13 +117,13 @@ input StringScalarFilters {
 
 type Query {
     getNodeStadium(filter: StadiumInput): Stadium
-    getNodeStadiums(filter: StadiumInput, options: Options): [Stadium]
+    getNodeStadiums(filter: StadiumInput, options: Options, sort: [StadiumSort!]): [Stadium]
     getNodeLeague(filter: LeagueInput): League
-    getNodeLeagues(filter: LeagueInput, options: Options): [League]
+    getNodeLeagues(filter: LeagueInput, options: Options, sort: [LeagueSort!]): [League]
     getNodeTeam(filter: TeamInput): Team
-    getNodeTeams(filter: TeamInput, options: Options): [Team]
+    getNodeTeams(filter: TeamInput, options: Options, sort: [TeamSort!]): [Team]
     getNodeCity(filter: CityInput): City
-    getNodeCitys(filter: CityInput, options: Options): [City]
+    getNodeCitys(filter: CityInput, options: Options, sort: [CitySort!]): [City]
 }
 
 schema {

--- a/src/test/fraud.graphql
+++ b/src/test/fraud.graphql
@@ -1,7 +1,12 @@
+enum SortingDirection {
+    ASC
+    DESC
+}
+
 type Dateofbirth @alias(property: "DateOfBirth") {
     _id: ID! @id
     value: String
-    accountFeature_of_accountsOut(filter: AccountInput, options: Options): [Account] @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: OUT)
+    accountFeature_of_accountsOut(filter: AccountInput, options: Options, sort: [AccountSort!]): [Account] @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: OUT)
     FEATURE_OF_ACCOUNT: Feature_of_account
 }
 
@@ -10,17 +15,22 @@ input DateofbirthInput {
     value: StringScalarFilters
 }
 
+input DateofbirthSort {
+    _id: SortingDirection
+    value: SortingDirection
+}
+
 type Account {
     _id: ID! @id
     first_name: String
     account_number: String
     last_name: String
-    emailaddressFeature_of_accountsIn(filter: EmailaddressInput, options: Options): [Emailaddress] @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: IN)
+    emailaddressFeature_of_accountsIn(filter: EmailaddressInput, options: Options, sort: [EmailaddressSort!]): [Emailaddress] @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: IN)
     ipaddressFeature_of_accountIn: Ipaddress @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: IN)
     addressFeature_of_accountIn: Address @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: IN)
     dateofbirthFeature_of_accountIn: Dateofbirth @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: IN)
-    phonenumberFeature_of_accountsIn(filter: PhonenumberInput, options: Options): [Phonenumber] @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: IN)
-    transactionAccount_edgesIn(filter: TransactionInput, options: Options): [Transaction] @relationship(edgeType: "ACCOUNT_EDGE", direction: IN)
+    phonenumberFeature_of_accountsIn(filter: PhonenumberInput, options: Options, sort: [PhonenumberSort!]): [Phonenumber] @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: IN)
+    transactionAccount_edgesIn(filter: TransactionInput, options: Options, sort: [TransactionSort!]): [Transaction] @relationship(edgeType: "ACCOUNT_EDGE", direction: IN)
     FEATURE_OF_ACCOUNT: Feature_of_account
     ACCOUNT_EDGE: Account_edge
 }
@@ -32,16 +42,28 @@ input AccountInput {
     last_name: StringScalarFilters
 }
 
+input AccountSort {
+    _id: SortingDirection
+    first_name: SortingDirection
+    account_number: SortingDirection
+    last_name: SortingDirection
+}
+
 type Merchant {
     _id: ID! @id
     name: String
-    transactionMerchant_edgesIn(filter: TransactionInput, options: Options): [Transaction] @relationship(edgeType: "MERCHANT_EDGE", direction: IN)
+    transactionMerchant_edgesIn(filter: TransactionInput, options: Options, sort: [TransactionSort!]): [Transaction] @relationship(edgeType: "MERCHANT_EDGE", direction: IN)
     MERCHANT_EDGE: Merchant_edge
 }
 
 input MerchantInput {
     _id: ID @id
     name: StringScalarFilters
+}
+
+input MerchantSort {
+    _id: SortingDirection
+    name: SortingDirection
 }
 
 type Transaction {
@@ -63,10 +85,16 @@ input TransactionInput {
     created: StringScalarFilters
 }
 
+input TransactionSort {
+    _id: SortingDirection
+    amount: SortingDirection
+    created: SortingDirection
+}
+
 type Address {
     _id: ID! @id
     value: String
-    accountFeature_of_accountsOut(filter: AccountInput, options: Options): [Account] @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: OUT)
+    accountFeature_of_accountsOut(filter: AccountInput, options: Options, sort: [AccountSort!]): [Account] @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: OUT)
     FEATURE_OF_ACCOUNT: Feature_of_account
 }
 
@@ -75,11 +103,16 @@ input AddressInput {
     value: StringScalarFilters
 }
 
+input AddressSort {
+    _id: SortingDirection
+    value: SortingDirection
+}
+
 type Phonenumber @alias(property: "PhoneNumber") {
     _id: ID! @id
     value: String
-    accountFeature_of_accountsOut(filter: AccountInput, options: Options): [Account] @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: OUT)
-    transactionFeature_of_transactionsOut(filter: TransactionInput, options: Options): [Transaction] @relationship(edgeType: "FEATURE_OF_TRANSACTION", direction: OUT)
+    accountFeature_of_accountsOut(filter: AccountInput, options: Options, sort: [AccountSort!]): [Account] @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: OUT)
+    transactionFeature_of_transactionsOut(filter: TransactionInput, options: Options, sort: [TransactionSort!]): [Transaction] @relationship(edgeType: "FEATURE_OF_TRANSACTION", direction: OUT)
     FEATURE_OF_ACCOUNT: Feature_of_account
     FEATURE_OF_TRANSACTION: Feature_of_transaction
 }
@@ -89,11 +122,16 @@ input PhonenumberInput {
     value: StringScalarFilters
 }
 
+input PhonenumberSort {
+    _id: SortingDirection
+    value: SortingDirection
+}
+
 type Ipaddress @alias(property: "IpAddress") {
     _id: ID! @id
     value: String
-    accountFeature_of_accountsOut(filter: AccountInput, options: Options): [Account] @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: OUT)
-    transactionFeature_of_transactionsOut(filter: TransactionInput, options: Options): [Transaction] @relationship(edgeType: "FEATURE_OF_TRANSACTION", direction: OUT)
+    accountFeature_of_accountsOut(filter: AccountInput, options: Options, sort: [AccountSort!]): [Account] @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: OUT)
+    transactionFeature_of_transactionsOut(filter: TransactionInput, options: Options, sort: [TransactionSort!]): [Transaction] @relationship(edgeType: "FEATURE_OF_TRANSACTION", direction: OUT)
     FEATURE_OF_ACCOUNT: Feature_of_account
     FEATURE_OF_TRANSACTION: Feature_of_transaction
 }
@@ -103,16 +141,26 @@ input IpaddressInput {
     value: StringScalarFilters
 }
 
+input IpaddressSort {
+    _id: SortingDirection
+    value: SortingDirection
+}
+
 type Emailaddress @alias(property: "EmailAddress") {
     _id: ID! @id
     value: String
-    accountFeature_of_accountsOut(filter: AccountInput, options: Options): [Account] @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: OUT)
+    accountFeature_of_accountsOut(filter: AccountInput, options: Options, sort: [AccountSort!]): [Account] @relationship(edgeType: "FEATURE_OF_ACCOUNT", direction: OUT)
     FEATURE_OF_ACCOUNT: Feature_of_account
 }
 
 input EmailaddressInput {
     _id: ID @id
     value: StringScalarFilters
+}
+
+input EmailaddressSort {
+    _id: SortingDirection
+    value: SortingDirection
 }
 
 type Feature_of_account @alias(property: "FEATURE_OF_ACCOUNT") {
@@ -145,21 +193,21 @@ input StringScalarFilters {
 
 type Query {
     getNodeDateofbirth(filter: DateofbirthInput): Dateofbirth
-    getNodeDateofbirths(filter: DateofbirthInput, options: Options): [Dateofbirth]
+    getNodeDateofbirths(filter: DateofbirthInput, options: Options, sort: [DateofbirthSort!]): [Dateofbirth]
     getNodeAccount(filter: AccountInput): Account
-    getNodeAccounts(filter: AccountInput, options: Options): [Account]
+    getNodeAccounts(filter: AccountInput, options: Options, sort: [AccountSort!]): [Account]
     getNodeMerchant(filter: MerchantInput): Merchant
-    getNodeMerchants(filter: MerchantInput, options: Options): [Merchant]
+    getNodeMerchants(filter: MerchantInput, options: Options, sort: [MerchantSort!]): [Merchant]
     getNodeTransaction(filter: TransactionInput): Transaction
-    getNodeTransactions(filter: TransactionInput, options: Options): [Transaction]
+    getNodeTransactions(filter: TransactionInput, options: Options, sort: [TransactionSort!]): [Transaction]
     getNodeAddress(filter: AddressInput): Address
-    getNodeAddresss(filter: AddressInput, options: Options): [Address]
+    getNodeAddresss(filter: AddressInput, options: Options, sort: [AddressSort!]): [Address]
     getNodePhonenumber(filter: PhonenumberInput): Phonenumber
-    getNodePhonenumbers(filter: PhonenumberInput, options: Options): [Phonenumber]
+    getNodePhonenumbers(filter: PhonenumberInput, options: Options, sort: [PhonenumberSort!]): [Phonenumber]
     getNodeIpaddress(filter: IpaddressInput): Ipaddress
-    getNodeIpaddresss(filter: IpaddressInput, options: Options): [Ipaddress]
+    getNodeIpaddresss(filter: IpaddressInput, options: Options, sort: [IpaddressSort!]): [Ipaddress]
     getNodeEmailaddress(filter: EmailaddressInput): Emailaddress
-    getNodeEmailaddresss(filter: EmailaddressInput, options: Options): [Emailaddress]
+    getNodeEmailaddresss(filter: EmailaddressInput, options: Options, sort: [EmailaddressSort!]): [Emailaddress]
 }
 
 schema {

--- a/src/test/knowledge.graphql
+++ b/src/test/knowledge.graphql
@@ -1,8 +1,13 @@
+enum SortingDirection {
+    ASC
+    DESC
+}
+
 type Date @alias(property: "date") {
     _id: ID! @id
     type: String
     text: String
-    postFound_insIn(filter: PostInput, options: Options): [Post] @relationship(edgeType: "found_in", direction: IN)
+    postFound_insIn(filter: PostInput, options: Options, sort: [PostSort!]): [Post] @relationship(edgeType: "found_in", direction: IN)
     found_in: Found_in
 }
 
@@ -10,6 +15,12 @@ input DateInput {
     _id: ID @id
     type: StringScalarFilters
     text: StringScalarFilters
+}
+
+input DateSort {
+    _id: SortingDirection
+    type: SortingDirection
+    text: SortingDirection
 }
 
 type Other @alias(property: "other") {
@@ -26,18 +37,24 @@ input OtherInput {
     text: StringScalarFilters
 }
 
+input OtherSort {
+    _id: SortingDirection
+    type: SortingDirection
+    text: SortingDirection
+}
+
 type Post @alias(property: "post") {
     _id: ID! @id
     title: String
     post_date: String
-    tagTaggedsOut(filter: TagInput, options: Options): [Tag] @relationship(edgeType: "tagged", direction: OUT)
-    organizationFound_insOut(filter: OrganizationInput, options: Options): [Organization] @relationship(edgeType: "found_in", direction: OUT)
-    titleFound_insOut(filter: TitleInput, options: Options): [Title] @relationship(edgeType: "found_in", direction: OUT)
-    locationFound_insOut(filter: LocationInput, options: Options): [Location] @relationship(edgeType: "found_in", direction: OUT)
-    dateFound_insOut(filter: DateInput, options: Options): [Date] @relationship(edgeType: "found_in", direction: OUT)
-    commercial_itemFound_insOut(filter: Commercial_itemInput, options: Options): [Commercial_item] @relationship(edgeType: "found_in", direction: OUT)
-    otherFound_insOut(filter: OtherInput, options: Options): [Other] @relationship(edgeType: "found_in", direction: OUT)
-    authorWritten_bysOut(filter: AuthorInput, options: Options): [Author] @relationship(edgeType: "written_by", direction: OUT)
+    tagTaggedsOut(filter: TagInput, options: Options, sort: [TagSort!]): [Tag] @relationship(edgeType: "tagged", direction: OUT)
+    organizationFound_insOut(filter: OrganizationInput, options: Options, sort: [OrganizationSort!]): [Organization] @relationship(edgeType: "found_in", direction: OUT)
+    titleFound_insOut(filter: TitleInput, options: Options, sort: [TitleSort!]): [Title] @relationship(edgeType: "found_in", direction: OUT)
+    locationFound_insOut(filter: LocationInput, options: Options, sort: [LocationSort!]): [Location] @relationship(edgeType: "found_in", direction: OUT)
+    dateFound_insOut(filter: DateInput, options: Options, sort: [DateSort!]): [Date] @relationship(edgeType: "found_in", direction: OUT)
+    commercial_itemFound_insOut(filter: Commercial_itemInput, options: Options, sort: [Commercial_itemSort!]): [Commercial_item] @relationship(edgeType: "found_in", direction: OUT)
+    otherFound_insOut(filter: OtherInput, options: Options, sort: [OtherSort!]): [Other] @relationship(edgeType: "found_in", direction: OUT)
+    authorWritten_bysOut(filter: AuthorInput, options: Options, sort: [AuthorSort!]): [Author] @relationship(edgeType: "written_by", direction: OUT)
     tagged: Tagged
     found_in: Found_in
     written_by: Written_by
@@ -49,10 +66,16 @@ input PostInput {
     post_date: StringScalarFilters
 }
 
+input PostSort {
+    _id: SortingDirection
+    title: SortingDirection
+    post_date: SortingDirection
+}
+
 type Author @alias(property: "author") {
     _id: ID! @id
     name: String
-    postWritten_bysIn(filter: PostInput, options: Options): [Post] @relationship(edgeType: "written_by", direction: IN)
+    postWritten_bysIn(filter: PostInput, options: Options, sort: [PostSort!]): [Post] @relationship(edgeType: "written_by", direction: IN)
     written_by: Written_by
 }
 
@@ -61,11 +84,16 @@ input AuthorInput {
     name: StringScalarFilters
 }
 
+input AuthorSort {
+    _id: SortingDirection
+    name: SortingDirection
+}
+
 type Organization @alias(property: "organization") {
     _id: ID! @id
     type: String
     text: String
-    postFound_insIn(filter: PostInput, options: Options): [Post] @relationship(edgeType: "found_in", direction: IN)
+    postFound_insIn(filter: PostInput, options: Options, sort: [PostSort!]): [Post] @relationship(edgeType: "found_in", direction: IN)
     found_in: Found_in
 }
 
@@ -75,11 +103,17 @@ input OrganizationInput {
     text: StringScalarFilters
 }
 
+input OrganizationSort {
+    _id: SortingDirection
+    type: SortingDirection
+    text: SortingDirection
+}
+
 type Location @alias(property: "location") {
     _id: ID! @id
     type: String
     text: String
-    postFound_insIn(filter: PostInput, options: Options): [Post] @relationship(edgeType: "found_in", direction: IN)
+    postFound_insIn(filter: PostInput, options: Options, sort: [PostSort!]): [Post] @relationship(edgeType: "found_in", direction: IN)
     found_in: Found_in
 }
 
@@ -89,10 +123,16 @@ input LocationInput {
     text: StringScalarFilters
 }
 
+input LocationSort {
+    _id: SortingDirection
+    type: SortingDirection
+    text: SortingDirection
+}
+
 type Tag @alias(property: "tag") {
     _id: ID! @id
     tag: String
-    postTaggedsIn(filter: PostInput, options: Options): [Post] @relationship(edgeType: "tagged", direction: IN)
+    postTaggedsIn(filter: PostInput, options: Options, sort: [PostSort!]): [Post] @relationship(edgeType: "tagged", direction: IN)
     tagged: Tagged
 }
 
@@ -101,11 +141,16 @@ input TagInput {
     tag: StringScalarFilters
 }
 
+input TagSort {
+    _id: SortingDirection
+    tag: SortingDirection
+}
+
 type Title @alias(property: "title") {
     _id: ID! @id
     type: String
     text: String
-    postFound_insIn(filter: PostInput, options: Options): [Post] @relationship(edgeType: "found_in", direction: IN)
+    postFound_insIn(filter: PostInput, options: Options, sort: [PostSort!]): [Post] @relationship(edgeType: "found_in", direction: IN)
     found_in: Found_in
 }
 
@@ -115,11 +160,17 @@ input TitleInput {
     text: StringScalarFilters
 }
 
+input TitleSort {
+    _id: SortingDirection
+    type: SortingDirection
+    text: SortingDirection
+}
+
 type Commercial_item @alias(property: "commercial_item") {
     _id: ID! @id
     type: String
     text: String
-    postFound_insIn(filter: PostInput, options: Options): [Post] @relationship(edgeType: "found_in", direction: IN)
+    postFound_insIn(filter: PostInput, options: Options, sort: [PostSort!]): [Post] @relationship(edgeType: "found_in", direction: IN)
     found_in: Found_in
 }
 
@@ -127,6 +178,12 @@ input Commercial_itemInput {
     _id: ID @id
     type: StringScalarFilters
     text: StringScalarFilters
+}
+
+input Commercial_itemSort {
+    _id: SortingDirection
+    type: SortingDirection
+    text: SortingDirection
 }
 
 type Tagged @alias(property: "tagged") {
@@ -160,23 +217,23 @@ input StringScalarFilters {
 
 type Query {
     getNodeDate(filter: DateInput): Date
-    getNodeDates(filter: DateInput, options: Options): [Date]
+    getNodeDates(filter: DateInput, options: Options, sort: [DateSort!]): [Date]
     getNodeOther(filter: OtherInput): Other
-    getNodeOthers(filter: OtherInput, options: Options): [Other]
+    getNodeOthers(filter: OtherInput, options: Options, sort: [OtherSort!]): [Other]
     getNodePost(filter: PostInput): Post
-    getNodePosts(filter: PostInput, options: Options): [Post]
+    getNodePosts(filter: PostInput, options: Options, sort: [PostSort!]): [Post]
     getNodeAuthor(filter: AuthorInput): Author
-    getNodeAuthors(filter: AuthorInput, options: Options): [Author]
+    getNodeAuthors(filter: AuthorInput, options: Options, sort: [AuthorSort!]): [Author]
     getNodeOrganization(filter: OrganizationInput): Organization
-    getNodeOrganizations(filter: OrganizationInput, options: Options): [Organization]
+    getNodeOrganizations(filter: OrganizationInput, options: Options, sort: [OrganizationSort!]): [Organization]
     getNodeLocation(filter: LocationInput): Location
-    getNodeLocations(filter: LocationInput, options: Options): [Location]
+    getNodeLocations(filter: LocationInput, options: Options, sort: [LocationSort!]): [Location]
     getNodeTag(filter: TagInput): Tag
-    getNodeTags(filter: TagInput, options: Options): [Tag]
+    getNodeTags(filter: TagInput, options: Options, sort: [TagSort!]): [Tag]
     getNodeTitle(filter: TitleInput): Title
-    getNodeTitles(filter: TitleInput, options: Options): [Title]
+    getNodeTitles(filter: TitleInput, options: Options, sort: [TitleSort!]): [Title]
     getNodeCommercial_item(filter: Commercial_itemInput): Commercial_item
-    getNodeCommercial_items(filter: Commercial_itemInput, options: Options): [Commercial_item]
+    getNodeCommercial_items(filter: Commercial_itemInput, options: Options, sort: [Commercial_itemSort!]): [Commercial_item]
 }
 
 schema {

--- a/src/test/node-edge-same-label.graphql
+++ b/src/test/node-edge-same-label.graphql
@@ -1,3 +1,8 @@
+enum SortingDirection {
+    ASC
+    DESC
+}
+
 type post {
     _id: ID! @id
     text: String
@@ -9,6 +14,11 @@ input postInput {
     text: StringScalarFilters
 }
 
+input postSort {
+    _id: SortingDirection
+    text: SortingDirection
+}
+
 type author {
     _id: ID! @id
     username: String
@@ -18,6 +28,11 @@ type author {
 input authorInput {
     _id: ID @id
     username: StringScalarFilters
+}
+
+input authorSort {
+    _id: SortingDirection
+    username: SortingDirection
 }
 
 type _author @alias(property: "author") {
@@ -43,9 +58,9 @@ input StringScalarFilters {
 
 type Query {
     getNodepost(filter: postInput): post
-    getNodeposts(filter: postInput, options: Options): [post]
+    getNodeposts(filter: postInput, options: Options, sort: [postSort!]): [post]
     getNodeauthor(filter: authorInput): author
-    getNodeauthors(filter: authorInput, options: Options): [author]
+    getNodeauthors(filter: authorInput, options: Options, sort: [authorSort!]): [author]
 }
 
 schema {

--- a/src/test/security.graphql
+++ b/src/test/security.graphql
@@ -1,8 +1,13 @@
+enum SortingDirection {
+    ASC
+    DESC
+}
+
 type Image @alias(property: "image") {
     _id: ID! @id
     scan_id: String
     arn: String
-    ec2_cn_instanceTransient_resource_linksIn(filter: Ec2_cn_instanceInput, options: Options): [Ec2_cn_instance] @relationship(edgeType: "transient_resource_link", direction: IN)
+    ec2_cn_instanceTransient_resource_linksIn(filter: Ec2_cn_instanceInput, options: Options, sort: [Ec2_cn_instanceSort!]): [Ec2_cn_instance] @relationship(edgeType: "transient_resource_link", direction: IN)
     transient_resource_link: Transient_resource_link
 }
 
@@ -10,6 +15,12 @@ input ImageInput {
     _id: ID @id
     scan_id: StringScalarFilters
     arn: StringScalarFilters
+}
+
+input ImageSort {
+_id: SortingDirection
+scan_id: SortingDirection
+arn: SortingDirection
 }
 
 type Guardduty_cn_detector @alias(property: "guardduty:detector") {
@@ -34,6 +45,17 @@ input Guardduty_cn_detectorInput {
     finding_publishing_frequency: StringScalarFilters
 }
 
+input Guardduty_cn_detectorSort {
+    _id: SortingDirection
+    created_at: SortingDirection
+    updated_at: SortingDirection
+    scan_id: SortingDirection
+    status: SortingDirection
+    arn: SortingDirection
+    service_role: SortingDirection
+    finding_publishing_frequency: SortingDirection
+}
+
 type Ec2_cn_vpc @alias(property: "ec2:vpc") {
     _id: ID! @id
     scan_id: String
@@ -41,9 +63,9 @@ type Ec2_cn_vpc @alias(property: "ec2:vpc") {
     arn: String
     is_default: String
     cidr_block: String
-    ec2_cn_network_hy_interfaceResource_linksIn(filter: Ec2_cn_network_hy_interfaceInput, options: Options): [Ec2_cn_network_hy_interface] @relationship(edgeType: "resource_link", direction: IN)
-    ec2_cn_subnetResource_linksIn(filter: Ec2_cn_subnetInput, options: Options): [Ec2_cn_subnet] @relationship(edgeType: "resource_link", direction: IN)
-    ec2_cn_instanceResource_linksIn(filter: Ec2_cn_instanceInput, options: Options): [Ec2_cn_instance] @relationship(edgeType: "resource_link", direction: IN)
+    ec2_cn_network_hy_interfaceResource_linksIn(filter: Ec2_cn_network_hy_interfaceInput, options: Options, sort: [Ec2_cn_network_hy_interfaceSort!]): [Ec2_cn_network_hy_interface] @relationship(edgeType: "resource_link", direction: IN)
+    ec2_cn_subnetResource_linksIn(filter: Ec2_cn_subnetInput, options: Options, sort: [Ec2_cn_subnetSort!]): [Ec2_cn_subnet] @relationship(edgeType: "resource_link", direction: IN)
+    ec2_cn_instanceResource_linksIn(filter: Ec2_cn_instanceInput, options: Options, sort: [Ec2_cn_instanceSort!]): [Ec2_cn_instance] @relationship(edgeType: "resource_link", direction: IN)
     resource_link: Resource_link
     transient_resource_link: Transient_resource_link
 }
@@ -57,6 +79,15 @@ input Ec2_cn_vpcInput {
     cidr_block: StringScalarFilters
 }
 
+input Ec2_cn_vpcSort {
+    _id: SortingDirection
+    scan_id: SortingDirection
+    state: SortingDirection
+    arn: SortingDirection
+    is_default: SortingDirection
+    cidr_block: SortingDirection
+}
+
 type Iam_cn_role @alias(property: "iam:role") {
     _id: ID! @id
     name: String
@@ -68,7 +99,7 @@ type Iam_cn_role @alias(property: "iam:role") {
     nassume_role_policy_document_text: String
     scan_id: String
     assume_role_policy_document_dot_version: String @alias(property: "assume_role_policy_document.version")
-    iam_cn_policyResource_linksOut(filter: Iam_cn_policyInput, options: Options): [Iam_cn_policy] @relationship(edgeType: "resource_link", direction: OUT)
+    iam_cn_policyResource_linksOut(filter: Iam_cn_policyInput, options: Options, sort: [Iam_cn_policySort!]): [Iam_cn_policy] @relationship(edgeType: "resource_link", direction: OUT)
     resource_link: Resource_link
 }
 
@@ -83,6 +114,19 @@ input Iam_cn_roleInput {
     nassume_role_policy_document_text: StringScalarFilters
     scan_id: StringScalarFilters
     assume_role_policy_document_dot_version: StringScalarFilters @alias(property: "assume_role_policy_document.version")
+}
+
+input Iam_cn_roleSort {
+    _id: SortingDirection
+    name: SortingDirection
+    principal_dot_aws: SortingDirection @alias(property: "principal.aws")
+    statement_dot_effect: SortingDirection @alias(property: "statement.effect")
+    statement_dot_action: SortingDirection @alias(property: "statement.action")
+    max_session_duration: SortingDirection
+    arn: SortingDirection
+    nassume_role_policy_document_text: SortingDirection
+    scan_id: SortingDirection
+    assume_role_policy_document_dot_version: SortingDirection @alias(property: "assume_role_policy_document.version")
 }
 
 type Ec2_cn_network_hy_interface @alias(property: "ec2:network-interface") {
@@ -113,6 +157,20 @@ input Ec2_cn_network_hy_interfaceInput {
     status: StringScalarFilters
     interface_type: StringScalarFilters
     description: StringScalarFilters
+}
+
+input Ec2_cn_network_hy_interfaceSort {
+    _id: SortingDirection
+    public_ip: SortingDirection
+    public_dns_name: SortingDirection
+    arn: SortingDirection
+    private_ip_address: SortingDirection
+    mac_address: SortingDirection
+    scan_id: SortingDirection
+    private_dns_name: SortingDirection
+    status: SortingDirection
+    interface_type: SortingDirection
+    description: SortingDirection
 }
 
 type Rds_cn_db @alias(property: "rds:db") {
@@ -164,6 +222,30 @@ input Rds_cn_dbInput {
     engine: StringScalarFilters
 }
 
+input Rds_cn_dbSort {
+    _id: SortingDirection
+    storage_type: SortingDirection
+    performance_insights_enabled: SortingDirection
+    dbi_resource_id: SortingDirection
+    scan_id: SortingDirection
+    db_instance_identifier: SortingDirection
+    backup_retention_period: SortingDirection
+    publicly_accessible: SortingDirection
+    multi_az: SortingDirection
+    availability_zone: SortingDirection
+    arn: SortingDirection
+    storage_encrypted: SortingDirection
+    iam_database_authentication_enabled: SortingDirection
+    db_instance_class: SortingDirection
+    endpoint_hosted_zone: SortingDirection
+    deletion_protection: SortingDirection
+    endpoint_address: SortingDirection
+    db_instance_status: SortingDirection
+    endpoint_port: SortingDirection
+    instance_create_time: SortingDirection
+    engine: SortingDirection
+}
+
 type Ec2_cn_instance @alias(property: "ec2:instance") {
     _id: ID! @id
     scan_id: String
@@ -191,6 +273,17 @@ input Ec2_cn_instanceInput {
     arn: StringScalarFilters
     private_ip_address: StringScalarFilters
     launch_time: StringScalarFilters
+}
+
+input Ec2_cn_instanceSort {
+    _id: SortingDirection
+    scan_id: SortingDirection
+    public_ip_address: SortingDirection
+    instance_type: SortingDirection
+    state: SortingDirection
+    arn: SortingDirection
+    private_ip_address: SortingDirection
+    launch_time: SortingDirection
 }
 
 type Iam_cn_user @alias(property: "iam:user") {
@@ -225,6 +318,22 @@ input Iam_cn_userInput {
     access_key_dot_create_date: StringScalarFilters @alias(property: "access_key.create_date")
 }
 
+input Iam_cn_userSort {
+    _id: SortingDirection
+    password_last_used: SortingDirection
+    name: SortingDirection
+    login_profile_dot_password_reset_required: SortingDirection @alias(property: "login_profile.password_reset_required")
+    arn: SortingDirection
+    access_key_dot_access_key_id: SortingDirection @alias(property: "access_key.access_key_id")
+    login_profile_dot_create_date: SortingDirection @alias(property: "login_profile.create_date")
+    scan_id: SortingDirection
+    create_date: SortingDirection
+    access_key_dot_last_used_date: SortingDirection @alias(property: "access_key.last_used_date")
+    access_key_dot_status: SortingDirection @alias(property: "access_key.status")
+    user_id: SortingDirection
+    access_key_dot_create_date: SortingDirection @alias(property: "access_key.create_date")
+}
+
 type Ec2_cn_security_hy_group @alias(property: "ec2:security-group") {
     _id: ID! @id
     egress_rule_dot_ip_protocol: String @alias(property: "egress_rule.ip_protocol")
@@ -240,10 +349,10 @@ type Ec2_cn_security_hy_group @alias(property: "ec2:security-group") {
     ingress_rule_dot_ip_protocol: String @alias(property: "ingress_rule.ip_protocol")
     ingress_rule_dot_to_port: String @alias(property: "ingress_rule.to_port")
     user_id_group_pairs_dot_account_id: String @alias(property: "user_id_group_pairs.account_id")
-    ec2_cn_instanceResource_linksIn(filter: Ec2_cn_instanceInput, options: Options): [Ec2_cn_instance] @relationship(edgeType: "resource_link", direction: IN)
+    ec2_cn_instanceResource_linksIn(filter: Ec2_cn_instanceInput, options: Options, sort: [Ec2_cn_instanceSort!]): [Ec2_cn_instance] @relationship(edgeType: "resource_link", direction: IN)
     ec2_cn_security_hy_groupResource_linkOut: Ec2_cn_security_hy_group @relationship(edgeType: "resource_link", direction: OUT)
     ec2_cn_security_hy_groupResource_linkIn: Ec2_cn_security_hy_group @relationship(edgeType: "resource_link", direction: IN)
-    tagTaggedsOut(filter: TagInput, options: Options): [Tag] @relationship(edgeType: "tagged", direction: OUT)
+    tagTaggedsOut(filter: TagInput, options: Options, sort: [TagSort!]): [Tag] @relationship(edgeType: "tagged", direction: OUT)
     resource_link: Resource_link
     tagged: Tagged
     transient_resource_link: Transient_resource_link
@@ -266,6 +375,23 @@ input Ec2_cn_security_hy_groupInput {
     user_id_group_pairs_dot_account_id: StringScalarFilters @alias(property: "user_id_group_pairs.account_id")
 }
 
+input Ec2_cn_security_hy_groupSort {
+    _id: SortingDirection
+    egress_rule_dot_ip_protocol: SortingDirection @alias(property: "egress_rule.ip_protocol")
+    name: SortingDirection
+    ip_range_dot_first_ip: SortingDirection @alias(property: "ip_range.first_ip")
+    arn: SortingDirection
+    egress_rule_dot_to_port: SortingDirection @alias(property: "egress_rule.to_port")
+    scan_id: SortingDirection
+    ip_range_dot_last_ip: SortingDirection @alias(property: "ip_range.last_ip")
+    egress_rule_dot_from_port: SortingDirection @alias(property: "egress_rule.from_port")
+    ip_range_dot_cidr_ip: SortingDirection @alias(property: "ip_range.cidr_ip")
+    ingress_rule_dot_from_port: SortingDirection @alias(property: "ingress_rule.from_port")
+    ingress_rule_dot_ip_protocol: SortingDirection @alias(property: "ingress_rule.ip_protocol")
+    ingress_rule_dot_to_port: SortingDirection @alias(property: "ingress_rule.to_port")
+    user_id_group_pairs_dot_account_id: SortingDirection @alias(property: "user_id_group_pairs.account_id")
+}
+
 type Ec2_cn_internet_hy_gateway @alias(property: "ec2:internet-gateway") {
     _id: ID! @id
     arn: String
@@ -281,6 +407,14 @@ input Ec2_cn_internet_hy_gatewayInput {
     scan_id: StringScalarFilters
     owner_id: StringScalarFilters
     attachment_dot_state: StringScalarFilters @alias(property: "attachment.state")
+}
+
+input Ec2_cn_internet_hy_gatewaySort {
+    _id: SortingDirection
+    arn: SortingDirection
+    scan_id: SortingDirection
+    owner_id: SortingDirection
+    attachment_dot_state: SortingDirection @alias(property: "attachment.state")
 }
 
 type Events_cn_rule @alias(property: "events:rule") {
@@ -305,6 +439,17 @@ input Events_cn_ruleInput {
     state: StringScalarFilters
 }
 
+input Events_cn_ruleSort {
+    _id: SortingDirection
+    arn: SortingDirection
+    name: SortingDirection
+    scan_id: SortingDirection
+    target_dot_arn: SortingDirection @alias(property: "target.arn")
+    target_dot_name: SortingDirection @alias(property: "target.name")
+    event_pattern: SortingDirection
+    state: SortingDirection
+}
+
 type Ec2_cn_subnet @alias(property: "ec2:subnet") {
     _id: ID! @id
     scan_id: String
@@ -313,7 +458,7 @@ type Ec2_cn_subnet @alias(property: "ec2:subnet") {
     arn: String
     last_ip: String
     cidr_block: String
-    ec2_cn_instanceResource_linksIn(filter: Ec2_cn_instanceInput, options: Options): [Ec2_cn_instance] @relationship(edgeType: "resource_link", direction: IN)
+    ec2_cn_instanceResource_linksIn(filter: Ec2_cn_instanceInput, options: Options, sort: [Ec2_cn_instanceSort!]): [Ec2_cn_instance] @relationship(edgeType: "resource_link", direction: IN)
     ec2_cn_vpcResource_linkOut: Ec2_cn_vpc @relationship(edgeType: "resource_link", direction: OUT)
     resource_link: Resource_link
 }
@@ -326,6 +471,16 @@ input Ec2_cn_subnetInput {
     arn: StringScalarFilters
     last_ip: StringScalarFilters
     cidr_block: StringScalarFilters
+}
+
+input Ec2_cn_subnetSort {
+    _id: SortingDirection
+    scan_id: SortingDirection
+    first_ip: SortingDirection
+    state: SortingDirection
+    arn: SortingDirection
+    last_ip: SortingDirection
+    cidr_block: SortingDirection
 }
 
 type Iam_cn_instance_hy_profile @alias(property: "iam:instance-profile") {
@@ -344,6 +499,13 @@ input Iam_cn_instance_hy_profileInput {
     scan_id: StringScalarFilters
 }
 
+input Iam_cn_instance_hy_profileSort {
+    _id: SortingDirection
+    arn: SortingDirection
+    name: SortingDirection
+    scan_id: SortingDirection
+}
+
 type Iam_cn_policy @alias(property: "iam:policy") {
     _id: ID! @id
     default_version_policy_document_text: String
@@ -352,7 +514,7 @@ type Iam_cn_policy @alias(property: "iam:policy") {
     scan_id: String
     arn: String
     policy_id: String
-    iam_cn_roleResource_linksIn(filter: Iam_cn_roleInput, options: Options): [Iam_cn_role] @relationship(edgeType: "resource_link", direction: IN)
+    iam_cn_roleResource_linksIn(filter: Iam_cn_roleInput, options: Options, sort: [Iam_cn_roleSort!]): [Iam_cn_role] @relationship(edgeType: "resource_link", direction: IN)
     resource_link: Resource_link
 }
 
@@ -364,6 +526,16 @@ input Iam_cn_policyInput {
     scan_id: StringScalarFilters
     arn: StringScalarFilters
     policy_id: StringScalarFilters
+}
+
+input Iam_cn_policySort {
+    _id: SortingDirection
+    default_version_policy_document_text: SortingDirection
+    default_version_id: SortingDirection
+    name: SortingDirection
+    scan_id: SortingDirection
+    arn: SortingDirection
+    policy_id: SortingDirection
 }
 
 type S3_cn_bucket @alias(property: "s3:bucket") {
@@ -384,6 +556,15 @@ input S3_cn_bucketInput {
     arn: StringScalarFilters
 }
 
+input S3_cn_bucketSort {
+    _id: SortingDirection
+    name: SortingDirection
+    scan_id: SortingDirection
+    server_side_default_encryption_rule_dot_algorithm: SortingDirection @alias(property: "server_side_default_encryption_rule.algorithm")
+    creation_date: SortingDirection
+    arn: SortingDirection
+}
+
 type Tag @alias(property: "tag") {
     _id: ID! @id
     scan_id: String
@@ -396,6 +577,12 @@ input TagInput {
     _id: ID @id
     scan_id: StringScalarFilters
     Name: StringScalarFilters
+}
+
+input TagSort {
+    _id: SortingDirection
+    scan_id: SortingDirection
+    Name: SortingDirection
 }
 
 type Kms_cn_key @alias(property: "kms:key") {
@@ -411,6 +598,13 @@ input Kms_cn_keyInput {
     arn: StringScalarFilters
     scan_id: StringScalarFilters
     key_id: StringScalarFilters
+}
+
+input Kms_cn_keySort {
+    _id: SortingDirection
+    arn: SortingDirection
+    scan_id: SortingDirection
+    key_id: SortingDirection
 }
 
 type Ec2_cn_volume @alias(property: "ec2:volume") {
@@ -444,6 +638,21 @@ input Ec2_cn_volumeInput {
     attachment_dot_delete_on_termination: StringScalarFilters @alias(property: "attachment.delete_on_termination")
 }
 
+input Ec2_cn_volumeSort {
+    _id: SortingDirection
+    encrypted: SortingDirection
+    availability_zone: SortingDirection
+    state: SortingDirection
+    arn: SortingDirection
+    attachment_dot_attach_time: SortingDirection @alias(property: "attachment.attach_time")
+    volume_type: SortingDirection
+    scan_id: SortingDirection
+    attachment_dot_state: SortingDirection @alias(property: "attachment.state")
+    size: SortingDirection
+    create_time: SortingDirection
+    attachment_dot_delete_on_termination: SortingDirection @alias(property: "attachment.delete_on_termination")
+}
+
 type Ec2_cn_route_hy_table @alias(property: "ec2:route-table") {
     _id: ID! @id
     route_dot_destination_cidr_block: String @alias(property: "route.destination_cidr_block")
@@ -475,6 +684,21 @@ input Ec2_cn_route_hy_tableInput {
     association_dot_route_table_association_id: StringScalarFilters @alias(property: "association.route_table_association_id")
 }
 
+input Ec2_cn_route_hy_tableSort {
+    _id: SortingDirection
+    route_dot_destination_cidr_block: SortingDirection @alias(property: "route.destination_cidr_block")
+    arn: SortingDirection
+    route_table_id: SortingDirection
+    association_dot_route_table_id: SortingDirection @alias(property: "association.route_table_id")
+    route_dot_origin: SortingDirection @alias(property: "route.origin")
+    route_dot_gateway_id: SortingDirection @alias(property: "route.gateway_id")
+    scan_id: SortingDirection
+    owner_id: SortingDirection
+    association_dot_main: SortingDirection @alias(property: "association.main")
+    route_dot_state: SortingDirection @alias(property: "route.state")
+    association_dot_route_table_association_id: SortingDirection @alias(property: "association.route_table_association_id")
+}
+
 type Resource_link @alias(property: "resource_link") {
     _id: ID! @id
 }
@@ -501,43 +725,43 @@ input StringScalarFilters {
 
 type Query {
     getNodeImage(filter: ImageInput): Image
-    getNodeImages(filter: ImageInput, options: Options): [Image]
+    getNodeImages(filter: ImageInput, options: Options, sort: [ImageSort!]): [Image]
     getNodeGuardduty_cn_detector(filter: Guardduty_cn_detectorInput): Guardduty_cn_detector
-    getNodeGuardduty_cn_detectors(filter: Guardduty_cn_detectorInput, options: Options): [Guardduty_cn_detector]
+    getNodeGuardduty_cn_detectors(filter: Guardduty_cn_detectorInput, options: Options, sort: [Guardduty_cn_detectorSort!]): [Guardduty_cn_detector]
     getNodeEc2_cn_vpc(filter: Ec2_cn_vpcInput): Ec2_cn_vpc
-    getNodeEc2_cn_vpcs(filter: Ec2_cn_vpcInput, options: Options): [Ec2_cn_vpc]
+    getNodeEc2_cn_vpcs(filter: Ec2_cn_vpcInput, options: Options, sort: [Ec2_cn_vpcSort!]): [Ec2_cn_vpc]
     getNodeIam_cn_role(filter: Iam_cn_roleInput): Iam_cn_role
-    getNodeIam_cn_roles(filter: Iam_cn_roleInput, options: Options): [Iam_cn_role]
+    getNodeIam_cn_roles(filter: Iam_cn_roleInput, options: Options, sort: [Iam_cn_roleSort!]): [Iam_cn_role]
     getNodeEc2_cn_network_hy_interface(filter: Ec2_cn_network_hy_interfaceInput): Ec2_cn_network_hy_interface
-    getNodeEc2_cn_network_hy_interfaces(filter: Ec2_cn_network_hy_interfaceInput, options: Options): [Ec2_cn_network_hy_interface]
+    getNodeEc2_cn_network_hy_interfaces(filter: Ec2_cn_network_hy_interfaceInput, options: Options, sort: [Ec2_cn_network_hy_interfaceSort!]): [Ec2_cn_network_hy_interface]
     getNodeRds_cn_db(filter: Rds_cn_dbInput): Rds_cn_db
-    getNodeRds_cn_dbs(filter: Rds_cn_dbInput, options: Options): [Rds_cn_db]
+    getNodeRds_cn_dbs(filter: Rds_cn_dbInput, options: Options, sort: [Rds_cn_dbSort!]): [Rds_cn_db]
     getNodeEc2_cn_instance(filter: Ec2_cn_instanceInput): Ec2_cn_instance
-    getNodeEc2_cn_instances(filter: Ec2_cn_instanceInput, options: Options): [Ec2_cn_instance]
+    getNodeEc2_cn_instances(filter: Ec2_cn_instanceInput, options: Options, sort: [Ec2_cn_instanceSort!]): [Ec2_cn_instance]
     getNodeIam_cn_user(filter: Iam_cn_userInput): Iam_cn_user
-    getNodeIam_cn_users(filter: Iam_cn_userInput, options: Options): [Iam_cn_user]
+    getNodeIam_cn_users(filter: Iam_cn_userInput, options: Options, sort: [Iam_cn_userSort!]): [Iam_cn_user]
     getNodeEc2_cn_security_hy_group(filter: Ec2_cn_security_hy_groupInput): Ec2_cn_security_hy_group
-    getNodeEc2_cn_security_hy_groups(filter: Ec2_cn_security_hy_groupInput, options: Options): [Ec2_cn_security_hy_group]
+    getNodeEc2_cn_security_hy_groups(filter: Ec2_cn_security_hy_groupInput, options: Options, sort: [Ec2_cn_security_hy_groupSort!]): [Ec2_cn_security_hy_group]
     getNodeEc2_cn_internet_hy_gateway(filter: Ec2_cn_internet_hy_gatewayInput): Ec2_cn_internet_hy_gateway
-    getNodeEc2_cn_internet_hy_gateways(filter: Ec2_cn_internet_hy_gatewayInput, options: Options): [Ec2_cn_internet_hy_gateway]
+    getNodeEc2_cn_internet_hy_gateways(filter: Ec2_cn_internet_hy_gatewayInput, options: Options, sort: [Ec2_cn_internet_hy_gatewaySort!]): [Ec2_cn_internet_hy_gateway]
     getNodeEvents_cn_rule(filter: Events_cn_ruleInput): Events_cn_rule
-    getNodeEvents_cn_rules(filter: Events_cn_ruleInput, options: Options): [Events_cn_rule]
+    getNodeEvents_cn_rules(filter: Events_cn_ruleInput, options: Options, sort: [Events_cn_ruleSort!]): [Events_cn_rule]
     getNodeEc2_cn_subnet(filter: Ec2_cn_subnetInput): Ec2_cn_subnet
-    getNodeEc2_cn_subnets(filter: Ec2_cn_subnetInput, options: Options): [Ec2_cn_subnet]
+    getNodeEc2_cn_subnets(filter: Ec2_cn_subnetInput, options: Options, sort: [Ec2_cn_subnetSort!]): [Ec2_cn_subnet]
     getNodeIam_cn_instance_hy_profile(filter: Iam_cn_instance_hy_profileInput): Iam_cn_instance_hy_profile
-    getNodeIam_cn_instance_hy_profiles(filter: Iam_cn_instance_hy_profileInput, options: Options): [Iam_cn_instance_hy_profile]
+    getNodeIam_cn_instance_hy_profiles(filter: Iam_cn_instance_hy_profileInput, options: Options, sort: [Iam_cn_instance_hy_profileSort!]): [Iam_cn_instance_hy_profile]
     getNodeIam_cn_policy(filter: Iam_cn_policyInput): Iam_cn_policy
-    getNodeIam_cn_policys(filter: Iam_cn_policyInput, options: Options): [Iam_cn_policy]
+    getNodeIam_cn_policys(filter: Iam_cn_policyInput, options: Options, sort: [Iam_cn_policySort!]): [Iam_cn_policy]
     getNodeS3_cn_bucket(filter: S3_cn_bucketInput): S3_cn_bucket
-    getNodeS3_cn_buckets(filter: S3_cn_bucketInput, options: Options): [S3_cn_bucket]
+    getNodeS3_cn_buckets(filter: S3_cn_bucketInput, options: Options, sort: [S3_cn_bucketSort!]): [S3_cn_bucket]
     getNodeTag(filter: TagInput): Tag
-    getNodeTags(filter: TagInput, options: Options): [Tag]
+    getNodeTags(filter: TagInput, options: Options, sort: [TagSort!]): [Tag]
     getNodeKms_cn_key(filter: Kms_cn_keyInput): Kms_cn_key
-    getNodeKms_cn_keys(filter: Kms_cn_keyInput, options: Options): [Kms_cn_key]
+    getNodeKms_cn_keys(filter: Kms_cn_keyInput, options: Options, sort: [Kms_cn_keySort!]): [Kms_cn_key]
     getNodeEc2_cn_volume(filter: Ec2_cn_volumeInput): Ec2_cn_volume
-    getNodeEc2_cn_volumes(filter: Ec2_cn_volumeInput, options: Options): [Ec2_cn_volume]
+    getNodeEc2_cn_volumes(filter: Ec2_cn_volumeInput, options: Options, sort: [Ec2_cn_volumeSort!]): [Ec2_cn_volume]
     getNodeEc2_cn_route_hy_table(filter: Ec2_cn_route_hy_tableInput): Ec2_cn_route_hy_table
-    getNodeEc2_cn_route_hy_tables(filter: Ec2_cn_route_hy_tableInput, options: Options): [Ec2_cn_route_hy_table]
+    getNodeEc2_cn_route_hy_tables(filter: Ec2_cn_route_hy_tableInput, options: Options, sort: [Ec2_cn_route_hy_tableSort!]): [Ec2_cn_route_hy_table]
 }
 
 schema {

--- a/src/test/special-chars-mutations.graphql
+++ b/src/test/special-chars-mutations.graphql
@@ -1,3 +1,8 @@
+enum SortingDirection {
+  ASC
+  DESC
+}
+
 type Abc_ex__dol_123_amp_efg @alias(property:"abc!$123&efg") {
   _id: ID! @id
   instance_type: String
@@ -30,12 +35,19 @@ input Abc_ex__dol_123_amp_efgUpdateInput {
   arn: String
 }
 
+input Abc_ex__dol_123_amp_efgSort {
+  _id: SortingDirection
+  instance_type: SortingDirection
+  state: SortingDirection
+  arn: SortingDirection
+}
+
 type Abc_op_123_cp__dot_efg_cn_456 @alias(property:"abc(123).efg:456") {
   _id: ID! @id
   name: String
   ip_range_dot_first_ip: String @alias(property: "ip_range.first_ip")
   ip_range_dot_last_ip: String @alias(property: "ip_range.last_ip")
-  abc_ex__dol_123_amp_efgResource_linksIn(filter: Abc_ex__dol_123_amp_efgInput, options: Options): [Abc_ex__dol_123_amp_efg] @relationship(edgeType:"resource_link", direction:IN)
+  abc_ex__dol_123_amp_efgResource_linksIn(filter: Abc_ex__dol_123_amp_efgInput, options: Options, sort: [Abc_ex__dol_123_amp_efgSort!]): [Abc_ex__dol_123_amp_efg] @relationship(edgeType:"resource_link", direction:IN)
   resource_link:Resource_link
 }
 
@@ -58,6 +70,13 @@ input Abc_op_123_cp__dot_efg_cn_456UpdateInput {
   name: String
   ip_range_dot_first_ip: String @alias(property: "ip_range.first_ip")
   ip_range_dot_last_ip: String @alias(property: "ip_range.last_ip")
+}
+
+input Abc_op_123_cp__dot_efg_cn_456Sort {
+  _id: SortingDirection
+  name: SortingDirection
+  ip_range_dot_first_ip: SortingDirection @alias(property: "ip_range.first_ip")
+  ip_range_dot_last_ip: SortingDirection @alias(property: "ip_range.last_ip")
 }
 
 type Abc_eq_123_at__os_efg_cs_456 @alias(property:"abc=123@[efg]456") {
@@ -88,6 +107,13 @@ input Abc_eq_123_at__os_efg_cs_456UpdateInput {
   arn: String
 }
 
+input Abc_eq_123_at__os_efg_cs_456Sort {
+  _id: SortingDirection
+  instance_type: SortingDirection
+  state: SortingDirection
+  arn: SortingDirection
+}
+
 type Abc_oc_123_cc__vb_efg_hy_456 @alias(property:"abc{123}|efg-456") {
   _id: ID! @id
   name: String
@@ -116,6 +142,13 @@ input Abc_oc_123_cc__vb_efg_hy_456UpdateInput {
   ip_range_dot_last_ip: String @alias(property: "ip_range.last_ip")
 }
 
+input Abc_oc_123_cc__vb_efg_hy_456Sort {
+  _id: SortingDirection
+  name: SortingDirection
+  ip_range_dot_first_ip: SortingDirection @alias(property: "ip_range.first_ip")
+  ip_range_dot_last_ip: SortingDirection @alias(property: "ip_range.last_ip")
+}
+
 type Resource_link @alias(property:"resource_link") {
   _id: ID! @id
 }
@@ -134,13 +167,13 @@ input StringScalarFilters {
 
 type Query {
   getNodeAbc_ex__dol_123_amp_efg(filter: Abc_ex__dol_123_amp_efgInput): Abc_ex__dol_123_amp_efg
-  getNodeAbc_ex__dol_123_amp_efgs(filter: Abc_ex__dol_123_amp_efgInput, options: Options): [Abc_ex__dol_123_amp_efg]
+  getNodeAbc_ex__dol_123_amp_efgs(filter: Abc_ex__dol_123_amp_efgInput, options: Options, sort: [Abc_ex__dol_123_amp_efgSort!]): [Abc_ex__dol_123_amp_efg]
   getNodeAbc_op_123_cp__dot_efg_cn_456(filter: Abc_op_123_cp__dot_efg_cn_456Input): Abc_op_123_cp__dot_efg_cn_456
-  getNodeAbc_op_123_cp__dot_efg_cn_456s(filter: Abc_op_123_cp__dot_efg_cn_456Input, options: Options): [Abc_op_123_cp__dot_efg_cn_456]
+  getNodeAbc_op_123_cp__dot_efg_cn_456s(filter: Abc_op_123_cp__dot_efg_cn_456Input, options: Options, sort: [Abc_op_123_cp__dot_efg_cn_456Sort!]): [Abc_op_123_cp__dot_efg_cn_456]
   getNodeAbc_eq_123_at__os_efg_cs_456(filter: Abc_eq_123_at__os_efg_cs_456Input): Abc_eq_123_at__os_efg_cs_456
-  getNodeAbc_eq_123_at__os_efg_cs_456s(filter: Abc_eq_123_at__os_efg_cs_456Input, options: Options): [Abc_eq_123_at__os_efg_cs_456]
+  getNodeAbc_eq_123_at__os_efg_cs_456s(filter: Abc_eq_123_at__os_efg_cs_456Input, options: Options, sort: [Abc_eq_123_at__os_efg_cs_456Sort!]): [Abc_eq_123_at__os_efg_cs_456]
   getNodeAbc_oc_123_cc__vb_efg_hy_456(filter: Abc_oc_123_cc__vb_efg_hy_456Input): Abc_oc_123_cc__vb_efg_hy_456
-  getNodeAbc_oc_123_cc__vb_efg_hy_456s(filter: Abc_oc_123_cc__vb_efg_hy_456Input, options: Options): [Abc_oc_123_cc__vb_efg_hy_456]
+  getNodeAbc_oc_123_cc__vb_efg_hy_456s(filter: Abc_oc_123_cc__vb_efg_hy_456Input, options: Options, sort: [Abc_oc_123_cc__vb_efg_hy_456Sort!]): [Abc_oc_123_cc__vb_efg_hy_456]
 }
 
 type Mutation {

--- a/src/test/special-chars.graphql
+++ b/src/test/special-chars.graphql
@@ -1,3 +1,8 @@
+enum SortingDirection {
+  ASC
+  DESC
+}
+
 type Abc_ex__dol_123_amp_efg @alias(property: "abc!$123&efg") {
         _id: ID! @id
         instance_type: String
@@ -16,12 +21,19 @@ input Abc_ex__dol_123_amp_efgInput {
         arn: StringScalarFilters
 }
 
+input Abc_ex__dol_123_amp_efgSort {
+ _id: SortingDirection
+ instance_type: SortingDirection
+ state: SortingDirection
+ arn: SortingDirection 
+}
+
 type Abc_op_123_cp__dot_efg_cn_456 @alias(property: "abc(123).efg:456") {
         _id: ID! @id
         name: String
         ip_range_dot_first_ip: String @alias(property: "ip_range.first_ip")
         ip_range_dot_last_ip: String @alias(property: "ip_range.last_ip")
-        abc_ex__dol_123_amp_efgResource_linksIn(filter: Abc_ex__dol_123_amp_efgInput, options: Options): [Abc_ex__dol_123_amp_efg] @relationship(edgeType: "resource_link", direction: IN)
+        abc_ex__dol_123_amp_efgResource_linksIn(filter: Abc_ex__dol_123_amp_efgInput, options: Options, sort: [Abc_ex__dol_123_amp_efgSort!]): [Abc_ex__dol_123_amp_efg] @relationship(edgeType: "resource_link", direction: IN)
         resource_link: Resource_link
 }
 
@@ -30,6 +42,13 @@ input Abc_op_123_cp__dot_efg_cn_456Input {
         name: StringScalarFilters
         ip_range_dot_first_ip: StringScalarFilters @alias(property: "ip_range.first_ip")
         ip_range_dot_last_ip: StringScalarFilters @alias(property: "ip_range.last_ip")
+}
+
+input Abc_op_123_cp__dot_efg_cn_456Sort {
+  _id: SortingDirection
+  name: SortingDirection
+  ip_range_dot_first_ip: SortingDirection @alias(property: "ip_range.first_ip")
+  ip_range_dot_last_ip: SortingDirection @alias(property: "ip_range.last_ip")
 }
 
 type Abc_eq_123_at__os_efg_cs_456 @alias(property: "abc=123@[efg]456") {
@@ -46,6 +65,13 @@ input Abc_eq_123_at__os_efg_cs_456Input {
         arn: StringScalarFilters
 }
 
+input Abc_eq_123_at__os_efg_cs_456Sort {
+  _id: SortingDirection
+  instance_type: SortingDirection
+  state: SortingDirection
+  arn: SortingDirection
+}
+
 type Abc_oc_123_cc__vb_efg_hy_456 @alias(property: "abc{123}|efg-456") {
         _id: ID! @id
         name: String
@@ -58,6 +84,13 @@ input Abc_oc_123_cc__vb_efg_hy_456Input {
         name: StringScalarFilters
         ip_range_dot_first_ip: StringScalarFilters @alias(property: "ip_range.first_ip")
         ip_range_dot_last_ip: StringScalarFilters @alias(property: "ip_range.last_ip")
+}
+
+input Abc_oc_123_cc__vb_efg_hy_456Sort {
+  _id: SortingDirection
+  name: SortingDirection
+  ip_range_dot_first_ip: SortingDirection @alias(property: "ip_range.first_ip")
+  ip_range_dot_last_ip: SortingDirection @alias(property: "ip_range.last_ip")
 }
 
 type Resource_link @alias(property: "resource_link") {
@@ -78,13 +111,13 @@ input StringScalarFilters {
 
 type Query {
         getNodeAbc_ex__dol_123_amp_efg(filter: Abc_ex__dol_123_amp_efgInput): Abc_ex__dol_123_amp_efg
-        getNodeAbc_ex__dol_123_amp_efgs(filter: Abc_ex__dol_123_amp_efgInput, options: Options): [Abc_ex__dol_123_amp_efg]
+        getNodeAbc_ex__dol_123_amp_efgs(filter: Abc_ex__dol_123_amp_efgInput, options: Options, sort: [Abc_ex__dol_123_amp_efgSort!]): [Abc_ex__dol_123_amp_efg]
         getNodeAbc_op_123_cp__dot_efg_cn_456(filter: Abc_op_123_cp__dot_efg_cn_456Input): Abc_op_123_cp__dot_efg_cn_456
-        getNodeAbc_op_123_cp__dot_efg_cn_456s(filter: Abc_op_123_cp__dot_efg_cn_456Input, options: Options): [Abc_op_123_cp__dot_efg_cn_456]
+        getNodeAbc_op_123_cp__dot_efg_cn_456s(filter: Abc_op_123_cp__dot_efg_cn_456Input, options: Options, sort: [Abc_op_123_cp__dot_efg_cn_456Sort!]): [Abc_op_123_cp__dot_efg_cn_456]
         getNodeAbc_eq_123_at__os_efg_cs_456(filter: Abc_eq_123_at__os_efg_cs_456Input): Abc_eq_123_at__os_efg_cs_456
-        getNodeAbc_eq_123_at__os_efg_cs_456s(filter: Abc_eq_123_at__os_efg_cs_456Input, options: Options): [Abc_eq_123_at__os_efg_cs_456]
+        getNodeAbc_eq_123_at__os_efg_cs_456s(filter: Abc_eq_123_at__os_efg_cs_456Input, options: Options, sort: [Abc_eq_123_at__os_efg_cs_456Sort!]): [Abc_eq_123_at__os_efg_cs_456]
         getNodeAbc_oc_123_cc__vb_efg_hy_456(filter: Abc_oc_123_cc__vb_efg_hy_456Input): Abc_oc_123_cc__vb_efg_hy_456
-        getNodeAbc_oc_123_cc__vb_efg_hy_456s(filter: Abc_oc_123_cc__vb_efg_hy_456Input, options: Options): [Abc_oc_123_cc__vb_efg_hy_456]
+        getNodeAbc_oc_123_cc__vb_efg_hy_456s(filter: Abc_oc_123_cc__vb_efg_hy_456Input, options: Options,  sort: [Abc_oc_123_cc__vb_efg_hy_456Sort!]): [Abc_oc_123_cc__vb_efg_hy_456]
 }
 
 schema {

--- a/src/test/user-group-validated.graphql
+++ b/src/test/user-group-validated.graphql
@@ -27,6 +27,11 @@ enum Role {
 "https://the-guild.dev/graphql/scalars/docs/scalars/email-address"
 scalar EmailAddress
 
+enum SortDirection {
+  ASC
+  DESC
+}
+
 input UserInput {
   userId: ID! @id
   firstName: String
@@ -51,6 +56,14 @@ input UserUpdateInput {
   email: EmailAddress
 }
 
+input UserSort {
+  userId: SortDirection
+  firstName: SortDirection
+  lastName: SortDirection
+  role: SortDirection
+  email: SortDirection
+}
+
 input GroupInput {
   _id: ID! @id
   name: String
@@ -66,6 +79,11 @@ input GroupUpdateInput {
   name: String
 }
 
+input GroupSort {
+  _id: SortDirection
+  name: SortDirection
+}
+
 input ModeratorInput {
   moderatorId: ID! @id
   name: String
@@ -79,6 +97,11 @@ input ModeratorCreateInput {
 input ModeratorUpdateInput {
   moderatorId: ID! @id
   name: String
+}
+
+input ModeratorSort {
+  moderatorId: SortDirection
+  name: SortDirection
 }
 
 type GroupEdge {
@@ -99,11 +122,11 @@ input StringScalarFilters {
 
 type Query {
   getNodeUser(filter: UserInput): User
-  getNodeUsers(filter: UserInput, options: Options): [User]
+  getNodeUsers(filter: UserInput, options: Options, sort: [UserSort!]): [User]
   getNodeGroup(filter: GroupInput): Group
-  getNodeGroups(filter: GroupInput, options: Options): [Group]
+  getNodeGroups(filter: GroupInput, options: Options, sort: [GroupSort!]): [Group]
   getNodeModerator(filter: ModeratorInput): Moderator
-  getNodeModerators(filter: ModeratorInput, options: Options): [Moderator]
+  getNodeModerators(filter: ModeratorInput, options: Options, sort: [ModeratorSort!]): [Moderator]
 }
 
 type Mutation {


### PR DESCRIPTION
The current graphQL utility does not support the sort argument in queries.

Added support for sort argument in queries including nested.
Wrote unit tests and fixed previous unit tests to follow added support.