### PR TITLE
Add missing CDK files and pass variables in CDK event handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This release contains new support for Apollo Server integration.
 * Fixed queries generated from an input schema which retrieve an array to have an option parameter with limit ([#97](https://github.com/aws/amazon-neptune-for-graphql/pull/97))
 * Fixed nested edge subqueries to return an empty array if no results were found (([#100](https://github.com/aws/amazon-neptune-for-graphql/pull/100))
 * Fixed usage of variables with nested edge subqueries (([#100](https://github.com/aws/amazon-neptune-for-graphql/pull/100))
+* Fixed cdk output file to contain previously missing files that were necessary to execute the lambda resolver (([#106](https://github.com/aws/amazon-neptune-for-graphql/pull/106))
 
 
 ### Features

--- a/src/CDKPipelineApp.js
+++ b/src/CDKPipelineApp.js
@@ -32,7 +32,7 @@ let APPSYNC_SCHEMA = '';
 let APPSYNC_ATTACH_QUERY = [];
 let APPSYNC_ATTACH_MUTATION = [];
 let SCHEMA_MODEL = null;
-let thisOutputFolderPath = './output';
+let RELATIVE_OUTPUT_PATH = './output';
 
 async function getSchemaFields(typeName) {
     /*  To be updated as:
@@ -56,8 +56,8 @@ async function getSchemaFields(typeName) {
 
 async function createDeploymentFile(templateFolderPath, resolverFilePath) {
     try {
-        const zipFilePath = path.join(thisOutputFolderPath, `${NAME}.zip`);
-        const resolverSchemaFilePath = path.join(thisOutputFolderPath, `${NAME}.resolver.schema.json`)
+        const zipFilePath = path.join(RELATIVE_OUTPUT_PATH, `${NAME}.zip`);
+        const resolverSchemaFilePath = path.join(RELATIVE_OUTPUT_PATH, `${NAME}.resolver.schema.json`)
         await createLambdaDeploymentPackage({
             outputZipFilePath: zipFilePath,
             templateFolderPath: templateFolderPath,
@@ -96,9 +96,9 @@ async function createAWSpipelineCDK({
     SCHEMA_MODEL = schemaModel;
     NEPTUNE_HOST = neptuneHost;
     NEPTUNE_PORT = neptunePort;
-    thisOutputFolderPath = outputFolderPath;
+    RELATIVE_OUTPUT_PATH = outputFolderPath;
 
-    LAMBDA_ZIP_FILE = `${thisOutputFolderPath}/${NAME}.zip`;
+    LAMBDA_ZIP_FILE = `${RELATIVE_OUTPUT_PATH}/${NAME}.zip`;
     let spinner = null;
     let neptuneClusterInfo = null;
 

--- a/src/main.js
+++ b/src/main.js
@@ -395,8 +395,8 @@ async function main() {
     const outputFilePrefix = createUpdatePipelineName || 
         createUpdatePipelineNeptuneDatabaseName || 
         inputCDKpipelineName || 
-        inputCDKpipelineDatabaseName || 
-        `${neptuneInfo?.graphName ? neptuneInfo.graphName.concat('.') : ''}output`;
+        inputCDKpipelineDatabaseName ||
+        `${neptuneInfo?.graphName?.concat('.') || ''}output`;
     // save the neptune schema early for troubleshooting purposes
     saveNeptuneSchema(outputFilePrefix);
 

--- a/src/main.js
+++ b/src/main.js
@@ -288,16 +288,13 @@ function processArgs() {
 
 /**
  * Saves the neptune schema to file
+ * @param outputFilePrefix a prefix to use for the generated neptune schema file name
  */
-function saveNeptuneSchema() {
+function saveNeptuneSchema(outputFilePrefix) {
     // Output Neptune schema
     if (inputGraphDBSchema !== '') {
         if (outputNeptuneSchemaFile === '') {
-            if (createUpdatePipelineName === '') {
-                outputNeptuneSchemaFile = outputFolderPath + '/output.neptune.schema.json';
-            } else {
-                outputNeptuneSchemaFile = `${outputFolderPath}/${createUpdatePipelineName}.neptune.schema.json`;
-            }
+            outputNeptuneSchemaFile = path.join(outputFolderPath, `${outputFilePrefix}.neptune.schema.json`);
         }
 
         try {
@@ -394,8 +391,14 @@ async function main() {
     }
 
     createOutputFolder();
+    // determine a common output file prefix depending on input arguments, falling back to a default value 'output' if no relevant inputs are provided
+    const outputFilePrefix = createUpdatePipelineName || 
+        createUpdatePipelineNeptuneDatabaseName || 
+        inputCDKpipelineName || 
+        inputCDKpipelineDatabaseName || 
+        `${neptuneInfo?.graphName ? neptuneInfo.graphName.concat('.') : ''}output`;
     // save the neptune schema early for troubleshooting purposes
-    saveNeptuneSchema();
+    saveNeptuneSchema(outputFilePrefix);
 
     // Option 2: inference GraphQL schema from graphDB schema
     if (inputGraphDBSchema != '' && inputGraphQLSchema == '' && inputGraphQLSchemaFile == '') {
@@ -510,7 +513,7 @@ async function main() {
     if (inputGraphQLSchemaChanges != '') {
         inputGraphQLSchema = changeGraphQLSchema(inputGraphQLSchema, inputGraphQLSchemaChanges); 
     }
-
+    
     if (inputGraphQLSchema != '') {
         // Parse schema
         schemaModel = schemaParser(inputGraphQLSchema);
@@ -520,13 +523,7 @@ async function main() {
 
         // Generate schema for resolver
         const queryDataModelJSON = JSON.stringify(schemaModel, null, 2);
-
-        let resolverSchemaFile;
-        if (createUpdatePipelineName == '') {
-            resolverSchemaFile = `${outputFolderPath}/output.resolver.schema.json`
-        } else {
-            resolverSchemaFile = `${outputFolderPath}/${createUpdatePipelineName}.resolver.schema.json`
-        }
+        const resolverSchemaFile = path.join(outputFolderPath, `${outputFilePrefix}.resolver.schema.json`);
 
         try {
             writeFileSync(resolverSchemaFile, queryDataModelJSON);
@@ -562,12 +559,8 @@ async function main() {
     if (inputGraphQLSchema != '') {
     
         outputSchema = schemaStringify(schemaModel, false);
-        if ( outputSchemaFile == '' ) {
-            if (createUpdatePipelineName == '') { 
-                outputSchemaFile = outputFolderPath + '/output.schema.graphql';
-            } else {
-                outputSchemaFile = `${outputFolderPath}/${createUpdatePipelineName}.schema.graphql`;
-            } 
+        if (!outputSchemaFile) {
+            outputSchemaFile = path.join(outputFolderPath, `${outputFilePrefix}.schema.graphql`);
         }
 
         try {
@@ -580,12 +573,8 @@ async function main() {
 
         // Output GraphQL schema with directives
         outputSourceSchema = schemaStringify(schemaModel, true);
-        if ( outputSourceSchemaFile == '' ) {
-            if (createUpdatePipelineName == '') { 
-                outputSourceSchemaFile = outputFolderPath + '/output.source.schema.graphql';
-            } else {
-                outputSourceSchemaFile = `${outputFolderPath}/${createUpdatePipelineName}.source.schema.graphql`;
-            } 
+        if ( outputSourceSchemaFile === '' ) {
+            outputSourceSchemaFile = path.join(outputFolderPath, `${outputFilePrefix}.source.schema.graphql`)
         }   
 
         try {
@@ -609,12 +598,8 @@ async function main() {
 
 
         // Output Javascript resolver
-        if (outputJSResolverFile == '') {
-            if (createUpdatePipelineName == '') { 
-                outputJSResolverFile = outputFolderPath + '/output.resolver.graphql.js';
-            } else {
-                outputJSResolverFile = `${outputFolderPath}/${createUpdatePipelineName}.resolver.graphql.js`;
-            } 
+        if (outputJSResolverFile === '') {
+            outputJSResolverFile = path.join(outputFolderPath, `${outputFilePrefix}.resolver.graphql.js`);
         }
 
         try {
@@ -642,12 +627,7 @@ async function main() {
         // output Apollo zip
         if (createUpdateApolloServer || createUpdateApolloServerSubgraph) {
             const apolloZipPath = path.join(outputFolderPath, `apollo-server-${neptuneInfo.graphName}-${new Date().getTime()}.zip`);
-            let resolverSchemaFilePath;
-            if (createUpdatePipelineName == '') {
-                resolverSchemaFilePath = path.join(outputFolderPath, 'output.resolver.schema.json');
-            } else {
-                resolverSchemaFilePath = path.join(outputFolderPath, `${createUpdatePipelineName}.resolver.schema.json`);
-            }
+            const resolverSchemaFilePath = path.join(outputFolderPath, `${outputFilePrefix}.resolver.schema.json`);
             try {
                 if (!quiet) {
                     spinner = ora('Creating Apollo server ZIP file ...').start();
@@ -756,6 +736,7 @@ async function main() {
                     neptuneHost: neptuneHost,
                     neptunePort: neptunePort,
                     outputFolderPath: outputFolderPath,
+                    resolverFilePath: outputLambdaResolverFile,
                     neptuneType: neptuneType
                 });
             } catch (err) {

--- a/templates/CDKTemplate.js
+++ b/templates/CDKTemplate.js
@@ -198,6 +198,7 @@ export function request(ctx) {
         payload: {
             field: ctx.info.fieldName, 
             arguments: args,
+            variables: ctx.info.variables,
             selectionSetGraphQL: ctx.info.selectionSetGraphQL,
             source 
         },

--- a/test/TestCases/Case01/Case01.02.test.js
+++ b/test/TestCases/Case01/Case01.02.test.js
@@ -1,6 +1,5 @@
-import { readJSONFile, checkOutputFilesSize, checkOutputFilesContent, checkFolderContainsFiles } from '../../testLib';
-
-const casetest = readJSONFile('./test/TestCases/Case01/case.json');
+import { checkFolderContainsFiles, compareFileContents } from '../../testLib';
+import path from "path";
 
 describe('Validate output files', () => {
     const expectedFiles = [
@@ -10,7 +9,14 @@ describe('Validate output files', () => {
         'output.schema.graphql',
         'output.source.schema.graphql'
     ];
-    checkFolderContainsFiles('./test/TestCases/Case01/output', expectedFiles);
-    checkOutputFilesSize('./test/TestCases/Case01/output', casetest.testOutputFilesSize, './test/TestCases/Case01/outputReference');
-    checkOutputFilesContent('./test/TestCases/Case01/output', casetest.testOutputFilesContent, './test/TestCases/Case01/outputReference');
+    const outputFolder = './test/TestCases/Case01/output';
+    checkFolderContainsFiles(outputFolder, expectedFiles);
+    const referenceFolder = './test/TestCases/Case01/outputReference';
+    compareFileContents([{
+        expected: path.join(referenceFolder, 'output.schema.graphql'),
+        actual: path.join(outputFolder, 'output.schema.graphql')
+    }, {
+        expected: path.join(referenceFolder, 'output.source.schema.graphql'),
+        actual: path.join(outputFolder, 'output.source.schema.graphql')
+    }]);
 });

--- a/test/TestCases/Case01/case.json
+++ b/test/TestCases/Case01/case.json
@@ -8,7 +8,5 @@
             "--output-folder-path", "./test/TestCases/Case01/output",
             "--output-no-lambda-zip"],
     "host": "<AIR_ROUTES_DB_HOST>",
-    "port": "<AIR_ROUTES_DB_PORT>",
-    "testOutputFilesSize": ["output.schema.graphql", "output.source.schema.graphql"],
-    "testOutputFilesContent": ["output.schema.graphql", "output.source.schema.graphql"]
+    "port": "<AIR_ROUTES_DB_PORT>"
 }

--- a/test/TestCases/Case02/Case02.01.test.js
+++ b/test/TestCases/Case02/Case02.01.test.js
@@ -11,10 +11,6 @@ async function executeUtility() {
 }
 
 describe('Validate successful execution', () => {
-    afterAll(async () => {
-        fs.rmSync('./test/TestCases/Case02/output', {recursive: true});
-    });
-
     test('Execute utility: ' + casetest.argv.join(' '), async () => {
         expect(await executeUtility()).not.toBe(null);
     }, 600000);

--- a/test/TestCases/Case02/Case02.02.test.js
+++ b/test/TestCases/Case02/Case02.02.test.js
@@ -4,7 +4,7 @@ import fs from "fs";
 const outputFolderPath = './test/TestCases/Case02/output';
 
 describe('Validate output content', () => {
-    afterAll(async () => {
+    afterAll(() => {
         fs.rmSync(outputFolderPath, {recursive: true});
     });
     

--- a/test/TestCases/Case02/Case02.02.test.js
+++ b/test/TestCases/Case02/Case02.02.test.js
@@ -1,0 +1,19 @@
+import { checkFolderContainsFiles } from '../../testLib';
+import fs from "fs";
+
+const outputFolderPath = './test/TestCases/Case02/output';
+
+describe('Validate output content', () => {
+    afterAll(async () => {
+        fs.rmSync(outputFolderPath, {recursive: true});
+    });
+    
+    checkFolderContainsFiles(outputFolderPath, [
+        'output.jsresolver.graphql.js',
+        'output.neptune.schema.json',
+        'output.resolver.graphql.js',
+        'output.resolver.schema.json',
+        'output.schema.graphql',
+        'output.source.schema.graphql'
+    ]);
+});

--- a/test/TestCases/Case03/Case03.02.test.js
+++ b/test/TestCases/Case03/Case03.02.test.js
@@ -1,0 +1,17 @@
+import { checkFolderContainsFiles } from '../../testLib';
+import fs from "fs";
+
+const outputFolderPath = './test/TestCases/Case03/output';
+
+describe('Validate output content', () => {
+    afterAll(async () => {
+        fs.rmSync(outputFolderPath, {recursive: true});
+    });
+    
+    checkFolderContainsFiles(outputFolderPath, [
+        'output.resolver.graphql.js',
+        'output.resolver.schema.json',
+        'output.schema.graphql',
+        'output.source.schema.graphql'
+    ]);
+});

--- a/test/TestCases/Case03/Case03.02.test.js
+++ b/test/TestCases/Case03/Case03.02.test.js
@@ -4,7 +4,7 @@ import fs from "fs";
 const outputFolderPath = './test/TestCases/Case03/output';
 
 describe('Validate output content', () => {
-    afterAll(async () => {
+    afterAll(() => {
         fs.rmSync(outputFolderPath, {recursive: true});
     });
     

--- a/test/TestCases/Case04/Case04.02.test.js
+++ b/test/TestCases/Case04/Case04.02.test.js
@@ -1,23 +1,31 @@
-import { readJSONFile, checkOutputFileContent, checkOutputFilesSize } from '../../testLib';
+import { readJSONFile, checkOutputFileContent, checkFolderContainsFiles } from '../../testLib';
 import { sortNeptuneSchema } from './util';
 import fs from "fs";
+import { parseNeptuneEndpoint } from "../../../src/util.js";
 
 const casetest = readJSONFile('./test/TestCases/Case04/case.json');
+const testDbInfo = parseNeptuneEndpoint(casetest.host + ':' + casetest.port);
+const outputFolderPath = './test/TestCases/Case04/output';
 
-checkOutputFilesSize('./test/TestCases/Case04/output', casetest.testOutputFilesSize, './test/TestCases/Case04/outputReference');
+const neptuneSchema = readJSONFile(`./test/TestCases/Case04/output/${testDbInfo.graphName}.output.neptune.schema.json`);
+const refNeptuneSchema = readJSONFile(`./test/TestCases/Case04/outputReference/output.neptune.schema.json`);
 
-const neptuneSchema = readJSONFile('./test/TestCases/Case04/output/output.neptune.schema.json');
-const refNeptuneSchema = readJSONFile('./test/TestCases/Case04/outputReference/output.neptune.schema.json');
-
-describe('Validate neptune schema', () => {
+describe('Validate output content', () => {
     afterAll(async () => {
-        fs.rmSync('./test/TestCases/Case04/output', {recursive: true});
+        fs.rmSync(outputFolderPath, {recursive: true});
     });
+
+    checkFolderContainsFiles(outputFolderPath, [
+        `${testDbInfo.graphName}.output.resolver.graphql.js`,
+        `${testDbInfo.graphName}.output.resolver.schema.json`,
+        `${testDbInfo.graphName}.output.schema.graphql`,
+        `${testDbInfo.graphName}.output.source.schema.graphql`
+    ]);
 
     // note that this test can be flaky depending on how the air routes sample data was loaded into neptune
     // for more consistent results, use neptune notebook %seed with gremlin language
     checkOutputFileContent(
-    'output.neptune.schema.json',
+    `${testDbInfo.graphName}.output.neptune.schema.json`,
     sortNeptuneSchema(neptuneSchema),
     sortNeptuneSchema(refNeptuneSchema),
     { checkRefIntegrity: false }

--- a/test/TestCases/Case04/Case04.02.test.js
+++ b/test/TestCases/Case04/Case04.02.test.js
@@ -11,7 +11,7 @@ const neptuneSchema = readJSONFile(`./test/TestCases/Case04/output/${testDbInfo.
 const refNeptuneSchema = readJSONFile(`./test/TestCases/Case04/outputReference/output.neptune.schema.json`);
 
 describe('Validate output content', () => {
-    afterAll(async () => {
+    afterAll(() => {
         fs.rmSync(outputFolderPath, {recursive: true});
     });
 

--- a/test/TestCases/Case05/Case05.02.test.js
+++ b/test/TestCases/Case05/Case05.02.test.js
@@ -14,7 +14,7 @@ describe('Validate pipeline with http resolver output content', () => {
         'AirportsJestTest.zip'
     ]);
 
-    test('Zip file contains expected files', async () => {
+    test('Zip file contains expected files', () => {
         const expectedFiles = [
             'index.mjs',
             'node_modules',

--- a/test/TestCases/Case05/Case05.02.test.js
+++ b/test/TestCases/Case05/Case05.02.test.js
@@ -1,20 +1,37 @@
-import { readJSONFile } from '../../testLib';
-import { main } from "../../../src/main";
+import { checkFolderContainsFiles, unzipAndGetContents } from '../../testLib';
 import fs from "fs";
+import path from "path";
 
-const casetest = readJSONFile('./test/TestCases/Case05/case02.json');
+const outputFolderPath = './test/TestCases/Case05/output';
 
-async function executeUtility() {    
-    process.argv = casetest.argv;
-    await main();
-}
+describe('Validate pipeline with http resolver output content', () => {
+    checkFolderContainsFiles(outputFolderPath, [
+        'AirportsJestTest.resolver.graphql.js',
+        'AirportsJestTest.resolver.schema.json',
+        'AirportsJestTest-resources.json',
+        'AirportsJestTest.schema.graphql',
+        'AirportsJestTest.source.schema.graphql',
+        'AirportsJestTest.zip'
+    ]);
 
-describe('Cleanup resources', () => {
-    afterAll(async () => {
-        fs.rmSync('./test/TestCases/Case05/output', {recursive: true});
+    test('Zip file contains expected files', async () => {
+        const expectedFiles = [
+            'index.mjs',
+            'node_modules',
+            'output.resolver.graphql.js',
+            'output.resolver.schema.json',
+            'package-lock.json',
+            'package.json',
+            'queryHttpNeptune.mjs'
+        ];
+        
+        
+        const unzippedFolder = path.join(outputFolderPath, 'unzipped');
+        const actualFiles = unzipAndGetContents(unzippedFolder, path.join(outputFolderPath, 'AirportsJestTest.zip'));
+        expect(actualFiles.toSorted()).toEqual(expectedFiles.toSorted());
+
+        // resolver should be using axios http client
+        const fileContent = fs.readFileSync(path.join(unzippedFolder, 'index.mjs'), 'utf8');
+        expect(fileContent).toContain('axios');
     });
-
-    test('Execute utility: ' + casetest.argv.join(' '), async () => {
-        expect(await executeUtility()).not.toBe(null);
-    }, 600000);
 });

--- a/test/TestCases/Case05/Case05.03.test.js
+++ b/test/TestCases/Case05/Case05.03.test.js
@@ -10,7 +10,7 @@ async function executeUtility() {
 }
 
 describe('Cleanup resources', () => {
-    afterAll(async () => {
+    afterAll(() => {
         fs.rmSync('./test/TestCases/Case05/output', {recursive: true});
     });
 

--- a/test/TestCases/Case05/Case05.03.test.js
+++ b/test/TestCases/Case05/Case05.03.test.js
@@ -2,14 +2,18 @@ import { readJSONFile } from '../../testLib';
 import { main } from "../../../src/main";
 import fs from "fs";
 
-const casetest = readJSONFile('./test/TestCases/Case03/case.json');
+const casetest = readJSONFile('./test/TestCases/Case05/case02.json');
 
 async function executeUtility() {    
     process.argv = casetest.argv;
     await main();
 }
 
-describe('Validate successful execution', () => {
+describe('Cleanup resources', () => {
+    afterAll(async () => {
+        fs.rmSync('./test/TestCases/Case05/output', {recursive: true});
+    });
+
     test('Execute utility: ' + casetest.argv.join(' '), async () => {
         expect(await executeUtility()).not.toBe(null);
     }, 600000);

--- a/test/TestCases/Case06/Case06.02.test.js
+++ b/test/TestCases/Case06/Case06.02.test.js
@@ -10,11 +10,11 @@ if (casetest.host.includes('neptune-graph')) {
 const outputFolderPath = './test/TestCases/Case06/case01-output';
 
 describe('Validate cdk pipeline with http resolver output content', () => {
-    afterAll(async () => {
+    afterAll(() => {
         fs.rmSync(outputFolderPath, {recursive: true});
     });
 
-    test('Zip file contains expected files', async () => {
+    test('Zip file contains expected files', () => {
         const expectedFiles = [
             'index.mjs',
             'node_modules',

--- a/test/TestCases/Case06/Case06.03.test.js
+++ b/test/TestCases/Case06/Case06.03.test.js
@@ -1,7 +1,7 @@
 import { readJSONFile } from '../../testLib';
 import { main } from "../../../src/main";
 
-const casetest = readJSONFile('./test/TestCases/Case06/case01.json');
+const casetest = readJSONFile('./test/TestCases/Case06/case02.json');
 
 async function executeUtility() {    
     process.argv = casetest.argv;

--- a/test/TestCases/Case06/Case06.04.test.js
+++ b/test/TestCases/Case06/Case06.04.test.js
@@ -5,11 +5,11 @@ import path from "path";
 const outputFolderPath = './test/TestCases/Case06/case02-output';
 
 describe('Validate cdk pipeline with sdk resolver output content', () => {
-    afterAll(async () => {
+    afterAll(() => {
         fs.rmSync(outputFolderPath, {recursive: true});
     });
 
-    test('Zip file contains expected files', async () => {
+    test('Zip file contains expected files', () => {
         const expectedFiles = [
             'index.mjs',
             'node_modules',

--- a/test/TestCases/Case06/Case06.04.test.js
+++ b/test/TestCases/Case06/Case06.04.test.js
@@ -1,0 +1,29 @@
+import { unzipAndGetContents } from '../../testLib';
+import fs from "fs";
+import path from "path";
+
+const outputFolderPath = './test/TestCases/Case06/case02-output';
+
+describe('Validate cdk pipeline with sdk resolver output content', () => {
+    afterAll(async () => {
+        fs.rmSync(outputFolderPath, {recursive: true});
+    });
+
+    test('Zip file contains expected files', async () => {
+        const expectedFiles = [
+            'index.mjs',
+            'node_modules',
+            'output.resolver.graphql.js',
+            'output.resolver.schema.json',
+            'package-lock.json',
+            'package.json'
+        ];
+        const unzippedFolder = path.join(outputFolderPath, 'cdk-unzipped');
+        const actualFiles = unzipAndGetContents(unzippedFolder, path.join(outputFolderPath, 'AirportCDKSDKTestJest.zip'));
+        expect(actualFiles.toSorted()).toEqual(expectedFiles.toSorted());
+
+        // resolver should be using aws sdk
+        const fileContent = fs.readFileSync(path.join(unzippedFolder, 'index.mjs'), 'utf8');
+        expect(fileContent).toContain('@aws-sdk/client-neptune');
+    });
+});

--- a/test/TestCases/Case06/case01.json
+++ b/test/TestCases/Case06/case01.json
@@ -1,9 +1,9 @@
 {
-    "name": "Unit Test (Air Routes) CDK Pipeline",
-    "description":"Create CDK pipeline",
+    "name": "Integration Test (Air Routes) CDK HTTP Pipeline",
+    "description":"Create CDK pipeline with http resolver",
     "argv":["--quiet", 
             "--input-schema-file", "./test/TestCases/airports.source.schema.graphql",
-            "--output-folder-path", "./test/TestCases/Case06/output",
+            "--output-folder-path", "./test/TestCases/Case06/case01-output",
             "--output-aws-pipeline-cdk",
             "--output-aws-pipeline-cdk-name", "AirportCDKTestJest",
             "--output-aws-pipeline-cdk-neptune-database-name", "airport00",
@@ -11,7 +11,5 @@
             "--output-aws-pipeline-cdk-neptune-endpoint", "<AIR_ROUTES_DB_HOST>:<AIR_ROUTES_DB_PORT>",
             "--output-resolver-query-https"],
     "host": "<AIR_ROUTES_DB_HOST>",
-    "port": "<AIR_ROUTES_DB_PORT>",
-    "testOutputFilesSize": ["output.resolver.graphql.js", "output.schema.graphql", "output.source.schema.graphql"],
-    "testOutputFilesContent": ["output.schema.graphql", "output.source.schema.graphql"]
+    "port": "<AIR_ROUTES_DB_PORT>"
 }

--- a/test/TestCases/Case06/case02.json
+++ b/test/TestCases/Case06/case02.json
@@ -1,0 +1,15 @@
+{
+    "name": "Integration Test (Air Routes) CDK SDK Pipeline",
+    "description":"Create CDK pipeline with sdk resolver",
+    "argv":["--quiet", 
+            "--input-schema-file", "./test/TestCases/airports.source.schema.graphql",
+            "--output-folder-path", "./test/TestCases/Case06/case02-output",
+            "--output-aws-pipeline-cdk",
+            "--output-aws-pipeline-cdk-name", "AirportCDKSDKTestJest",
+            "--output-aws-pipeline-cdk-neptune-database-name", "airport00",
+            "--output-aws-pipeline-cdk-region", "us-east-1",
+            "--output-aws-pipeline-cdk-neptune-endpoint", "<AIR_ROUTES_DB_HOST>:<AIR_ROUTES_DB_PORT>",
+            "--output-resolver-query-sdk"],
+    "host": "<AIR_ROUTES_DB_HOST>",
+    "port": "<AIR_ROUTES_DB_PORT>"
+}

--- a/test/TestCases/Case07/Case07.02.test.js
+++ b/test/TestCases/Case07/Case07.02.test.js
@@ -1,16 +1,45 @@
-import {checkFolderContainsFiles, checkOutputFilesContent, checkOutputZipLambdaUsesSdk, readJSONFile} from '../../testLib';
+import { checkFolderContainsFiles, compareFileContents, unzipAndGetContents } from '../../testLib';
+import path from "path";
+import fs from "fs";
 
-describe('Validate output files', () => {
-    const casetest = readJSONFile('./test/TestCases/Case07/case01.json');
+const outputFolderPath = './test/TestCases/Case07/output';
+const referenceFolder = './test/TestCases/Case07/outputReference';
+
+describe('Validate pipeline with sdk resolver output content', () => {
     const expectedFiles = [
         'AirportsJestSDKTest.resolver.schema.json',
         'AirportsJestSDKTest.zip',
         'AirportsJestSDKTest-resources.json',
-        'output.resolver.graphql.js',
-        'output.schema.graphql',
-        'output.source.schema.graphql'
+        'sdk.resolver.graphql.js',
+        'sdk.schema.graphql',
+        'sdk.source.schema.graphql'
     ];
-    checkFolderContainsFiles('./test/TestCases/Case07/output', expectedFiles);
-    checkOutputFilesContent('./test/TestCases/Case07/output', casetest.testOutputFilesContent, './test/TestCases/Case07/outputReference');
-    checkOutputZipLambdaUsesSdk('./test/TestCases/Case07/output', './test/TestCases/Case07/output/AirportsJestSDKTest.zip');
+    checkFolderContainsFiles(outputFolderPath, expectedFiles);
+    compareFileContents([{
+        expected: path.join(referenceFolder, 'output.schema.graphql'),
+        actual: path.join(outputFolderPath, 'sdk.schema.graphql')
+    }, {
+        expected: path.join(referenceFolder, 'output.source.schema.graphql'),
+        actual: path.join(outputFolderPath, 'sdk.source.schema.graphql')
+    }]);
+    
+    test('Zip file contains expected files', async () => {
+        const expectedFiles = [
+            'index.mjs',
+            'node_modules',
+            'output.resolver.graphql.js',
+            'output.resolver.schema.json',
+            'package-lock.json',
+            'package.json'
+        ];
+
+
+        const unzippedFolder = path.join(outputFolderPath, 'unzipped');
+        const actualFiles = unzipAndGetContents(unzippedFolder, path.join(outputFolderPath, 'AirportsJestSDKTest.zip'));
+        expect(actualFiles.toSorted()).toEqual(expectedFiles.toSorted());
+
+        // resolver should be using aws sdk
+        const fileContent = fs.readFileSync(path.join(unzippedFolder, 'index.mjs'), 'utf8');
+        expect(fileContent).toContain('@aws-sdk/client-neptune');
+    });
 });

--- a/test/TestCases/Case07/Case07.02.test.js
+++ b/test/TestCases/Case07/Case07.02.test.js
@@ -23,7 +23,7 @@ describe('Validate pipeline with sdk resolver output content', () => {
         actual: path.join(outputFolderPath, 'sdk.source.schema.graphql')
     }]);
     
-    test('Zip file contains expected files', async () => {
+    test('Zip file contains expected files', () => {
         const expectedFiles = [
             'index.mjs',
             'node_modules',

--- a/test/TestCases/Case07/case01.json
+++ b/test/TestCases/Case07/case01.json
@@ -4,14 +4,13 @@
     "argv":["--quiet",
             "--input-schema-file", "./test/TestCases/airports.source.schema.graphql",
             "--output-folder-path", "./test/TestCases/Case07/output",
-            "--output-schema-file", "./test/TestCases/Case07/output/output.schema.graphql",
-            "--output-source-schema-file", "./test/TestCases/Case07/output/output.source.schema.graphql",
-            "--output-js-resolver-file", "./test/TestCases/Case07/output/output.resolver.graphql.js",
+            "--output-schema-file", "./test/TestCases/Case07/output/sdk.schema.graphql",
+            "--output-source-schema-file", "./test/TestCases/Case07/output/sdk.source.schema.graphql",
+            "--output-js-resolver-file", "./test/TestCases/Case07/output/sdk.resolver.graphql.js",
             "--create-update-aws-pipeline",
             "--create-update-aws-pipeline-name", "AirportsJestSDKTest",
             "--create-update-aws-pipeline-neptune-endpoint", "<AIR_ROUTES_DB_HOST>:<AIR_ROUTES_DB_PORT>",
             "--output-resolver-query-sdk"],
     "host": "<AIR_ROUTES_DB_HOST>",
-    "port": "<AIR_ROUTES_DB_PORT>",
-    "testOutputFilesContent": ["output.schema.graphql", "output.source.schema.graphql"]
+    "port": "<AIR_ROUTES_DB_PORT>"
 }

--- a/test/TestCases/Case09/Case09.02.test.js
+++ b/test/TestCases/Case09/Case09.02.test.js
@@ -7,7 +7,7 @@ const testDbInfo = parseNeptuneEndpoint(testCase.host + ':' + testCase.port);
 
 const outputFolderPath = './test/TestCases/Case09/output';
 describe('Validate Apollo Server Subgraph output artifacts', () => {
-    afterAll(async () => {
+    afterAll(() => {
         fs.rmSync(outputFolderPath, {recursive: true});
     });
 

--- a/test/TestCases/Case09/Case09.02.test.js
+++ b/test/TestCases/Case09/Case09.02.test.js
@@ -1,4 +1,4 @@
-import {readJSONFile, testApolloArtifacts} from '../../testLib';
+import { checkFolderContainsFiles, readJSONFile, testApolloArtifacts } from '../../testLib';
 import fs from "fs";
 import {parseNeptuneEndpoint} from "../../../src/util.js";
 
@@ -10,6 +10,14 @@ describe('Validate Apollo Server Subgraph output artifacts', () => {
     afterAll(async () => {
         fs.rmSync(outputFolderPath, {recursive: true});
     });
+
+    checkFolderContainsFiles(outputFolderPath, [
+        `${testDbInfo.graphName}.output.neptune.schema.json`,
+        `${testDbInfo.graphName}.output.resolver.graphql.js`,
+        `${testDbInfo.graphName}.output.resolver.schema.json`,
+        `${testDbInfo.graphName}.output.schema.graphql`,
+        `${testDbInfo.graphName}.output.source.schema.graphql`
+    ]);
 
     testApolloArtifacts(outputFolderPath, testDbInfo, true);
 });

--- a/test/testLib.js
+++ b/test/testLib.js
@@ -49,18 +49,11 @@ function readJSONFile(fileName) {
     return JSON.parse(text);
 }
 
-
-function checkOutputFilesSize(outputFolder, files, referenceFolder) {    
-    files.forEach(file => {        
-        const stats = fs.statSync(`${outputFolder}/${file}`);
-        const referenceStats = fs.statSync(`${referenceFolder}/${file}`);
-        test('File size: ' + file, async () => {
-            expect.assertions(1);
-            expect(stats.size).toBe(referenceStats.size);
-        });
-    });
-}
-
+/**
+ * Checks that a given folder contains expected files.
+ * @param {string} folderPath the folder to check for files
+ * @param {string[]} fileNames the names of the files that are expected to be in the given folder
+ */
 function checkFolderContainsFiles(folderPath, fileNames= []) {
     fileNames.forEach(fileName => {
         test(`File ${fileName} exists in output folder ${folderPath}`, async () => {
@@ -70,11 +63,17 @@ function checkFolderContainsFiles(folderPath, fileNames= []) {
     });
 }
 
-function checkOutputFilesContent(outputFolder, files, referenceFolder) {    
-    files.forEach(file => {        
-        const stats = fs.readFileSync(`${outputFolder}/${file}`, 'utf8');
-        const referenceStats = fs.readFileSync(`${referenceFolder}/${file}`, 'utf8');        
-        checkOutputFileContent(file, stats, referenceStats);
+/**
+ * Compares the contents of files which are expected to be the same
+ * @param {object[]} files array of files to compare
+ * @param {string} files.expected path to the file with expected content
+ * @param {string} files.actual path to the file with actual content to compare with the associated expected file
+ */
+function compareFileContents(files = [{expected: '', actual: ''}]) {
+    files.forEach(file => {
+        const expectedStats = fs.readFileSync(file.expected, 'utf8');
+        const actualStats = fs.readFileSync(file.actual, 'utf8');
+        checkOutputFileContent(file, expectedStats, actualStats);
     });
 }
 
@@ -220,9 +219,8 @@ export {
     checkFileContains,
     checkFolderContainsFiles,
     checkOutputFileContent,
-    checkOutputFilesContent,
-    checkOutputFilesSize,
     checkOutputZipLambdaUsesSdk,
+    compareFileContents,
     loadResolver,
     readJSONFile,
     testApolloArtifacts,


### PR DESCRIPTION
This changeset fixes a couple cdk deployment bugs:
* changed `CDKPipelineApp.js` to call the `createLambdaDeploymentPackage` function so that it uses the same logic as non-cdk deployment pipeline and will now include previously missing files (json schema file and queryHttpNeptune.mjs) which are necessary for lambda resolver execution
* fixed the cdk app sync event handler to pass along variables as part of the event, which is necessary in order for the resolver to handle query variables

This changeset also contains improvements to output file logic and test coverage:
* changed `main.js` to determine an output file prefix once before any output files are created to repeated code duplication
* changed `main.js` to reference the neptune graph name as part of the output file prefix for scenarios where a pipeline is not being executed as to avoid overwriting existing files from a previous utility execution
* changed `createZip` function in `zipPackage.js` to wait for the zip file stream to be closed before resolving the promise so that the integration tests would not attempt to read the zip file before it was finished being written
* added verification of expected output files to test cases that were previously missing it
* removed test function `checkOutputFilesSize` and its usages as it is unnecessary to verify output file sizes if their content is also being checked for equality
* replaced `checkOutputFilesContent` test function which assumed output files had the same name as the comparison files with new function `compareFileContents` which is more flexible with file names

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
