### PR TITLE
Resolver schema performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,3 +61,4 @@ This release contains new support for Apollo Server integration.
 * Enabled mutations for the Apollo Server ([#98](https://github.com/aws/amazon-neptune-for-graphql/pull/98))
 * Refactored integration tests to be less vulnerable to resolver logic changes ([#99](https://github.com/aws/amazon-neptune-for-graphql/pull/99))
 * Enabled usage of query fragments with Apollo Server ([#103](https://github.com/aws/amazon-neptune-for-graphql/pull/103))
+* Compressed resolver schema file and moved schema initialization outside of event handlers to improve performance ([#111](https://github.com/aws/amazon-neptune-for-graphql/pull/111))

--- a/src/CDKPipelineApp.js
+++ b/src/CDKPipelineApp.js
@@ -57,7 +57,7 @@ async function getSchemaFields(typeName) {
 async function createDeploymentFile(templateFolderPath, resolverFilePath) {
     try {
         const zipFilePath = path.join(RELATIVE_OUTPUT_PATH, `${NAME}.zip`);
-        const resolverSchemaFilePath = path.join(RELATIVE_OUTPUT_PATH, `${NAME}.resolver.schema.json`)
+        const resolverSchemaFilePath = path.join(RELATIVE_OUTPUT_PATH, `${NAME}.resolver.schema.json.gz`)
         await createLambdaDeploymentPackage({
             outputZipFilePath: zipFilePath,
             templateFolderPath: templateFolderPath,

--- a/src/main.js
+++ b/src/main.js
@@ -531,6 +531,7 @@ async function main() {
         const queryDataModelJSON = JSON.stringify(schemaModel, null, 2);
 
         try {
+            // resolver schema is compressed for better schema initialization performance
             await compressToGzipFile(queryDataModelJSON, resolverSchemaFile);
             loggerInfo('Wrote compressed schema for resolver to file: ' + yellow(resolverSchemaFile), {toConsole: true});
         } catch (err) {

--- a/src/pipelineResources.js
+++ b/src/pipelineResources.js
@@ -396,7 +396,7 @@ async function createLambdaRole() {
  */
 async function createDeploymentPackage(templateFolderPath, resolverFilePath) {
     const zipFilePath = path.join(thisOutputFolderPath, `${NAME}.zip`);
-    const resolverSchemaFilePath = path.join(thisOutputFolderPath, `${NAME}.resolver.schema.json`)
+    const resolverSchemaFilePath = path.join(thisOutputFolderPath, `${NAME}.resolver.schema.json.gz`)
     await createLambdaDeploymentPackage({
         outputZipFilePath: zipFilePath,
         templateFolderPath: templateFolderPath,

--- a/src/zipPackage.js
+++ b/src/zipPackage.js
@@ -4,26 +4,26 @@ import path from "path";
 import { fileURLToPath } from "url";
 import zlib from 'zlib';
 
-export function toGzipFile(inputString, gzipFilePath) {
+/**
+ * Compresses a string and writes it to a gzip file.
+ * @param {string} inputString - The string to compress
+ * @param {string} gzipFilePath - The path to the gzip file to write
+ * @returns {Promise<void>} - A promise that resolves when the compression is complete
+ */
+export function compressToGzipFile(inputString, gzipFilePath) {
     return new Promise((resolve, reject) => {
-        // Convert the string to a buffer
         const buffer = Buffer.from(inputString, 'utf-8');
-
-        // Compress the buffer
         zlib.gzip(buffer, (error, compressedBuffer) => {
             if (error) {
                 reject(`Error compressing string: ${error.message}`);
                 return;
             }
-
-            // Write the compressed buffer to a file
             fs.writeFile(gzipFilePath, compressedBuffer, (writeError) => {
                 if (writeError) {
                     reject(`Error writing to file: ${writeError.message}`);
                     return;
                 }
-
-                resolve(gzipFilePath);
+                resolve();
             });
         });
     });
@@ -131,10 +131,9 @@ export async function createApolloDeploymentPackage({zipFilePath, resolverFilePa
             {source: resolverFilePath, target: 'output.resolver.graphql.js'},
             {source: schemaFilePath, target: 'output.schema.graphql'},
             {source: resolverSchemaFilePath, target: 'output.resolver.schema.json.gz'},
-
+            {source: path.join(modulePath, '/../templates/util.mjs')},
             // querying neptune using SDK not yet supported
-            {source: path.join(modulePath, '/../templates/queryHttpNeptune.mjs')},
-            {source: path.join(modulePath, '/../templates/util.mjs')}
+            {source: path.join(modulePath, '/../templates/queryHttpNeptune.mjs')}
         ],
         includeContent: [{source: envVars.join('\n'), target: '.env'}],
         // exclude node_modules from apollo package

--- a/templates/ApolloServer/neptune.mjs
+++ b/templates/ApolloServer/neptune.mjs
@@ -1,12 +1,11 @@
 import axios from 'axios';
 import * as rax from 'retry-axios';
-import {aws4Interceptor} from 'aws4-axios';
-import {fromNodeProviderChain} from '@aws-sdk/credential-providers';
+import { aws4Interceptor } from 'aws4-axios';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import dotenv from 'dotenv';
-import {queryNeptune} from './queryHttpNeptune.mjs'
-import {resolveGraphDBQueryFromEvent, initSchema} from "./output.resolver.graphql.js";
-import {readFileSync} from "fs";
-
+import { queryNeptune } from './queryHttpNeptune.mjs'
+import { initSchema, resolveGraphDBQueryFromEvent } from "./output.resolver.graphql.js";
+import { decompressGzipToString } from './util.mjs';
 
 dotenv.config();
 
@@ -23,10 +22,11 @@ const interceptor = aws4Interceptor({
 axios.interceptors.request.use(interceptor);
 rax.attach();
 
+const schemaDataModelJSON = await decompressGzipToString('output.resolver.schema.json.gz');
+const schemaModel = JSON.parse(schemaDataModelJSON);
+initSchema(schemaModel);
+
 export async function resolveEvent(event) {
-    const schemaDataModelJSON = readFileSync('output.resolver.schema.json', 'utf-8');
-    let schemaModel = JSON.parse(schemaDataModelJSON);
-    initSchema(schemaModel);
     const resolved = resolveGraphDBQueryFromEvent(event);
     try {
         return queryNeptune(`https://${process.env.NEPTUNE_HOST}:${process.env.NEPTUNE_PORT}`, resolved, {loggingEnabled: loggingEnabled});

--- a/templates/Lambda4AppSyncGraphSDK/index.mjs
+++ b/templates/Lambda4AppSyncGraphSDK/index.mjs
@@ -1,16 +1,16 @@
-import {ExecuteQueryCommand, NeptuneGraphClient} from "@aws-sdk/client-neptune-graph";
-import {resolveGraphDBQueryFromAppSyncEvent, initSchema} from './output.resolver.graphql.js';
-import {readFileSync} from "fs";
+import { ExecuteQueryCommand, NeptuneGraphClient } from "@aws-sdk/client-neptune-graph";
+import { initSchema, resolveGraphDBQueryFromAppSyncEvent } from './output.resolver.graphql.js';
+import { decompressGzipToString } from './util.mjs';
 
 const PROTOCOL = 'https';
 const QUERY_LANGUAGE = 'OPEN_CYPHER';
 const RESOLVER_LANGUAGE = 'opencypher';
 
-const schemaDataModelJSON = readFileSync('output.resolver.schema.json', 'utf-8');
+let client;
+
+const schemaDataModelJSON = await decompressGzipToString('output.resolver.schema.json.gz');
 const schemaModel = JSON.parse(schemaDataModelJSON);
 initSchema(schemaModel);
-
-let client;
 
 function getClient() {
     if (!client) {

--- a/templates/Lambda4AppSyncGraphSDK/index.mjs
+++ b/templates/Lambda4AppSyncGraphSDK/index.mjs
@@ -6,6 +6,10 @@ const PROTOCOL = 'https';
 const QUERY_LANGUAGE = 'OPEN_CYPHER';
 const RESOLVER_LANGUAGE = 'opencypher';
 
+const schemaDataModelJSON = readFileSync('output.resolver.schema.json', 'utf-8');
+const schemaModel = JSON.parse(schemaDataModelJSON);
+initSchema(schemaModel);
+
 let client;
 
 function getClient() {
@@ -50,9 +54,6 @@ function log(message) {
  */
 function resolveGraphQuery(event) {
     try {
-        const schemaDataModelJSON = readFileSync('output.resolver.schema.json', 'utf-8');
-        let schemaModel = JSON.parse(schemaDataModelJSON);
-        initSchema(schemaModel);
         let resolver = resolveGraphDBQueryFromAppSyncEvent(event);
         if (resolver.language !== RESOLVER_LANGUAGE) {
             return onError('Unsupported resolver language:' + resolver.language)

--- a/templates/Lambda4AppSyncHTTP/index.mjs
+++ b/templates/Lambda4AppSyncHTTP/index.mjs
@@ -7,13 +7,16 @@ import {readFileSync} from "fs";
 
 const LOGGING_ENABLED = process.env.LOGGING_ENABLED;
 
+const schemaDataModelJSON = readFileSync('output.resolver.schema.json', 'utf-8');
+const schemaModel = JSON.parse(schemaDataModelJSON);
+initSchema(schemaModel);
+
 const {
     AWS_ACCESS_KEY_ID,
     AWS_SECRET_ACCESS_KEY,
     AWS_SESSION_TOKEN,
     AWS_REGION
 } = process.env;
-
 
 if (process.env.NEPTUNE_IAM_AUTH_ENABLED === 'true') {
     let serviceName;
@@ -47,9 +50,6 @@ export const handler = async (event) => {
     }
     try {
         // Create Neptune query from GraphQL query
-        const schemaDataModelJSON = readFileSync('output.resolver.schema.json', 'utf-8');
-        let schemaModel = JSON.parse(schemaDataModelJSON);
-        initSchema(schemaModel);
         const resolver = resolveGraphDBQueryFromAppSyncEvent(event);
         if (LOGGING_ENABLED) console.log("Resolver: ", resolver);
         return queryNeptune(`https://${process.env.NEPTUNE_HOST}:${process.env.NEPTUNE_PORT}`, resolver, {loggingEnabled: LOGGING_ENABLED})

--- a/templates/Lambda4AppSyncHTTP/index.mjs
+++ b/templates/Lambda4AppSyncHTTP/index.mjs
@@ -1,15 +1,11 @@
 import axios from "axios";
 import * as rax from 'retry-axios';
 import { aws4Interceptor } from "aws4-axios";
-import {resolveGraphDBQueryFromAppSyncEvent, initSchema} from './output.resolver.graphql.js';
-import {queryNeptune} from "./queryHttpNeptune.mjs";
-import {readFileSync} from "fs";
+import { initSchema, resolveGraphDBQueryFromAppSyncEvent } from './output.resolver.graphql.js';
+import { queryNeptune } from "./queryHttpNeptune.mjs";
+import { decompressGzipToString } from './util.mjs';
 
 const LOGGING_ENABLED = process.env.LOGGING_ENABLED;
-
-const schemaDataModelJSON = readFileSync('output.resolver.schema.json', 'utf-8');
-const schemaModel = JSON.parse(schemaDataModelJSON);
-initSchema(schemaModel);
 
 const {
     AWS_ACCESS_KEY_ID,
@@ -42,6 +38,10 @@ if (process.env.NEPTUNE_IAM_AUTH_ENABLED === 'true') {
 }
 
 rax.attach();
+
+const schemaDataModelJSON = await decompressGzipToString('output.resolver.schema.json.gz');
+const schemaModel = JSON.parse(schemaDataModelJSON);
+initSchema(schemaModel);
 
 export const handler = async (event) => {
     if (LOGGING_ENABLED) console.log("Event: ", event);

--- a/templates/Lambda4AppSyncSDK/index.mjs
+++ b/templates/Lambda4AppSyncSDK/index.mjs
@@ -1,6 +1,14 @@
-import { NeptunedataClient, ExecuteOpenCypherQueryCommand, ExecuteGremlinQueryCommand } from "@aws-sdk/client-neptunedata";
-import {resolveGraphDBQueryFromAppSyncEvent, refactorGremlinqueryOutput, initSchema} from './output.resolver.graphql.js';
-import {readFileSync} from "fs";
+import {
+    ExecuteGremlinQueryCommand,
+    ExecuteOpenCypherQueryCommand,
+    NeptunedataClient
+} from "@aws-sdk/client-neptunedata";
+import {
+    initSchema,
+    refactorGremlinqueryOutput,
+    resolveGraphDBQueryFromAppSyncEvent
+} from './output.resolver.graphql.js';
+import { decompressGzipToString } from './util.mjs';
 
 const LOGGING_ENABLED = process.env.LOGGING_ENABLED;
 
@@ -8,7 +16,7 @@ const config = {
     endpoint: `https://${process.env.NEPTUNE_HOST}:${process.env.NEPTUNE_PORT}`
 };
 
-const schemaDataModelJSON = readFileSync('output.resolver.schema.json', 'utf-8');
+const schemaDataModelJSON = await decompressGzipToString('output.resolver.schema.json.gz');
 const schemaModel = JSON.parse(schemaDataModelJSON);
 initSchema(schemaModel);
 

--- a/templates/Lambda4AppSyncSDK/index.mjs
+++ b/templates/Lambda4AppSyncSDK/index.mjs
@@ -8,6 +8,10 @@ const config = {
     endpoint: `https://${process.env.NEPTUNE_HOST}:${process.env.NEPTUNE_PORT}`
 };
 
+const schemaDataModelJSON = readFileSync('output.resolver.schema.json', 'utf-8');
+const schemaModel = JSON.parse(schemaDataModelJSON);
+initSchema(schemaModel);
+
 let client;
 
 function getClient() {
@@ -42,9 +46,6 @@ export const handler = async(event) => {
     let resolver = { query:'', parameters:{}, language: 'opencypher', fieldsAlias: {} };
 
     try {
-        const schemaDataModelJSON = readFileSync('output.resolver.schema.json', 'utf-8');
-        let schemaModel = JSON.parse(schemaDataModelJSON);
-        initSchema(schemaModel);
         resolver = resolveGraphDBQueryFromAppSyncEvent(event);
         if (LOGGING_ENABLED) console.log(JSON.stringify(resolver, null, 2));
     } catch (error) {

--- a/templates/util.mjs
+++ b/templates/util.mjs
@@ -1,0 +1,36 @@
+import { createReadStream } from "fs";
+import zlib from "zlib";
+
+/**
+ * Unzips a gzip file and returns its contents as a string
+ *
+ * @param {string} inputFilePath - Path to the gzipped file to be decompressed
+ * @returns {Promise<string>} - The decompressed file contents as a string
+ */
+export function decompressGzipToString(inputFilePath) {
+    return new Promise((resolve, reject) => {
+        const readStream = createReadStream(inputFilePath);
+        readStream.on('error', (err) => {
+            reject(`Error reading file: ${err.message}`);
+        });
+
+        const gunzip = zlib.createGunzip();
+        gunzip.on('error', (err) => {
+            reject(`Error decompressing file: ${err.message}`);
+        });
+
+        // Collect the decompressed data chunks
+        const chunks = [];
+        gunzip.on('data', (chunk) => {
+            chunks.push(chunk);
+        });
+
+        // When decompression is complete, return the string
+        gunzip.on('end', () => {
+            const result = Buffer.concat(chunks).toString('utf-8');
+            resolve(result);
+        });
+
+        readStream.pipe(gunzip);
+    });
+}

--- a/templates/util.mjs
+++ b/templates/util.mjs
@@ -11,12 +11,12 @@ export function decompressGzipToString(inputFilePath) {
     return new Promise((resolve, reject) => {
         const readStream = createReadStream(inputFilePath);
         readStream.on('error', (err) => {
-            reject(`Error reading file: ${err.message}`);
+            reject(`Error reading gzip file: ${err.message}`);
         });
 
         const gunzip = zlib.createGunzip();
         gunzip.on('error', (err) => {
-            reject(`Error decompressing file: ${err.message}`);
+            reject(`Error decompressing gzip file: ${err.message}`);
         });
 
         // Collect the decompressed data chunks

--- a/test/TestCases/Case01/Case01.02.test.js
+++ b/test/TestCases/Case01/Case01.02.test.js
@@ -5,7 +5,7 @@ describe('Validate output files', () => {
     const expectedFiles = [
         'output.resolver.graphql.js',
         'output.jsresolver.graphql.js',
-        'output.resolver.schema.json',
+        'output.resolver.schema.json.gz',
         'output.schema.graphql',
         'output.source.schema.graphql'
     ];

--- a/test/TestCases/Case01/Case01.03.test.js
+++ b/test/TestCases/Case01/Case01.03.test.js
@@ -6,7 +6,7 @@ const casetest = readJSONFile('./test/TestCases/Case01/case.json');
 try {
     await testResolverQueriesResults(   './TestCases/Case01/output/output.resolver.graphql.js',
         './test/TestCases/Case01/queries',
-        './test/TestCases/Case01/output/output.resolver.schema.json',
+        './test/TestCases/Case01/output/output.resolver.schema.json.gz',
         casetest.host,
         casetest.port);
 } finally {

--- a/test/TestCases/Case02/Case02.02.test.js
+++ b/test/TestCases/Case02/Case02.02.test.js
@@ -12,7 +12,7 @@ describe('Validate output content', () => {
         'output.jsresolver.graphql.js',
         'output.neptune.schema.json',
         'output.resolver.graphql.js',
-        'output.resolver.schema.json',
+        'output.resolver.schema.json.gz',
         'output.schema.graphql',
         'output.source.schema.graphql'
     ]);

--- a/test/TestCases/Case03/Case03.02.test.js
+++ b/test/TestCases/Case03/Case03.02.test.js
@@ -10,7 +10,7 @@ describe('Validate output content', () => {
     
     checkFolderContainsFiles(outputFolderPath, [
         'output.resolver.graphql.js',
-        'output.resolver.schema.json',
+        'output.resolver.schema.json.gz',
         'output.schema.graphql',
         'output.source.schema.graphql'
     ]);

--- a/test/TestCases/Case04/Case04.02.test.js
+++ b/test/TestCases/Case04/Case04.02.test.js
@@ -17,7 +17,7 @@ describe('Validate output content', () => {
 
     checkFolderContainsFiles(outputFolderPath, [
         `${testDbInfo.graphName}.output.resolver.graphql.js`,
-        `${testDbInfo.graphName}.output.resolver.schema.json`,
+        `${testDbInfo.graphName}.output.resolver.schema.json.gz`,
         `${testDbInfo.graphName}.output.schema.graphql`,
         `${testDbInfo.graphName}.output.source.schema.graphql`
     ]);
@@ -25,7 +25,7 @@ describe('Validate output content', () => {
     // note that this test can be flaky depending on how the air routes sample data was loaded into neptune
     // for more consistent results, use neptune notebook %seed with gremlin language
     checkOutputFileContent(
-    `${testDbInfo.graphName}.output.neptune.schema.json`,
+    `${testDbInfo.graphName}.output.neptune.schema.json.gz`,
     sortNeptuneSchema(neptuneSchema),
     sortNeptuneSchema(refNeptuneSchema),
     { checkRefIntegrity: false }

--- a/test/TestCases/Case05/Case05.02.test.js
+++ b/test/TestCases/Case05/Case05.02.test.js
@@ -1,4 +1,4 @@
-import { checkFolderContainsFiles, unzipAndGetContents } from '../../testLib';
+import { checkFolderContainsFiles, executeAppSyncQuery, unzipAndGetContents } from '../../testLib';
 import fs from "fs";
 import path from "path";
 
@@ -34,4 +34,12 @@ describe('Validate pipeline with http resolver output content', () => {
         const fileContent = fs.readFileSync(path.join(unzippedFolder, 'index.mjs'), 'utf8');
         expect(fileContent).toContain('axios');
     });
+
+    test('Can query app sync API successfully', async () => {
+        const awsResources = JSON.parse(fs.readFileSync(path.join(outputFolderPath, 'AirportsJestTest-resources.json'), 'utf8'));
+        const apiId = awsResources.AppSyncAPI;
+        const region = awsResources.region;
+        const response = await executeAppSyncQuery(apiId, 'query {getNodeContinents {code, desc}}', {}, region);
+        console.log(response);
+    }, 600000);
 });

--- a/test/TestCases/Case05/Case05.02.test.js
+++ b/test/TestCases/Case05/Case05.02.test.js
@@ -7,7 +7,7 @@ const outputFolderPath = './test/TestCases/Case05/output';
 describe('Validate pipeline with http resolver output content', () => {
     checkFolderContainsFiles(outputFolderPath, [
         'AirportsJestTest.resolver.graphql.js',
-        'AirportsJestTest.resolver.schema.json',
+        'AirportsJestTest.resolver.schema.json.gz',
         'AirportsJestTest-resources.json',
         'AirportsJestTest.schema.graphql',
         'AirportsJestTest.source.schema.graphql',
@@ -19,10 +19,11 @@ describe('Validate pipeline with http resolver output content', () => {
             'index.mjs',
             'node_modules',
             'output.resolver.graphql.js',
-            'output.resolver.schema.json',
+            'output.resolver.schema.json.gz',
             'package-lock.json',
             'package.json',
-            'queryHttpNeptune.mjs'
+            'queryHttpNeptune.mjs',
+            'util.mjs'
         ];
         
         

--- a/test/TestCases/Case05/Case05.02.test.js
+++ b/test/TestCases/Case05/Case05.02.test.js
@@ -39,7 +39,8 @@ describe('Validate pipeline with http resolver output content', () => {
         const awsResources = JSON.parse(fs.readFileSync(path.join(outputFolderPath, 'AirportsJestTest-resources.json'), 'utf8'));
         const apiId = awsResources.AppSyncAPI;
         const region = awsResources.region;
-        const response = await executeAppSyncQuery(apiId, 'query {getNodeContinents {code, desc}}', {}, region);
-        console.log(response);
+        const results = await executeAppSyncQuery(apiId, 'query {getNodeContinents {code}}', {}, region);
+        const codes = results.data.getNodeContinents.map(continent => continent.code).sort();
+        expect(codes).toEqual(['AF', 'AN', 'AS', 'EU', 'NA', 'OC', 'SA']);
     }, 600000);
 });

--- a/test/TestCases/Case06/Case06.02.test.js
+++ b/test/TestCases/Case06/Case06.02.test.js
@@ -19,10 +19,11 @@ describe('Validate cdk pipeline with http resolver output content', () => {
             'index.mjs',
             'node_modules',
             'output.resolver.graphql.js',
-            'output.resolver.schema.json',
+            'output.resolver.schema.json.gz',
             'package-lock.json',
             'package.json',
-            'queryHttpNeptune.mjs'
+            'queryHttpNeptune.mjs',
+            'util.mjs'
         ];
         const unzippedFolder = path.join(outputFolderPath, 'cdk-unzipped');
         const actualFiles = unzipAndGetContents(unzippedFolder, path.join(outputFolderPath, 'AirportCDKTestJest.zip'));

--- a/test/TestCases/Case06/Case06.04.test.js
+++ b/test/TestCases/Case06/Case06.04.test.js
@@ -14,9 +14,10 @@ describe('Validate cdk pipeline with sdk resolver output content', () => {
             'index.mjs',
             'node_modules',
             'output.resolver.graphql.js',
-            'output.resolver.schema.json',
+            'output.resolver.schema.json.gz',
             'package-lock.json',
-            'package.json'
+            'package.json',
+            'util.mjs'
         ];
         const unzippedFolder = path.join(outputFolderPath, 'cdk-unzipped');
         const actualFiles = unzipAndGetContents(unzippedFolder, path.join(outputFolderPath, 'AirportCDKSDKTestJest.zip'));

--- a/test/TestCases/Case07/Case07.02.test.js
+++ b/test/TestCases/Case07/Case07.02.test.js
@@ -1,4 +1,4 @@
-import { checkFolderContainsFiles, compareFileContents, unzipAndGetContents } from '../../testLib';
+import { checkFolderContainsFiles, compareFileContents, executeAppSyncQuery, unzipAndGetContents } from '../../testLib';
 import path from "path";
 import fs from "fs";
 
@@ -43,4 +43,13 @@ describe('Validate pipeline with sdk resolver output content', () => {
         const fileContent = fs.readFileSync(path.join(unzippedFolder, 'index.mjs'), 'utf8');
         expect(fileContent).toContain('@aws-sdk/client-neptune');
     });
+
+    test('Can query app sync API successfully', async () => {
+        const awsResources = JSON.parse(fs.readFileSync(path.join(outputFolderPath, 'AirportsJestSDKTest-resources.json'), 'utf8'));
+        const apiId = awsResources.AppSyncAPI;
+        const region = awsResources.region;
+        const results = await executeAppSyncQuery(apiId, 'query {getNodeContinents {code}}', {}, region);
+        const codes = results.data.getNodeContinents.map(continent => continent.code).sort();
+        expect(codes).toEqual(['AF', 'AN', 'AS', 'EU', 'NA', 'OC', 'SA']);
+    }, 600000);
 });

--- a/test/TestCases/Case07/Case07.02.test.js
+++ b/test/TestCases/Case07/Case07.02.test.js
@@ -7,7 +7,7 @@ const referenceFolder = './test/TestCases/Case07/outputReference';
 
 describe('Validate pipeline with sdk resolver output content', () => {
     const expectedFiles = [
-        'AirportsJestSDKTest.resolver.schema.json',
+        'AirportsJestSDKTest.resolver.schema.json.gz',
         'AirportsJestSDKTest.zip',
         'AirportsJestSDKTest-resources.json',
         'sdk.resolver.graphql.js',
@@ -28,9 +28,10 @@ describe('Validate pipeline with sdk resolver output content', () => {
             'index.mjs',
             'node_modules',
             'output.resolver.graphql.js',
-            'output.resolver.schema.json',
+            'output.resolver.schema.json.gz',
             'package-lock.json',
-            'package.json'
+            'package.json',
+            'util.mjs'
         ];
 
 

--- a/test/TestCases/Case09/Case09.02.test.js
+++ b/test/TestCases/Case09/Case09.02.test.js
@@ -14,7 +14,7 @@ describe('Validate Apollo Server Subgraph output artifacts', () => {
     checkFolderContainsFiles(outputFolderPath, [
         `${testDbInfo.graphName}.output.neptune.schema.json`,
         `${testDbInfo.graphName}.output.resolver.graphql.js`,
-        `${testDbInfo.graphName}.output.resolver.schema.json`,
+        `${testDbInfo.graphName}.output.resolver.schema.json.gz`,
         `${testDbInfo.graphName}.output.schema.graphql`,
         `${testDbInfo.graphName}.output.source.schema.graphql`
     ]);

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-appsync": "^3.445.0",
         "adm-zip": "0.5.16",
-        "axios": "^1.6.2",
+        "axios": "^1.9.0",
         "graphql-tag": "2.12.6"
       }
     },

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -9,8 +9,1213 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
+        "@aws-sdk/client-appsync": "^3.445.0",
         "adm-zip": "0.5.16",
+        "axios": "^1.6.2",
         "graphql-tag": "2.12.6"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-appsync": {
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-appsync/-/client-appsync-3.830.0.tgz",
+      "integrity": "sha512-Q+mOJOXlN0XuWwworLb/vKhM4NdapaXmFZBikb1JFJ9g61ejuUZVmcxpmwviOUgBdgbA8QpOpDF2wkYlsFN+FQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/credential-provider-node": "3.830.0",
+        "@aws-sdk/middleware-host-header": "3.821.0",
+        "@aws-sdk/middleware-logger": "3.821.0",
+        "@aws-sdk/middleware-recursion-detection": "3.821.0",
+        "@aws-sdk/middleware-user-agent": "3.828.0",
+        "@aws-sdk/region-config-resolver": "3.821.0",
+        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/util-endpoints": "3.828.0",
+        "@aws-sdk/util-user-agent-browser": "3.821.0",
+        "@aws-sdk/util-user-agent-node": "3.828.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.5.3",
+        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.11",
+        "@smithy/middleware-retry": "^4.1.12",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.19",
+        "@smithy/util-defaults-mode-node": "^4.0.19",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.5",
+        "@smithy/util-stream": "^4.2.2",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.830.0.tgz",
+      "integrity": "sha512-5zCEpfI+zwX2SIa258L+TItNbBoAvQQ6w74qdFM6YJufQ1F9tvwjTX8T+eSTT9nsFIvfYnUaGalWwJVfmJUgVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/middleware-host-header": "3.821.0",
+        "@aws-sdk/middleware-logger": "3.821.0",
+        "@aws-sdk/middleware-recursion-detection": "3.821.0",
+        "@aws-sdk/middleware-user-agent": "3.828.0",
+        "@aws-sdk/region-config-resolver": "3.821.0",
+        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/util-endpoints": "3.828.0",
+        "@aws-sdk/util-user-agent-browser": "3.821.0",
+        "@aws-sdk/util-user-agent-node": "3.828.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.5.3",
+        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.11",
+        "@smithy/middleware-retry": "^4.1.12",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.19",
+        "@smithy/util-defaults-mode-node": "^4.0.19",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.5",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.826.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.826.0.tgz",
+      "integrity": "sha512-BGbQYzWj3ps+dblq33FY5tz/SsgJCcXX0zjQlSC07tYvU1jHTUvsefphyig+fY38xZ4wdKjbTop+KUmXUYrOXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/xml-builder": "3.821.0",
+        "@smithy/core": "^3.5.3",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/signature-v4": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-utf8": "^4.0.0",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.826.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.826.0.tgz",
+      "integrity": "sha512-DK3pQY8+iKK3MGDdC3uOZQ2psU01obaKlTYhEwNu4VWzgwQL4Vi3sWj4xSWGEK41vqZxiRLq6fOq7ysRI+qEZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.826.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.826.0.tgz",
+      "integrity": "sha512-N+IVZBh+yx/9GbMZTKO/gErBi/FYZQtcFRItoLbY+6WU+0cSWyZYfkoeOxHmQV3iX9k65oljERIWUmL9x6OSQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-stream": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.830.0.tgz",
+      "integrity": "sha512-zeQenzvh8JRY5nULd8izdjVGoCM1tgsVVsrLSwDkHxZTTW0hW/bmOmXfvdaE0wDdomXW7m2CkQDSmP7XdvNXZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/credential-provider-env": "3.826.0",
+        "@aws-sdk/credential-provider-http": "3.826.0",
+        "@aws-sdk/credential-provider-process": "3.826.0",
+        "@aws-sdk/credential-provider-sso": "3.830.0",
+        "@aws-sdk/credential-provider-web-identity": "3.830.0",
+        "@aws-sdk/nested-clients": "3.830.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/credential-provider-imds": "^4.0.6",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.830.0.tgz",
+      "integrity": "sha512-X/2LrTgwtK1pkWrvofxQBI8VTi6QVLtSMpsKKPPnJQ0vgqC0e4czSIs3ZxiEsOkCBaQ2usXSiKyh0ccsQ6k2OA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.826.0",
+        "@aws-sdk/credential-provider-http": "3.826.0",
+        "@aws-sdk/credential-provider-ini": "3.830.0",
+        "@aws-sdk/credential-provider-process": "3.826.0",
+        "@aws-sdk/credential-provider-sso": "3.830.0",
+        "@aws-sdk/credential-provider-web-identity": "3.830.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/credential-provider-imds": "^4.0.6",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.826.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.826.0.tgz",
+      "integrity": "sha512-kURrc4amu3NLtw1yZw7EoLNEVhmOMRUTs+chaNcmS+ERm3yK0nKjaJzmKahmwlTQTSl3wJ8jjK7x962VPo+zWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.830.0.tgz",
+      "integrity": "sha512-+VdRpZmfekzpySqZikAKx6l5ndnLGluioIgUG4ZznrButgFD/iogzFtGmBDFB3ZLViX1l4pMXru0zFwJEZT21Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.830.0",
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/token-providers": "3.830.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.830.0.tgz",
+      "integrity": "sha512-hPYrKsZeeOdLROJ59T6Y8yZ0iwC/60L3qhZXjapBFjbqBtMaQiMTI645K6xVXBioA6vxXq7B4aLOhYqk6Fy/Ww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/nested-clients": "3.830.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.821.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.821.0.tgz",
+      "integrity": "sha512-xSMR+sopSeWGx5/4pAGhhfMvGBHioVBbqGvDs6pG64xfNwM5vq5s5v6D04e2i+uSTj4qGa71dLUs5I0UzAK3sw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.821.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.821.0.tgz",
+      "integrity": "sha512-0cvI0ipf2tGx7fXYEEN5fBeZDz2RnHyb9xftSgUsEq7NBxjV0yTZfLJw6Za5rjE6snC80dRN8+bTNR1tuG89zA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.821.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.821.0.tgz",
+      "integrity": "sha512-efmaifbhBoqKG3bAoEfDdcM8hn1psF+4qa7ykWuYmfmah59JBeqHLfz5W9m9JoTwoKPkFcVLWZxnyZzAnVBOIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.828.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.828.0.tgz",
+      "integrity": "sha512-nixvI/SETXRdmrVab4D9LvXT3lrXkwAWGWk2GVvQvzlqN1/M/RfClj+o37Sn4FqRkGH9o9g7Fqb1YqZ4mqDAtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/util-endpoints": "3.828.0",
+        "@smithy/core": "^3.5.3",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.830.0.tgz",
+      "integrity": "sha512-5N5YTlBr1vtxf7+t+UaIQ625KEAmm7fY9o1e3MgGOi/paBoI0+axr3ud24qLIy0NSzFlAHEaxUSWxcERNjIoZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/middleware-host-header": "3.821.0",
+        "@aws-sdk/middleware-logger": "3.821.0",
+        "@aws-sdk/middleware-recursion-detection": "3.821.0",
+        "@aws-sdk/middleware-user-agent": "3.828.0",
+        "@aws-sdk/region-config-resolver": "3.821.0",
+        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/util-endpoints": "3.828.0",
+        "@aws-sdk/util-user-agent-browser": "3.821.0",
+        "@aws-sdk/util-user-agent-node": "3.828.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.5.3",
+        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.11",
+        "@smithy/middleware-retry": "^4.1.12",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.19",
+        "@smithy/util-defaults-mode-node": "^4.0.19",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.5",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.821.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.821.0.tgz",
+      "integrity": "sha512-t8og+lRCIIy5nlId0bScNpCkif8sc0LhmtaKsbm0ZPm3sCa/WhCbSZibjbZ28FNjVCV+p0D9RYZx0VDDbtWyjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.830.0.tgz",
+      "integrity": "sha512-aJ4guFwj92nV9D+EgJPaCFKK0I3y2uMchiDfh69Zqnmwfxxxfxat6F79VA7PS0BdbjRfhLbn+Ghjftnomu2c1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/nested-clients": "3.830.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.821.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.821.0.tgz",
+      "integrity": "sha512-Znroqdai1a90TlxGaJ+FK1lwC0fHpo97Xjsp5UKGR5JODYm7f9+/fF17ebO1KdoBr/Rm0UIFiF5VmI8ts9F1eA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.828.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.828.0.tgz",
+      "integrity": "sha512-RvKch111SblqdkPzg3oCIdlGxlQs+k+P7Etory9FmxPHyPDvsP1j1c74PmgYqtzzMWmoXTjd+c9naUHh9xG8xg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-endpoints": "^3.0.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.804.0.tgz",
+      "integrity": "sha512-zVoRfpmBVPodYlnMjgVjfGoEZagyRF5IPn3Uo6ZvOZp24chnW/FRstH7ESDHDDRga4z3V+ElUQHKpFDXWyBW5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.821.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.821.0.tgz",
+      "integrity": "sha512-irWZHyM0Jr1xhC+38OuZ7JB6OXMLPZlj48thElpsO1ZSLRkLZx5+I7VV6k3sp2yZ7BYbKz/G2ojSv4wdm7XTLw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/types": "^4.3.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.828.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.828.0.tgz",
+      "integrity": "sha512-LdN6fTBzTlQmc8O8f1wiZN0qF3yBWVGis7NwpWK7FUEzP9bEZRxYfIkV9oV9zpt6iNRze1SedK3JQVB/udxBoA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.828.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.821.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.821.0.tgz",
+      "integrity": "sha512-DIIotRnefVL6DiaHtO6/21DhJ4JZnnIwdNbpwiAhdt/AVbttcE4yw925gsjur0OGv5BTYXQXU3YnANBYnZjuQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/abort-controller": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.4.tgz",
+      "integrity": "sha512-gJnEjZMvigPDQWHrW3oPrFhQtkrgqBkyjj3pCIdF3A5M6vsZODG93KNlfJprv6bp4245bdT32fsHK4kkH3KYDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.4.tgz",
+      "integrity": "sha512-prmU+rDddxHOH0oNcwemL+SwnzcG65sBF2yXRO7aeXIn/xTlq2pX7JLVbkBnVLowHLg4/OL4+jBmv9hVrVGS+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.5.3.tgz",
+      "integrity": "sha512-xa5byV9fEguZNofCclv6v9ra0FYh5FATQW/da7FQUVTic94DfrN/NvmKZjrMyzbpqfot9ZjBaO8U1UeTbmSLuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-stream": "^4.2.2",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.6.tgz",
+      "integrity": "sha512-hKMWcANhUiNbCJouYkZ9V3+/Qf9pteR1dnwgdyzR09R4ODEYx8BbUysHwRSyex4rZ9zapddZhLFTnT4ZijR4pw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.4.tgz",
+      "integrity": "sha512-AMtBR5pHppYMVD7z7G+OlHHAcgAN7v0kVKEpHuTO4Gb199Gowh0taYi9oDStFeUhetkeP55JLSVlTW1n9rFtUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/querystring-builder": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-base64": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.4.tgz",
+      "integrity": "sha512-qnbTPUhCVnCgBp4z4BUJUhOEkVwxiEi1cyFM+Zj6o+aY8OFGxUQleKWq8ltgp3dujuhXojIvJWdoqpm6dVO3lQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.4.tgz",
+      "integrity": "sha512-bNYMi7WKTJHu0gn26wg8OscncTt1t2b8KcsZxvOv56XA6cyXtOAAAaNP7+m45xfppXfOatXF3Sb1MNsLUgVLTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+      "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.4.tgz",
+      "integrity": "sha512-F7gDyfI2BB1Kc+4M6rpuOLne5LOcEknH1n6UQB69qv+HucXBR1rkzXBnQTB2q46sFy1PM/zuSJOB532yc8bg3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.11.tgz",
+      "integrity": "sha512-zDogwtRLzKl58lVS8wPcARevFZNBOOqnmzWWxVe9XiaXU2CADFjvJ9XfNibgkOWs08sxLuSr81NrpY4mgp9OwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.5.3",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-middleware": "^4.0.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.12.tgz",
+      "integrity": "sha512-wvIH70c4e91NtRxdaLZF+mbLZ/HcC6yg7ySKUiufL6ESp6zJUSnJucZ309AvG9nqCFHSRB5I6T3Ez1Q9wCh0Ww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/service-error-classification": "^4.0.5",
+        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.5",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.8.tgz",
+      "integrity": "sha512-iSSl7HJoJaGyMIoNn2B7czghOVwJ9nD7TMvLhMWeSB5vt0TnEYyRRqPJu/TqW76WScaNvYYB8nRoiBHR9S1Ddw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.4.tgz",
+      "integrity": "sha512-kagK5ggDrBUCCzI93ft6DjteNSfY8Ulr83UtySog/h09lTIOAJ/xUSObutanlPT0nhoHAkpmW9V5K8oPyLh+QA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.3.tgz",
+      "integrity": "sha512-HGHQr2s59qaU1lrVH6MbLlmOBxadtzTsoO4c+bF5asdgVik3I8o7JIOzoeqWc5MjVa+vD36/LWE0iXKpNqooRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.6.tgz",
+      "integrity": "sha512-NqbmSz7AW2rvw4kXhKGrYTiJVDHnMsFnX4i+/FzcZAfbOBauPYs2ekuECkSbtqaxETLLTu9Rl/ex6+I2BKErPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/querystring-builder": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.4.tgz",
+      "integrity": "sha512-qHJ2sSgu4FqF4U/5UUp4DhXNmdTrgmoAai6oQiM+c5RZ/sbDwJ12qxB1M6FnP+Tn/ggkPZf9ccn4jqKSINaquw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.2.tgz",
+      "integrity": "sha512-rOG5cNLBXovxIrICSBm95dLqzfvxjEmuZx4KK3hWwPFHGdW3lxY0fZNXfv2zebfRO7sJZ5pKJYHScsqopeIWtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.4.tgz",
+      "integrity": "sha512-SwREZcDnEYoh9tLNgMbpop+UTGq44Hl9tdj3rf+yeLcfH7+J8OXEBaMc2kDxtyRHu8BhSg9ADEx0gFHvpJgU8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-uri-escape": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.4.tgz",
+      "integrity": "sha512-6yZf53i/qB8gRHH/l2ZwUG5xgkPgQF15/KxH0DdXMDHjesA9MeZje/853ifkSY0x4m5S+dfDZ+c4x439PF0M2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.5.tgz",
+      "integrity": "sha512-LvcfhrnCBvCmTee81pRlh1F39yTS/+kYleVeLCwNtkY8wtGg8V/ca9rbZZvYIl8OjlMtL6KIjaiL/lgVqHD2nA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.4.tgz",
+      "integrity": "sha512-63X0260LoFBjrHifPDs+nM9tV0VMkOTl4JRMYNuKh/f5PauSjowTfvF3LogfkWdcPoxsA9UjqEOgjeYIbhb7Nw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.2.tgz",
+      "integrity": "sha512-d3+U/VpX7a60seHziWnVZOHuEgJlclufjkS6zhXvxcJgkJq4UWdH5eOBLzHRMx6gXjsdT9h6lfpmLzbrdupHgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.0.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-hex-encoding": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-uri-escape": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.3.tgz",
+      "integrity": "sha512-xxzNYgA0HD6ETCe5QJubsxP0hQH3QK3kbpJz3QrosBCuIWyEXLR/CO5hFb2OeawEKUxMNhz3a1nuJNN2np2RMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.5.3",
+        "@smithy/middleware-endpoint": "^4.1.11",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-stream": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.1.tgz",
+      "integrity": "sha512-UqKOQBL2x6+HWl3P+3QqFD4ncKq0I8Nuz9QItGv5WuKuMHuuwlhvqcZCoXGfc+P1QmfJE7VieykoYYmrOoFJxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.4.tgz",
+      "integrity": "sha512-eMkc144MuN7B0TDA4U2fKs+BqczVbk3W+qIvcoCY6D1JY3hnAdCuhCZODC+GAeaxj0p6Jroz4+XMUn3PCxQQeQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+      "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+      "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
+      "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
+      "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.19.tgz",
+      "integrity": "sha512-mvLMh87xSmQrV5XqnUYEPoiFFeEGYeAKIDDKdhE2ahqitm8OHM3aSvhqL6rrK6wm1brIk90JhxDf5lf2hbrLbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/types": "^4.3.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.19.tgz",
+      "integrity": "sha512-8tYnx+LUfj6m+zkUUIrIQJxPM1xVxfRBvoGHua7R/i6qAxOMjqR6CpEpDwKoIs1o0+hOjGvkKE23CafKL0vJ9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/credential-provider-imds": "^4.0.6",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.6.tgz",
+      "integrity": "sha512-YARl3tFL3WgPuLzljRUnrS2ngLiUtkwhQtj8PAL13XZSyUiNLQxwG3fBBq3QXFqGFUXepIN73pINp3y8c2nBmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
+      "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.4.tgz",
+      "integrity": "sha512-9MLKmkBmf4PRb0ONJikCbCwORACcil6gUWojwARCClT7RmLzF04hUR4WdRprIXal7XVyrddadYNfp2eF3nrvtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.5.tgz",
+      "integrity": "sha512-V7MSjVDTlEt/plmOFBn1762Dyu5uqMrV2Pl2X0dYk4XvWfdWJNe9Bs5Bzb56wkCuiWjSfClVMGcsuKrGj7S/yg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.0.5",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.2.tgz",
+      "integrity": "sha512-aI+GLi7MJoVxg24/3J1ipwLoYzgkB4kUfogZfnslcYlynj3xsQ0e7vk4TnTro9hhsS5PvX1mwmkRqqHQjwcU7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-hex-encoding": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+      "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+      "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/adm-zip": {
@@ -20,6 +1225,238 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/graphql": {
@@ -46,6 +1483,93 @@
       "peerDependencies": {
         "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/test/package.json
+++ b/test/package.json
@@ -13,6 +13,6 @@
     "graphql-tag": "2.12.6",
     "adm-zip": "0.5.16",
     "@aws-sdk/client-appsync": "^3.445.0",
-    "axios": "^1.6.2"
+    "axios": "^1.9.0"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -11,6 +11,8 @@
   "type": "module",
   "dependencies": {
     "graphql-tag": "2.12.6",
-    "adm-zip": "0.5.16"
+    "adm-zip": "0.5.16",
+    "@aws-sdk/client-appsync": "^3.445.0",
+    "axios": "^1.6.2"
   }
 }

--- a/test/testLib.js
+++ b/test/testLib.js
@@ -212,21 +212,14 @@ async function testApolloArtifacts(outputFolderPath, testDbInfo, subgraph = fals
  * @returns {Promise<string>} - The API key
  */
 async function createAppSyncApiKey(apiId, region, description = 'jest test API key') {
-    // Create AppSync client
     const appSyncClient = new AppSyncClient({ region });
-    
     try {
-        // Create a new API key
         const createKeyCommand = new CreateApiKeyCommand({
             apiId: apiId,
             description: description
         });
-        
-        console.log(`Creating API key for AppSync API: ${apiId}`);
         const keyResponse = await appSyncClient.send(createKeyCommand);
-        const apiKey = keyResponse.apiKey.id;
-        
-        return apiKey;
+        return keyResponse.apiKey.id;
     } catch (error) {
         console.error('Error creating AppSync API key:', error);
         throw error;
@@ -245,20 +238,13 @@ async function createAppSyncApiKey(apiId, region, description = 'jest test API k
  */
 async function executeGraphQLQuery(apiId, apiKey, query, variables, region) {
     try {
-        // Create AppSync client
         const appSyncClient = new AppSyncClient({ region });
-        
-        // Get the AppSync API URL
         const getApiCommand = new GetGraphqlApiCommand({
             apiId: apiId
         });
-        
         const apiDetails = await appSyncClient.send(getApiCommand);
         const apiUrl = apiDetails.graphqlApi.uris.GRAPHQL;
         
-        console.log(`Executing GraphQL query against: ${apiUrl}`);
-        
-        // Execute the GraphQL query
         const response = await axios({
             url: apiUrl,
             method: 'post',
@@ -272,7 +258,6 @@ async function executeGraphQLQuery(apiId, apiKey, query, variables, region) {
             }
         });
 
-        console.log('Received response from GraphQL query: ' + JSON.stringify(response.data));
         return response.data;
     } catch (error) {
         console.error('Error executing GraphQL query:', error);
@@ -288,10 +273,13 @@ async function executeGraphQLQuery(apiId, apiKey, query, variables, region) {
  * @param {string} query - The GraphQL query to execute
  * @param {object} variables - Variables to use with the GraphQL query
  * @param {string} region - AWS region where the AppSync API is deployed
+ * @param {string} apiKey - The optional API key to use for authentication - if not provided, a new API key will be created
  * @returns {Promise<object>} - The GraphQL query response
  */
-async function executeAppSyncQuery(apiId, query, variables, region) {
-    const apiKey = await createAppSyncApiKey(apiId, region);
+async function executeAppSyncQuery(apiId, query, variables, region, apiKey) {
+    if (!apiKey) {
+        apiKey = await createAppSyncApiKey(apiId, region);
+    }
     return executeGraphQLQuery(apiId, apiKey, query, variables, region);
 }
 


### PR DESCRIPTION
Improved lambda cold start and query performance by making changes to resolver schema handling:
* used gzip compression for resolver schema file to reduce file I/O time during lambda cold starts
* moved schema initialization outside of event handlers so that it is not executed for each graphQL query
* added integration test validation that App Sync APIs can be queried successfully to check that schema changes did not break functionality

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
