### PR TITLE
Replace graphql-tag.gql with graphql.parse for resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This release contains new support for Apollo Server integration.
 * Fixed usage of variables with nested edge subqueries (([#100](https://github.com/aws/amazon-neptune-for-graphql/pull/100))
 * Fixed cdk output file to contain previously missing files that were necessary to execute the lambda resolver (([#106](https://github.com/aws/amazon-neptune-for-graphql/pull/106))
 * Fixed resolution of nested variables in selection set arguments (([#108](https://github.com/aws/amazon-neptune-for-graphql/pull/108))
+* Changed resolver to use `graphql` `parse` instead of `graphql-tag` `gql` to avoid stale values due to caching (([#109](https://github.com/aws/amazon-neptune-for-graphql/pull/109))
 
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -6664,9 +6664,9 @@
       }
     },
     "node_modules/archiver-utils/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -6986,9 +6986,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10200,9 +10200,9 @@
       }
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/src/test/templates/JSResolverOCHTTPS.test.js
+++ b/src/test/templates/JSResolverOCHTTPS.test.js
@@ -1283,9 +1283,11 @@ test('should resolve multiple app sync events with updated variable values', () 
         field: 'getNodeAirports',
         arguments: { options: { limit: 3 } },
         selectionSetGraphQL: '{ code, airportRoutesOut(filter: {country: {eq: $country}}, options: {limit: $limit}) { code } }',
+        // initial variable values
         variables: { country: 'CA',  limit: 2}
     });
 
+    // first result should reflect initial variable values
     expect(firstResult).toEqual({
         query: 'MATCH (getNodeAirports_Airport:`airport`) WITH getNodeAirports_Airport LIMIT 3\n' +
             'OPTIONAL MATCH (getNodeAirports_Airport)-[getNodeAirports_Airport_airportRoutesOut_route:route]->(getNodeAirports_Airport_airportRoutesOut:`airport`) WHERE getNodeAirports_Airport_airportRoutesOut.country = $getNodeAirports_Airport_airportRoutesOut_country\n' +
@@ -1300,9 +1302,11 @@ test('should resolve multiple app sync events with updated variable values', () 
         field: 'getNodeAirports',
         arguments: { options: { limit: 3 } },
         selectionSetGraphQL: '{ code, airportRoutesOut(filter: {country: {eq: $country}}, options: {limit: $limit}) { code } }',
+        // updated variable values
         variables: { country: 'MX',  limit: 1}
     });
 
+    // second result should reflect updated variable values
     expect(secondResult).toEqual({
         query: 'MATCH (getNodeAirports_Airport:`airport`) WITH getNodeAirports_Airport LIMIT 3\n' +
             'OPTIONAL MATCH (getNodeAirports_Airport)-[getNodeAirports_Airport_airportRoutesOut_route:route]->(getNodeAirports_Airport_airportRoutesOut:`airport`) WHERE getNodeAirports_Airport_airportRoutesOut.country = $getNodeAirports_Airport_airportRoutesOut_country\n' +

--- a/src/test/templates/JSResolverOCHTTPS.test.js
+++ b/src/test/templates/JSResolverOCHTTPS.test.js
@@ -1277,3 +1277,39 @@ test('should throw error for query with multiple sort arguments in one object', 
         });
     }).toThrow('Cannot have more than one field in a single sort object. Please use multiple single-field sort objects instead');
 });
+
+test('should resolve multiple app sync events with updated variable values', () => {
+    const firstResult = resolveGraphDBQueryFromAppSyncEvent({
+        field: 'getNodeAirports',
+        arguments: { options: { limit: 3 } },
+        selectionSetGraphQL: '{ code, airportRoutesOut(filter: {country: {eq: $country}}, options: {limit: $limit}) { code } }',
+        variables: { country: 'CA',  limit: 2}
+    });
+
+    expect(firstResult).toEqual({
+        query: 'MATCH (getNodeAirports_Airport:`airport`) WITH getNodeAirports_Airport LIMIT 3\n' +
+            'OPTIONAL MATCH (getNodeAirports_Airport)-[getNodeAirports_Airport_airportRoutesOut_route:route]->(getNodeAirports_Airport_airportRoutesOut:`airport`) WHERE getNodeAirports_Airport_airportRoutesOut.country = $getNodeAirports_Airport_airportRoutesOut_country\n' +
+            'WITH getNodeAirports_Airport, CASE WHEN getNodeAirports_Airport_airportRoutesOut IS NULL THEN [] ELSE COLLECT({code: getNodeAirports_Airport_airportRoutesOut.`code`})[..2] END AS getNodeAirports_Airport_airportRoutesOut_collect\n' +
+            'RETURN collect({code: getNodeAirports_Airport.`code`, airportRoutesOut: getNodeAirports_Airport_airportRoutesOut_collect})[..3]',
+        parameters: { getNodeAirports_Airport_airportRoutesOut_country: 'CA'},
+        language: 'opencypher',
+        refactorOutput: null
+    });
+
+    const secondResult = resolveGraphDBQueryFromAppSyncEvent({
+        field: 'getNodeAirports',
+        arguments: { options: { limit: 3 } },
+        selectionSetGraphQL: '{ code, airportRoutesOut(filter: {country: {eq: $country}}, options: {limit: $limit}) { code } }',
+        variables: { country: 'MX',  limit: 1}
+    });
+
+    expect(secondResult).toEqual({
+        query: 'MATCH (getNodeAirports_Airport:`airport`) WITH getNodeAirports_Airport LIMIT 3\n' +
+            'OPTIONAL MATCH (getNodeAirports_Airport)-[getNodeAirports_Airport_airportRoutesOut_route:route]->(getNodeAirports_Airport_airportRoutesOut:`airport`) WHERE getNodeAirports_Airport_airportRoutesOut.country = $getNodeAirports_Airport_airportRoutesOut_country\n' +
+            'WITH getNodeAirports_Airport, CASE WHEN getNodeAirports_Airport_airportRoutesOut IS NULL THEN [] ELSE COLLECT({code: getNodeAirports_Airport_airportRoutesOut.`code`})[..1] END AS getNodeAirports_Airport_airportRoutesOut_collect\n' +
+            'RETURN collect({code: getNodeAirports_Airport.`code`, airportRoutesOut: getNodeAirports_Airport_airportRoutesOut_collect})[..3]',
+        parameters: { getNodeAirports_Airport_airportRoutesOut_country: 'MX'},
+        language: 'opencypher',
+        refactorOutput: null
+    });
+});

--- a/templates/ApolloServer/package-lock.json
+++ b/templates/ApolloServer/package-lock.json
@@ -15,7 +15,7 @@
         "aws4-axios": "^3.3.14",
         "axios": "^1.7.9",
         "dotenv": "^16.4.7",
-        "graphql-tag": "^2.12.6",
+        "graphql": "^16.8.1",
         "retry-axios": "^3.1.3"
       }
     },
@@ -2384,24 +2384,8 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
       "integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/graphql-tag": {
-      "version": "2.12.6",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
-      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/has-flag": {

--- a/templates/ApolloServer/package.json
+++ b/templates/ApolloServer/package.json
@@ -15,7 +15,7 @@
     "@aws-sdk/credential-providers": "^3.729.0",
     "aws4-axios": "^3.3.14",
     "axios": "^1.7.9",
-    "graphql-tag": "^2.12.6",
+    "graphql": "^16.8.1",
     "retry-axios": "^3.1.3",
     "dotenv": "^16.4.7"
   }

--- a/templates/JSResolverOCHTTPS.js
+++ b/templates/JSResolverOCHTTPS.js
@@ -10,8 +10,7 @@ express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 */
 
-import { astFromValue, buildASTSchema, GraphQLError, GraphQLID, GraphQLInputObjectType, typeFromAST } from 'graphql';
-import { gql } from 'graphql-tag'; // GraphQL library to parse the GraphQL query
+import { astFromValue, buildASTSchema, GraphQLError, GraphQLID, GraphQLInputObjectType, parse, typeFromAST } from 'graphql';
 
 const useCallSubquery = false;
 
@@ -43,7 +42,7 @@ export function resolveGraphDBQueryFromAppSyncEvent(event) {
         // fragments not yet supported in app sync - see https://github.com/aws-samples/appsync-with-postgraphile-rds/issues/18
         fragments: {},
         variables: event.variables,
-        selectionSet: event.selectionSetGraphQL ? gql`${event.selectionSetGraphQL}`.definitions[0].selectionSet : {}
+        selectionSet: event.selectionSetGraphQL ? parse(event.selectionSetGraphQL).definitions[0].selectionSet : {}
     });
 }
 
@@ -1399,7 +1398,7 @@ function resolveGremlinQuery(obj, querySchemaInfo) {
 function parseQueryInput(queryObjOrStr) {
     // Backwards compatibility
     if (typeof queryObjOrStr === 'string') {
-        return gql(queryObjOrStr);
+        return parse(queryObjOrStr);
     }
 
     // Already in AST format

--- a/templates/Lambda4AppSyncGraphSDK/package-lock.json
+++ b/templates/Lambda4AppSyncGraphSDK/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-neptune-graph": "3.662.0",
-        "graphql-tag": "2.12.6"
+        "graphql": "^16.8.1"
       }
     },
     "node_modules/@aws-crypto/sha256-browser": {
@@ -1272,24 +1272,8 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
       "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/graphql-tag": {
-      "version": "2.12.6",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
-      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/strnum": {

--- a/templates/Lambda4AppSyncGraphSDK/package.json
+++ b/templates/Lambda4AppSyncGraphSDK/package.json
@@ -11,6 +11,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/client-neptune-graph": "3.662.0",
-    "graphql-tag": "2.12.6"
+    "graphql": "^16.8.1"
   }
 }

--- a/templates/Lambda4AppSyncHTTP/package-lock.json
+++ b/templates/Lambda4AppSyncHTTP/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "aws4-axios": "3.3.0",
         "axios": "^1.9.0",
-        "graphql-tag": "2.12.6",
+        "graphql": "^16.8.1",
         "retry-axios": "3.1.0"
       }
     },
@@ -1303,24 +1303,8 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
       "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/graphql-tag": {
-      "version": "2.12.6",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
-      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/mime-db": {

--- a/templates/Lambda4AppSyncHTTP/package.json
+++ b/templates/Lambda4AppSyncHTTP/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "aws4-axios": "3.3.0",
     "axios": "^1.9.0",
-    "graphql-tag": "2.12.6",
+    "graphql": "^16.8.1",
     "retry-axios": "3.1.0"
   }
 }

--- a/templates/Lambda4AppSyncSDK/package-lock.json
+++ b/templates/Lambda4AppSyncSDK/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-neptunedata": "3.403.0",
-        "graphql-tag": "2.12.6"
+        "graphql": "^16.8.1"
       }
     },
     "node_modules/@aws-crypto/ie11-detection": {
@@ -1182,24 +1182,8 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
       "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/graphql-tag": {
-      "version": "2.12.6",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
-      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/strnum": {

--- a/templates/Lambda4AppSyncSDK/package.json
+++ b/templates/Lambda4AppSyncSDK/package.json
@@ -11,6 +11,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/client-neptunedata": "3.403.0",
-    "graphql-tag": "2.12.6"
+    "graphql": "^16.8.1"
   }
 }


### PR DESCRIPTION
Replace use of `graphql-tag` `gql` with `graphql` `parse` for server resolver code as `gql` can resolve stale cached variable values if the same variable name is referenced in subsequent queries. According to `graphql-tag` documentation, the library is meant for client-side code so may not be suitable for server-side usage. 

Note that this change fixes stale variable values on the resolver side but it is still possible that cached variable values can be referenced on the client-side. For example the default Apollo Studio UI and client for local environments have their own caching mechanisms and are out of scope for this changeset.

There is an additional change to update the `brace-expansion` version as the previous one had a minor vulnerability.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
