### PR TITLE
Reformat line wrapping in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,50 +16,88 @@ permissions and limitations under the License.
 
 ## Release v1.2.0 (Release Date: TBD)
 
-This release contains new support for Apollo Server integration.
-
-### Bug Fixes
-
-* Don't cast integers to floats in Neptune schema ([#62](https://github.com/aws/amazon-neptune-for-graphql/pull/62))
-* Fix query from AppSync with an empty filter object ([#61](https://github.com/aws/amazon-neptune-for-graphql/pull/61))
-* Retain numeric parameter value type when creating open cypher query ([#63](https://github.com/aws/amazon-neptune-for-graphql/pull/63))
-* Fixed bug with ID argument type conversion and added Apollo arguments to help menu ([#74](https://github.com/aws/amazon-neptune-for-graphql/pull/74))
-* Upgraded axios and babel versions to fix security warnings ([#90](https://github.com/aws/amazon-neptune-for-graphql/pull/90))
-* Fixed failing integration test by excluding `node_modules` from Apollo zip ([#94](https://github.com/aws/amazon-neptune-for-graphql/pull/94))
-* Fixed enum types in schema to be included in input types ([#95](https://github.com/aws/amazon-neptune-for-graphql/pull/95))
-* Fixed bug where id fields without @id directives are not accounted for ([#96](https://github.com/aws/amazon-neptune-for-graphql/pull/96))
-* Fixed custom scalar types in schema to be included in input types ([#97](https://github.com/aws/amazon-neptune-for-graphql/pull/97))
-* Fixed queries generated from an input schema which retrieve an array to have an option parameter with limit ([#97](https://github.com/aws/amazon-neptune-for-graphql/pull/97))
-* Fixed nested edge subqueries to return an empty array if no results were found (([#100](https://github.com/aws/amazon-neptune-for-graphql/pull/100))
-* Fixed usage of variables with nested edge subqueries (([#100](https://github.com/aws/amazon-neptune-for-graphql/pull/100))
-* Fixed cdk output file to contain previously missing files that were necessary to execute the lambda resolver (([#106](https://github.com/aws/amazon-neptune-for-graphql/pull/106))
-* Fixed resolution of nested variables in selection set arguments (([#108](https://github.com/aws/amazon-neptune-for-graphql/pull/108))
-* Changed resolver to use `graphql` `parse` instead of `graphql-tag` `gql` to avoid stale values due to caching (([#109](https://github.com/aws/amazon-neptune-for-graphql/pull/109))
-
-
 ### Features
 
-* Support output of zip package of Apollo Server artifacts (([#70](https://github.com/aws/amazon-neptune-for-graphql/pull/70)), ([#72](https://github.com/aws/amazon-neptune-for-graphql/pull/72)), ([#73](https://github.com/aws/amazon-neptune-for-graphql/pull/73)), ([#75](https://github.com/aws/amazon-neptune-for-graphql/pull/75)), ([#76](https://github.com/aws/amazon-neptune-for-graphql/pull/76)))
-* Allow filtering using string comparison operators `eq`, `contains`, `startsWith`, `endsWith` (([#100](https://github.com/aws/amazon-neptune-for-graphql/pull/100))
-* Added pagination support through the addition of an `offset` argument in query options which can be used in combination with the existing `limit` (([#102](https://github.com/aws/amazon-neptune-for-graphql/pull/102))
-* Added support for queries with sorting ([#105](https://github.com/aws/amazon-neptune-for-graphql/pull/105))
-
+* Support output of zip package of Apollo Server
+  artifacts (([#70](https://github.com/aws/amazon-neptune-for-graphql/pull/70)), ([#72](https://github.com/aws/amazon-neptune-for-graphql/pull/72)), ([#73](https://github.com/aws/amazon-neptune-for-graphql/pull/73)), ([#75](https://github.com/aws/amazon-neptune-for-graphql/pull/75)), ([#76](https://github.com/aws/amazon-neptune-for-graphql/pull/76)))
+* Allow filtering using string comparison operators `eq`, `contains`,
+  `startsWith`,
+  `endsWith` (([#100](https://github.com/aws/amazon-neptune-for-graphql/pull/100))
+* Added pagination support through the addition of an `offset` argument in query
+  options which can be used in combination with the existing
+  `limit` (([#102](https://github.com/aws/amazon-neptune-for-graphql/pull/102))
+* Added support for queries with
+  sorting ([#105](https://github.com/aws/amazon-neptune-for-graphql/pull/105))
 
 ### Improvements
 
-* Increased graphdb.js test coverage using sample data ([#53](https://github.com/aws/amazon-neptune-for-graphql/pull/53))
-* Saved the neptune schema to file early so that it can be used for troubleshooting ([#56](https://github.com/aws/amazon-neptune-for-graphql/pull/56))
-* Alias edges with same label as a node ([#57](https://github.com/aws/amazon-neptune-for-graphql/pull/57))
-* Cap concurrent requests to get Neptune schema ([#58](https://github.com/aws/amazon-neptune-for-graphql/pull/58))
-* Honour @id directive on type fields ([#60](https://github.com/aws/amazon-neptune-for-graphql/pull/60))
-* Changed lambda template to use ECMAScripts modules ([#68](https://github.com/aws/amazon-neptune-for-graphql/pull/68))
-* Add template file missing from packaging ([#71](https://github.com/aws/amazon-neptune-for-graphql/pull/71))
-* Separated graphQL schema from resolver template ([#79](https://github.com/aws/amazon-neptune-for-graphql/pull/79))
-* Added unit tests for resolver and moved resolver integration tests to be unit tests ([#83](https://github.com/aws/amazon-neptune-for-graphql/pull/83))
-* Set limit on the expensive query which is retrieving distinct to and from labels for edges ([#89](https://github.com/aws/amazon-neptune-for-graphql/pull/89))
-* Added distinct input types for create and update mutations ([#93](https://github.com/aws/amazon-neptune-for-graphql/pull/93))
-* Enabled mutations for the Apollo Server ([#98](https://github.com/aws/amazon-neptune-for-graphql/pull/98))
-* Refactored integration tests to be less vulnerable to resolver logic changes ([#99](https://github.com/aws/amazon-neptune-for-graphql/pull/99))
-* Enabled usage of query fragments with Apollo Server ([#103](https://github.com/aws/amazon-neptune-for-graphql/pull/103))
-* Compressed resolver schema file and moved schema initialization outside of event handlers to improve performance ([#111](https://github.com/aws/amazon-neptune-for-graphql/pull/111))
-* Updated and proofread outdated documentation ([#107](https://github.com/aws/amazon-neptune-for-graphql/pull/107))
+* Increased graphdb.js test coverage using sample
+  data ([#53](https://github.com/aws/amazon-neptune-for-graphql/pull/53))
+* Saved the neptune schema to file early so that it can be used for
+  troubleshooting ([#56](https://github.com/aws/amazon-neptune-for-graphql/pull/56))
+* Alias edges with same label as a
+  node ([#57](https://github.com/aws/amazon-neptune-for-graphql/pull/57))
+* Cap concurrent requests to get Neptune
+  schema ([#58](https://github.com/aws/amazon-neptune-for-graphql/pull/58))
+* Honour @id directive on type
+  fields ([#60](https://github.com/aws/amazon-neptune-for-graphql/pull/60))
+* Changed lambda template to use ECMAScripts
+  modules ([#68](https://github.com/aws/amazon-neptune-for-graphql/pull/68))
+* Add template file missing from
+  packaging ([#71](https://github.com/aws/amazon-neptune-for-graphql/pull/71))
+* Separated graphQL schema from resolver
+  template ([#79](https://github.com/aws/amazon-neptune-for-graphql/pull/79))
+* Added unit tests for resolver and moved resolver integration tests to be unit
+  tests ([#83](https://github.com/aws/amazon-neptune-for-graphql/pull/83))
+* Set limit on the expensive query which is retrieving distinct to and from
+  labels for
+  edges ([#89](https://github.com/aws/amazon-neptune-for-graphql/pull/89))
+* Added distinct input types for create and update
+  mutations ([#93](https://github.com/aws/amazon-neptune-for-graphql/pull/93))
+* Enabled mutations for the Apollo
+  Server ([#98](https://github.com/aws/amazon-neptune-for-graphql/pull/98))
+* Refactored integration tests to be less vulnerable to resolver logic
+  changes ([#99](https://github.com/aws/amazon-neptune-for-graphql/pull/99))
+* Enabled usage of query fragments with Apollo
+  Server ([#103](https://github.com/aws/amazon-neptune-for-graphql/pull/103))
+* Compressed resolver schema file and moved schema initialization outside of
+  event handlers to improve
+  performance ([#111](https://github.com/aws/amazon-neptune-for-graphql/pull/111))
+* Updated and proofread outdated
+  documentation ([#107](https://github.com/aws/amazon-neptune-for-graphql/pull/107))
+
+### Bug Fixes
+
+* Don't cast integers to floats in Neptune
+  schema ([#62](https://github.com/aws/amazon-neptune-for-graphql/pull/62))
+* Fix query from AppSync with an empty filter
+  object ([#61](https://github.com/aws/amazon-neptune-for-graphql/pull/61))
+* Retain numeric parameter value type when creating open cypher
+  query ([#63](https://github.com/aws/amazon-neptune-for-graphql/pull/63))
+* Fixed bug with ID argument type conversion and added Apollo arguments to help
+  menu ([#74](https://github.com/aws/amazon-neptune-for-graphql/pull/74))
+* Upgraded axios and babel versions to fix security
+  warnings ([#90](https://github.com/aws/amazon-neptune-for-graphql/pull/90))
+* Fixed failing integration test by excluding `node_modules` from Apollo
+  zip ([#94](https://github.com/aws/amazon-neptune-for-graphql/pull/94))
+* Fixed enum types in schema to be included in input
+  types ([#95](https://github.com/aws/amazon-neptune-for-graphql/pull/95))
+* Fixed bug where id fields without @id directives are not accounted
+  for ([#96](https://github.com/aws/amazon-neptune-for-graphql/pull/96))
+* Fixed custom scalar types in schema to be included in input
+  types ([#97](https://github.com/aws/amazon-neptune-for-graphql/pull/97))
+* Fixed queries generated from an input schema which retrieve an array to have
+  an option parameter with
+  limit ([#97](https://github.com/aws/amazon-neptune-for-graphql/pull/97))
+* Fixed nested edge subqueries to return an empty array if no results were
+  found (([#100](https://github.com/aws/amazon-neptune-for-graphql/pull/100))
+* Fixed usage of variables with nested edge
+  subqueries (([#100](https://github.com/aws/amazon-neptune-for-graphql/pull/100))
+* Fixed cdk output file to contain previously missing files that were necessary
+  to execute the lambda
+  resolver (([#106](https://github.com/aws/amazon-neptune-for-graphql/pull/106))
+* Fixed resolution of nested variables in selection set
+  arguments (([#108](https://github.com/aws/amazon-neptune-for-graphql/pull/108))
+* Changed resolver to use `graphql` `parse` instead of `graphql-tag` `gql` to
+  avoid stale values due to
+  caching (([#109](https://github.com/aws/amazon-neptune-for-graphql/pull/109))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ permissions and limitations under the License.
   event handlers to improve
   performance ([#111](https://github.com/aws/amazon-neptune-for-graphql/pull/111))
 * Updated and proofread outdated
-  documentation ([#107](https://github.com/aws/amazon-neptune-for-graphql/pull/107))
+  documentation (([#112](https://github.com/aws/amazon-neptune-for-graphql/pull/107)), ([#107](https://github.com/aws/amazon-neptune-for-graphql/pull/112)))
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,13 @@ permissions and limitations under the License.
 ### Features
 
 * Support output of zip package of Apollo Server
-  artifacts (([#70](https://github.com/aws/amazon-neptune-for-graphql/pull/70)), ([#72](https://github.com/aws/amazon-neptune-for-graphql/pull/72)), ([#73](https://github.com/aws/amazon-neptune-for-graphql/pull/73)), ([#75](https://github.com/aws/amazon-neptune-for-graphql/pull/75)), ([#76](https://github.com/aws/amazon-neptune-for-graphql/pull/76)))
+  artifacts ([#70](https://github.com/aws/amazon-neptune-for-graphql/pull/70), [#72](https://github.com/aws/amazon-neptune-for-graphql/pull/72), [#73](https://github.com/aws/amazon-neptune-for-graphql/pull/73), [#75](https://github.com/aws/amazon-neptune-for-graphql/pull/75), [#76](https://github.com/aws/amazon-neptune-for-graphql/pull/76))
 * Allow filtering using string comparison operators `eq`, `contains`,
   `startsWith`,
-  `endsWith` (([#100](https://github.com/aws/amazon-neptune-for-graphql/pull/100))
+  `endsWith` ([#100](https://github.com/aws/amazon-neptune-for-graphql/pull/100))
 * Added pagination support through the addition of an `offset` argument in query
   options which can be used in combination with the existing
-  `limit` (([#102](https://github.com/aws/amazon-neptune-for-graphql/pull/102))
+  `limit` ([#102](https://github.com/aws/amazon-neptune-for-graphql/pull/102))
 * Added support for queries with
   sorting ([#105](https://github.com/aws/amazon-neptune-for-graphql/pull/105))
 
@@ -64,7 +64,7 @@ permissions and limitations under the License.
   event handlers to improve
   performance ([#111](https://github.com/aws/amazon-neptune-for-graphql/pull/111))
 * Updated and proofread outdated
-  documentation (([#112](https://github.com/aws/amazon-neptune-for-graphql/pull/107)), ([#107](https://github.com/aws/amazon-neptune-for-graphql/pull/112)))
+  documentation ([#112](https://github.com/aws/amazon-neptune-for-graphql/pull/107), [#107](https://github.com/aws/amazon-neptune-for-graphql/pull/112))
 
 ### Bug Fixes
 
@@ -90,14 +90,14 @@ permissions and limitations under the License.
   an option parameter with
   limit ([#97](https://github.com/aws/amazon-neptune-for-graphql/pull/97))
 * Fixed nested edge subqueries to return an empty array if no results were
-  found (([#100](https://github.com/aws/amazon-neptune-for-graphql/pull/100))
+  found ([#100](https://github.com/aws/amazon-neptune-for-graphql/pull/100))
 * Fixed usage of variables with nested edge
-  subqueries (([#100](https://github.com/aws/amazon-neptune-for-graphql/pull/100))
+  subqueries ([#100](https://github.com/aws/amazon-neptune-for-graphql/pull/100))
 * Fixed cdk output file to contain previously missing files that were necessary
   to execute the lambda
-  resolver (([#106](https://github.com/aws/amazon-neptune-for-graphql/pull/106))
+  resolver ([#106](https://github.com/aws/amazon-neptune-for-graphql/pull/106))
 * Fixed resolution of nested variables in selection set
-  arguments (([#108](https://github.com/aws/amazon-neptune-for-graphql/pull/108))
+  arguments ([#108](https://github.com/aws/amazon-neptune-for-graphql/pull/108))
 * Changed resolver to use `graphql` `parse` instead of `graphql-tag` `gql` to
   avoid stale values due to
-  caching (([#109](https://github.com/aws/amazon-neptune-for-graphql/pull/109))
+  caching ([#109](https://github.com/aws/amazon-neptune-for-graphql/pull/109))

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,7 @@
 ## Code of Conduct
-This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
-For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
+
+This project has adopted
+the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
+For more information see
+the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
 opensource-codeofconduct@amazon.com with any additional questions or comments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,59 +1,78 @@
 # Contributing Guidelines
 
-Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional
-documentation, we greatly value feedback and contributions from our community.
+Thank you for your interest in contributing to our project. Whether it's a bug
+report, new feature, correction, or additional documentation, we greatly value
+feedback and contributions from our community.
 
-Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
-information to effectively respond to your bug report or contribution.
-
+Please read through this document before submitting any issues or pull requests
+to ensure we have all the necessary information to effectively respond to your
+bug report or contribution.
 
 ## Reporting Bugs/Feature Requests
 
-We welcome you to use the GitHub issue tracker to report bugs or suggest features.
+We welcome you to use the GitHub issue tracker to report bugs or suggest
+features.
 
-When filing an issue, please check existing open, or recently closed, issues to make sure somebody else hasn't already
-reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
+When filing an issue, please check existing open, or recently closed, issues to
+make sure somebody else hasn't already reported the issue. Please try to include
+as much information as you can. Details like these are incredibly useful:
 
 * A reproducible test case or series of steps
 * The version of our code being used
 * Any modifications you've made relevant to the bug
 * Anything unusual about your environment or deployment
 
-
 ## Contributing via Pull Requests
-Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
+
+Contributions via pull requests are much appreciated. Before sending us a pull
+request, please ensure that:
 
 1. You are working against the latest source on the *main* branch.
-2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
-3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
+2. You check existing open, and recently merged, pull requests to make sure
+   someone else hasn't addressed the problem already.
+3. You open an issue to discuss any significant work - we would hate for your
+   time to be wasted.
 
 To send us a pull request, please:
 
 1. Fork the repository.
-2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
+2. Modify the source; please focus on the specific change you are contributing.
+   If you also reformat all the code, it will be hard for us to focus on your
+   change.
 3. Ensure local tests pass.
 4. Commit to your fork using clear commit messages.
-5. Send us a pull request, answering any default questions in the pull request interface.
-6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+5. Send us a pull request, answering any default questions in the pull request
+   interface.
+6. Pay attention to any automated CI failures reported in the pull request, and
+   stay involved in the conversation.
 
-GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
+GitHub provides additional document
+on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
-
 ## Finding contributions to work on
-Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
 
+Looking at the existing issues is a great way to find something to contribute
+on. As our projects, by default, use the default GitHub issue labels (
+enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at
+any 'help wanted' issues is a great place to start.
 
 ## Code of Conduct
-This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
-For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
+
+This project has adopted
+the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
+For more information see
+the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
 opensource-codeofconduct@amazon.com with any additional questions or comments.
 
-
 ## Security issue notifications
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
 
+If you discover a potential security issue in this project we ask that you
+notify AWS/Amazon Security via
+our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/).
+Please do **not** create a public github issue.
 
 ## Licensing
 
-See the [LICENSE](./LICENSE.txt) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](./LICENSE.txt) file for our project's licensing. We will ask
+you to confirm the licensing of your contribution.

--- a/README.md
+++ b/README.md
@@ -123,17 +123,22 @@ the execution, you will find in the AppSync console your new GraphQL API called
 menu. (*Note: follow the setup instructions below to enable your environment to
 reach the Neptune database and create AWS resources.*)
 
-`neptune-for-graphql --input-graphdb-schema-neptune-endpoint `<
-*your-neptune-database-endpoint:port*>
-` --create-update-aws-pipeline --create-update-aws-pipeline-name` <
-*your-new-GraphQL-API-name*>` --output-resolver-query-https`
+```
+neptune-for-graphql \
+  --input-graphdb-schema-neptune-endpoint <your-neptune-database-endpoint:port> \
+  --create-update-aws-pipeline \
+  --create-update-aws-pipeline-name <your-new-GraphQL-API-name> \
+  --output-resolver-query-https \
+```
 
 If you run the command above a second time, it will look again at the Neptune
 database data and update the AppSync API and the Lambda code.
 
 To rollback, removing all the AWS resources run:
 
-`neptune-for-graphql --remove-aws-pipeline-name` <*your-new-GraphQL-API-name*>
+```
+neptune-for-graphql --remove-aws-pipeline-name <your-new-GraphQL-API-name>
+```
 
 #### References:
 
@@ -167,10 +172,14 @@ menu.
 > Follow the setup instructions below to enable your environment to reach the
 > Neptune database and create AWS resources.
 
-`neptune-for-graphql --input-schema-file `<*your-graphql-schema-file*>
-` --create-update-aws-pipeline --create-update-aws-pipeline-name` <
-*your-new-GraphQL-API-name*>` --create-update-aws-pipeline-neptune-endpoint` <
-*your-neptune-database-endpoint:port*>  ` --output-resolver-query-https`
+```
+neptune-for-graphql \
+  --input-schema-file <your-graphql-schema-file> \
+  --create-update-aws-pipeline \
+  --create-update-aws-pipeline-name <your-new-GraphQL-API-name> \
+  --create-update-aws-pipeline-neptune-endpoint <your-neptune-database-endpoint:port> \
+  --output-resolver-query-https
+```
 
 #### References:
 
@@ -188,12 +197,14 @@ You can start from a GraphQL schema with directives for a graph database. For
 the list of supported directives see the section
 below [Customize the GraphQL schema with directives](#customize-the-graphql-schema-with-directives).
 
-`neptune-for-graphql --input-schema-file `<
-*your-graphql-schema-file-with-directives*>
-` --create-update-aws-pipeline --create-update-aws-pipeline-name` <
-*your-new-GraphQL-API-name*> `--create-update-aws-pipeline-neptune-endpoint` <
-*your-neptune-database-endpoint:port*>` --output-resolver-query-https`
-
+```
+neptune-for-graphql \
+  --input-schema-file <your-graphql-schema-file-with-directives> \
+  --create-update-aws-pipeline \
+  --create-update-aws-pipeline-name <your-new-GraphQL-API-name> \
+  --create-update-aws-pipeline-neptune-endpoint <your-neptune-database-endpoint:port> \
+  --output-resolver-query-https
+```
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -3,19 +3,38 @@
 
 # **Amazon Neptune utility for GraphQL&trade; schemas and resolvers**
 
-The Amazon Neptune utility for GraphQL&trade; is a Node.js command-line utility to help with the creation and maintenance of a GraphQL API for the Amazon Neptune Database or Neptune Analytics graph. It is a no-code solution for a GraphQL resolver when GraphQL queries have a variable number of input parameters and return a variable number of nested fields.
+The Amazon Neptune utility for GraphQL&trade; is a Node.js command-line utility
+to help with the creation and maintenance of a GraphQL API for the Amazon
+Neptune Database or Neptune Analytics graph. It is a no-code solution for a
+GraphQL resolver when GraphQL queries have a variable number of input parameters
+and return a variable number of nested fields.
 
-If you **start from a Neptune database with data**, the utility discovers the graph database schema including nodes, edges, properties and edges cardinality. This database schema is then used to generate the GraphQL schema with the directives required to map the GraphQL types to the graph databases nodes and edges, and auto-generate the resolver code. We optimized the resolver code to reduce the latency of querying Amazon Neptune by returning only the data requested by the GraphQL query.
+If you **start from a Neptune database with data**, the utility discovers the
+graph database schema including nodes, edges, properties and edges cardinality.
+This database schema is then used to generate the GraphQL schema with the
+directives required to map the GraphQL types to the graph databases nodes and
+edges, and auto-generate the resolver code. We optimized the resolver code to
+reduce the latency of querying Amazon Neptune by returning only the data
+requested by the GraphQL query.
 
 > [!NOTE]
-> 
-> This utility works for Property Graph databases only. Support for RDF has not yet been added.
+>
+> This utility works for Property Graph databases only. Support for RDF has not
+> yet been added.
 
-You can also **start with a GraphQL schema with your types and an empty Neptune database**. The utility will process your starting GraphQL schema and inference the directives required to map it to the Neptune database graph nodes and edges. You can also **start with a GraphQL schema with the directives**, that you have modified or created.
+You can also **start with a GraphQL schema with your types and an empty Neptune
+database**. The utility will process your starting GraphQL schema and inference
+the directives required to map it to the Neptune database graph nodes and edges.
+You can also **start with a GraphQL schema with the directives**, that you have
+modified or created.
 
-The utility has the option to **generate the AWS resources** of the entire pipeline, including the AWS AppSync API, configuring the roles, data source, schema and resolver, and the AWS Lambda that queries Amazon Neptune.
+The utility has the option to **generate the AWS resources** of the entire
+pipeline, including the AWS AppSync API, configuring the roles, data source,
+schema and resolver, and the AWS Lambda that queries Amazon Neptune.
 
-If you have a **few queries** with a static number of input parameters and return fields, and you are willing to code your GraphQL resolver, look at these blogs:
+If you have a **few queries** with a static number of input parameters and
+return fields, and you are willing to code your GraphQL resolver, look at these
+blogs:
 
 - [Building Serverless Calorie tracker application with AWS AppSync and Amazon Neptune](https://github.com/aws-samples/aws-appsync-calorie-tracker-workshop)
 - [Integrating alternative data sources with AWS AppSync: Amazon Neptune and Amazon ElastiCache](https://aws.amazon.com/blogs/mobile/integrating-aws-appsync-neptune-elasticache/)
@@ -23,6 +42,7 @@ If you have a **few queries** with a static number of input parameters and retur
 <br>
 
 Index:
+
 - [Install and Setup](#install-and-setup)
 - [Starting from a Neptune database with data](#starting-from-a-neptune-database-with-data)
 - [Starting from a Neptune database with data: Air Routes Example](https://github.com/aws/amazon-neptune-for-graphql/blob/main/doc/routesExample.md)
@@ -40,252 +60,402 @@ Index:
 
 <br>
 
-# Install and Setup 
-The utility requires Node.js to be executed. Some features require reaching to a Neptune database, and having access to the AWS CLI with permissions to create AWS resources. You can also run the utility just to process input files without the need to connect it directly to a Neptune database or to create AWS resources. In this case you will find the GraphQL schemas and the resolver code in the local *output* directory.
+# Install and Setup
+
+The utility requires Node.js to be executed. Some features require reaching to a
+Neptune database, and having access to the AWS CLI with permissions to create
+AWS resources. You can also run the utility just to process input files without
+the need to connect it directly to a Neptune database or to create AWS
+resources. In this case you will find the GraphQL schemas and the resolver code
+in the local *output* directory.
 
 ### Node.js is required in any scenario
-Node.js is required to run the utility, v18 or above. 
-- To install it on macOS or Windows go to the [Node.js website](https://nodejs.org/) to download the installer.
-- To install on an EC2-Instance follow the [AWS documentation](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-up-node-on-ec2-instance.html).
+
+Node.js is required to run the utility, v18 or above.
+
+- To install it on macOS or Windows go to
+  the [Node.js website](https://nodejs.org/) to download the installer.
+- To install on an EC2-Instance follow
+  the [AWS documentation](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-up-node-on-ec2-instance.html).
 
 ### Install the Amazon Neptune utility for GraphQL
+
 The utility is available as NPM package. To install it:
 
 `npm install @aws/neptune-for-graphql -g`
 
 After the installation run the utility `--help`` command to check if runs:
 
-`neptune-for-graphql --help` 
+`neptune-for-graphql --help`
 
 ### Reach to a Neptune database endpoint
-If you are starting from a Neptune database with data, you need to enable the utility to reach the database endpoint. By default Neptune databases are accessible only within a VPC.
 
-The easiet way is to run the utility from an EC2 instance which network is configured within your Neptune database VPC. The minimum size instance to run the utility is ***t2.micro*** (free of charge). During the creation of the instance select the Neptune database VPC using the *Common Security Groups* pulldown menu.
+If you are starting from a Neptune database with data, you need to enable the
+utility to reach the database endpoint. By default Neptune databases are
+accessible only within a VPC.
 
+The easiet way is to run the utility from an EC2 instance which network is
+configured within your Neptune database VPC. The minimum size instance to run
+the utility is ***t2.micro*** (free of charge). During the creation of the
+instance select the Neptune database VPC using the *Common Security Groups*
+pulldown menu.
 
 #### Next Step
+
 - Install Node.js
-- [Install AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) if you need to create the AWS resources, or you need an IAM role to access the Neptune database.
+- [Install AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+  if you need to create the AWS resources, or you need an IAM role to access the
+  Neptune database.
 
 <br>
 
-
 # Starting from a Neptune database with data
-Independently if you are familiar with GraphQL or not, the command below is the fastest way to create a GraphQL API. Starting from an existing Neptune database endpoint, the utility scans the Neptune database discovering the schema of the existing nodes, edges and properties. Based on the graph database schema, it inferences a GraphQL schema, queries and mutations. Then, it creates an AppSync GraphQL API, and the required AWS resources, like a pair of IAM roles and a Lambda function with the GraphQL resolver code. As soon as the utility complete the execution, you will find in the AppSync console your new GraphQL API called *your-new-GraphQL-API-name*API. To test it, use the AppSync “Queries” from the menu. (*Note: follow the setup instructions below to enable your environment to reach the Neptune database and create AWS resources.*)
 
-`neptune-for-graphql --input-graphdb-schema-neptune-endpoint `<*your-neptune-database-endpoint:port*>` --create-update-aws-pipeline --create-update-aws-pipeline-name` <*your-new-GraphQL-API-name*>` --output-resolver-query-https`
+Independently if you are familiar with GraphQL or not, the command below is the
+fastest way to create a GraphQL API. Starting from an existing Neptune database
+endpoint, the utility scans the Neptune database discovering the schema of the
+existing nodes, edges and properties. Based on the graph database schema, it
+inferences a GraphQL schema, queries and mutations. Then, it creates an AppSync
+GraphQL API, and the required AWS resources, like a pair of IAM roles and a
+Lambda function with the GraphQL resolver code. As soon as the utility complete
+the execution, you will find in the AppSync console your new GraphQL API called
+*your-new-GraphQL-API-name*API. To test it, use the AppSync “Queries” from the
+menu. (*Note: follow the setup instructions below to enable your environment to
+reach the Neptune database and create AWS resources.*)
 
-If you run the command above a second time, it will look again at the Neptune database data and update the AppSync API and the Lambda code.
+`neptune-for-graphql --input-graphdb-schema-neptune-endpoint `<
+*your-neptune-database-endpoint:port*>
+` --create-update-aws-pipeline --create-update-aws-pipeline-name` <
+*your-new-GraphQL-API-name*>` --output-resolver-query-https`
+
+If you run the command above a second time, it will look again at the Neptune
+database data and update the AppSync API and the Lambda code.
 
 To rollback, removing all the AWS resources run:
 
 `neptune-for-graphql --remove-aws-pipeline-name` <*your-new-GraphQL-API-name*>
 
 #### References:
-- [Here](/doc/routesExample.md) is an example using the Air Routes data on Amazon Neptune, showing the outputs of the utility.
-- If you are wondering which AWS resources the utility is creating, look at the section below.
+
+- [Here](/doc/routesExample.md) is an example using the Air Routes data on
+  Amazon Neptune, showing the outputs of the utility.
+- If you are wondering which AWS resources the utility is creating, look at the
+  section below.
 - To customize the GraphQL schema, look at the section below.
 
 <br>
 
 # Starting from a GraphQL schema and an empty Neptune database
-You can start from an empty Neptune database and use a GraphQL API to create the data and query it. Running the command below, the utility will automate the creation of the AWS resources.
-Your *your-graphql-schema-file* must include the GraphQL schema types, like in the [TODO example](/doc/todoExample.md). The utility will analyze your schema and create an extended version based on your types. It will add queries and mutations for the nodes stored in the graph database, and in case your schema have nested types, it will add relationships between the types stored as edges in the graph database, again see the [TODO example](/doc/todoExample.md).
-The utility creates an AppSync GraphQL API and the required AWS resources, like a pair of IAM roles and a Lambda function with the GraphQL resolver code. As soon as the utility completes the execution, you will find in the AppSync console your new GraphQL API called *your-new-GraphQL-API-name*API. To test it, use the AppSync “Queries” from the menu.
+
+You can start from an empty Neptune database and use a GraphQL API to create the
+data and query it. Running the command below, the utility will automate the
+creation of the AWS resources. Your *your-graphql-schema-file* must include the
+GraphQL schema types, like in the [TODO example](/doc/todoExample.md). The
+utility will analyze your schema and create an extended version based on your
+types. It will add queries and mutations for the nodes stored in the graph
+database, and in case your schema have nested types, it will add relationships
+between the types stored as edges in the graph database, again see
+the [TODO example](/doc/todoExample.md). The utility creates an AppSync GraphQL
+API and the required AWS resources, like a pair of IAM roles and a Lambda
+function with the GraphQL resolver code. As soon as the utility completes the
+execution, you will find in the AppSync console your new GraphQL API called
+*your-new-GraphQL-API-name*API. To test it, use the AppSync “Queries” from the
+menu.
 
 > [!TIP]
 >
-> Follow the setup instructions below to enable your environment to reach the Neptune database and create AWS resources.
+> Follow the setup instructions below to enable your environment to reach the
+> Neptune database and create AWS resources.
 
-`neptune-for-graphql --input-schema-file `<*your-graphql-schema-file*>` --create-update-aws-pipeline --create-update-aws-pipeline-name` <*your-new-GraphQL-API-name*>` --create-update-aws-pipeline-neptune-endpoint` <*your-neptune-database-endpoint:port*>  ` --output-resolver-query-https`
+`neptune-for-graphql --input-schema-file `<*your-graphql-schema-file*>
+` --create-update-aws-pipeline --create-update-aws-pipeline-name` <
+*your-new-GraphQL-API-name*>` --create-update-aws-pipeline-neptune-endpoint` <
+*your-neptune-database-endpoint:port*>  ` --output-resolver-query-https`
 
 #### References:
-- [Here](https://github.com/aws/amazon-neptune-for-graphql/blob/main/doc/todoExample.md) is an example using a TODO GraphQL schema, showing the outputs of the utility.
-- If you are wondering which AWS resources the utility is creating, look at the section below.
+
+- [Here](https://github.com/aws/amazon-neptune-for-graphql/blob/main/doc/todoExample.md)
+  is an example using a TODO GraphQL schema, showing the outputs of the utility.
+- If you are wondering which AWS resources the utility is creating, look at the
+  section below.
 - To customize the GraphQL schema, look at the section below.
 
 <br>
 
 # Starting from a GraphQL schema with directives
-You can start from a GraphQL schema with directives for a graph database. For the list of supported directives see the section below [Customize the GraphQL schema with directives](#customize-the-graphql-schema-with-directives). 
 
+You can start from a GraphQL schema with directives for a graph database. For
+the list of supported directives see the section
+below [Customize the GraphQL schema with directives](#customize-the-graphql-schema-with-directives).
 
-`neptune-for-graphql --input-schema-file `<*your-graphql-schema-file-with-directives*>` --create-update-aws-pipeline --create-update-aws-pipeline-name` <*your-new-GraphQL-API-name*> `--create-update-aws-pipeline-neptune-endpoint` <*your-neptune-database-endpoint:port*>` --output-resolver-query-https`
+`neptune-for-graphql --input-schema-file `<
+*your-graphql-schema-file-with-directives*>
+` --create-update-aws-pipeline --create-update-aws-pipeline-name` <
+*your-new-GraphQL-API-name*> `--create-update-aws-pipeline-neptune-endpoint` <
+*your-neptune-database-endpoint:port*>` --output-resolver-query-https`
 
 
 <br>
 
 # Customize the GraphQL schema with directives
-The utility generates a GraphQL schema with directives, queries and mutations. You might want to use it as is, or change it. Below are ways to change it.
+
+The utility generates a GraphQL schema with directives, queries and mutations.
+You might want to use it as is, or change it. Below are ways to change it.
 
 ### Please no mutations in my schema
-In case you don't want your Graph API having the option of updating your database data, add the the CLI option `--output-schema-no-mutations`.
 
-
+In case you don't want your Graph API having the option of updating your
+database data, add the the CLI option `--output-schema-no-mutations`.
 
 ### @alias
-This directive can be applied to GraphQL schema types or fields. It maps different names between the graph database and the GraphQL schema. The syntax is *@alias(property: your-name)*. In the example below *airport* is the graph database node label mapped to the *Airport* GraphQL type, and *desc* is the property of the graph database node mapped to the field *description*. See the [Air Routes Example](https://github.com/aws/amazon-neptune-for-graphql/blob/main/doc/routesExample.md). The GraphQL guidance is pascal case for types and camel case for fields.
+
+This directive can be applied to GraphQL schema types or fields. It maps
+different names between the graph database and the GraphQL schema. The syntax is
+*@alias(property: your-name)*. In the example below *airport* is the graph
+database node label mapped to the *Airport* GraphQL type, and *desc* is the
+property of the graph database node mapped to the field *description*. See
+the [Air Routes Example](https://github.com/aws/amazon-neptune-for-graphql/blob/main/doc/routesExample.md).
+The GraphQL guidance is pascal case for types and camel case for fields.
 
 ```graphql
-type Airport @alias(property: "airport") {  
-  city: String
-  description: String @alias(property: "desc")  
+type Airport @alias(property: "airport") {
+    city: String
+    description: String @alias(property: "desc")
 }
 ```
 
 ### @relationship
-This directive maps nested GraphQL types to a graph databases edges. The syntax is *@relationship(edgeType: graphdb-edge-name, direction: IN|OUT)*. 
+
+This directive maps nested GraphQL types to a graph databases edges. The syntax
+is *@relationship(edgeType: graphdb-edge-name, direction: IN|OUT)*.
 <br>
-See the [Todo Example](https://github.com/aws/amazon-neptune-for-graphql/blob/main/doc/todoExample.md) and the [Air Routes Example](https://github.com/aws/amazon-neptune-for-graphql/blob/main/doc/routesExample.md).
+See
+the [Todo Example](https://github.com/aws/amazon-neptune-for-graphql/blob/main/doc/todoExample.md)
+and
+the [Air Routes Example](https://github.com/aws/amazon-neptune-for-graphql/blob/main/doc/routesExample.md).
 
 ```graphql
 type Airport @alias(property: "airport") {
-  ...
-  continentContainsIn: Continent @relationship(edgeType: "contains", direction: IN)
-  countryContainsIn: Country @relationship(edgeType: "contains", direction: IN)
-  airportRoutesOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "route", direction: OUT)
-  airportRoutesIn(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "route", direction: IN)
+    ...
+continentContainsIn: Continent @relationship(edgeType: "contains", direction: IN)
+countryContainsIn: Country @relationship(edgeType: "contains", direction: IN)
+airportRoutesOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "route", direction: OUT)
+airportRoutesIn(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "route", direction: IN)
 }
 ```
 
 ### @graphQuery, @cypher
-You can define your openCypher queries to resolve a field value, add queries or mutations. 
 
-Here a new field *outboundRoutesCount* is added to the type *Airport* to count the outbound routes:
+You can define your openCypher queries to resolve a field value, add queries or
+mutations.
+
+Here a new field *outboundRoutesCount* is added to the type *Airport* to count
+the outbound routes:
 
 ```graphql
 type Airport @alias(property: "airport") {
-  ...
-  outboundRoutesCount: Int @graphQuery(statement: "MATCH (this)-[r:route]->(a) RETURN count(r)")
+    ...
+outboundRoutesCount: Int @graphQuery(statement: "MATCH (this)-[r:route]->(a) RETURN count(r)")
 }
 ```
-Here is an example of new queries and mutations. Note that if you omit the *RETURN*, the resolver will assume the keyword *this* is the returning scope.
+
+Here is an example of new queries and mutations. Note that if you omit the
+*RETURN*, the resolver will assume the keyword *this* is the returning scope.
+
 ```graphql
 type Query {
-  getAirportConnection(fromCode: String!, toCode: String!): Airport @cypher(statement: "MATCH (:airport{code: '$fromCode'})-[:route]->(this:airport)-[:route]->(:airport{code:'$toCode'})")   
+    getAirportConnection(fromCode: String!, toCode: String!): Airport @cypher(statement: "MATCH (:airport{code: '$fromCode'})-[:route]->(this:airport)-[:route]->(:airport{code:'$toCode'})")
 }
 
 type Mutation {
-  createAirport(input: AirportCreateInput!): Airport @graphQuery(statement: "CREATE (this:airport {$input}) RETURN this")
-  addRoute(fromAirportCode:String, toAirportCode:String, dist:Int): Route @graphQuery(statement: "MATCH (from:airport{code:'$fromAirportCode'}), (to:airport{code:'$toAirportCode'}) CREATE (from)-[this:route{dist:$dist}]->(to) RETURN this")
+    createAirport(input: AirportCreateInput!): Airport @graphQuery(statement: "CREATE (this:airport {$input}) RETURN this")
+    addRoute(fromAirportCode:String, toAirportCode:String, dist:Int): Route @graphQuery(statement: "MATCH (from:airport{code:'$fromAirportCode'}), (to:airport{code:'$toAirportCode'}) CREATE (from)-[this:route{dist:$dist}]->(to) RETURN this")
 }
 ```
 
-You can add a query or mutation using a Gremlin query. At this time Gremlin queries are limited to return *scalar* values, or *elementMap()* for a single node, or *elementMap().fold()* for a list of nodes.
+You can add a query or mutation using a Gremlin query. At this time Gremlin
+queries are limited to return *scalar* values, or *elementMap()* for a single
+node, or *elementMap().fold()* for a list of nodes.
+
 ```graphql
 type Query {
-  getAirportWithGremlin(code:String): Airport @graphQuery(statement: "g.V().has('airport', 'code', '$code').elementMap()") # single node
-  getAirportsWithGremlin: [Airport] @graphQuery(statement: "g.V().hasLabel('airport').elementMap().fold()") # list of nodes
-  getCountriesCount: Int @graphQuery(statement: "g.V().hasLabel('country').count()")  # scalar example
+    getAirportWithGremlin(code:String): Airport @graphQuery(statement: "g.V().has('airport', 'code', '$code').elementMap()") # single node
+    getAirportsWithGremlin: [Airport] @graphQuery(statement: "g.V().hasLabel('airport').elementMap().fold()") # list of nodes
+    getCountriesCount: Int @graphQuery(statement: "g.V().hasLabel('country').count()")  # scalar example
 }
 ```
 
 ### @id
-The directive @id identifies the field mapped to the graph database entity id. Graph databases like Amazon Neptune always have a unique id for nodes and edges assigned during bulk imports or autogenerated. 
-In the example below _id 
+
+The directive @id identifies the field mapped to the graph database entity id.
+Graph databases like Amazon Neptune always have a unique id for nodes and edges
+assigned during bulk imports or autogenerated. In the example below _id
+
 ```graphql
 type Airport {
-  _id: ID! @id
-  city: String
-  code: String  
+    _id: ID! @id
+    city: String
+    code: String
 }
 ```
 
 ### Reserved types, queries and mutations names
-The utility auto generates queries and mutations to enable you to have a working GraphQL API just after having ran the utility. The pattern of these names are recognized by the resolver and are reserved. Here is an example for the type *Airport* and the connecting type *Route*:
 
-The type *Options* is reserved. 
+The utility auto generates queries and mutations to enable you to have a working
+GraphQL API just after having ran the utility. The pattern of these names are
+recognized by the resolver and are reserved. Here is an example for the type
+*Airport* and the connecting type *Route*:
+
+The type *Options* is reserved.
+
 ```graphql
 input Options {
-  limit: Int
+    limit: Int
 }
 ```
 
 The function parameters *filter*, *options*, and *sort* are reserved.
+
 ```graphql
-type Query {  
+type Query {
     getNodeAirports(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport]
 }
 ```
 
-The beginning of query names *getNode...*, and the beginning of the mutations names like *createNode...*, *updateNode...*, *deleteNode...*, *connectNode...*, *updateEdge...*, and *deleteEdge...*.
+The beginning of query names *getNode...*, and the beginning of the mutations
+names like *createNode...*, *updateNode...*, *deleteNode...*, *connectNode...*,
+*updateEdge...*, and *deleteEdge...*.
+
 ```graphql
-type Query {  
-  getNodeAirport(id: ID, filter: AirportInput): Airport
-  getNodeAirports(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport]
+type Query {
+    getNodeAirport(id: ID, filter: AirportInput): Airport
+    getNodeAirports(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport]
 }
 
-type Mutation {  
-  createNodeAirport(input: AirportCreateInput!): Airport
-  updateNodeAirport(id: ID!, input: AirportUpdateInput!): Airport
-  deleteNodeAirport(id: ID!): Boolean  
-  connectNodeAirportToNodeAirportEdgeRoute(from: ID!, to: ID!, edge: RouteInput!): Route
-  updateEdgeRouteFromAirportToAirport(from: ID!, to: ID!, edge: RouteInput!): Route
-  deleteEdgeRouteFromAirportToAirport(from: ID!, to: ID!): Boolean
+type Mutation {
+    createNodeAirport(input: AirportCreateInput!): Airport
+    updateNodeAirport(id: ID!, input: AirportUpdateInput!): Airport
+    deleteNodeAirport(id: ID!): Boolean
+    connectNodeAirportToNodeAirportEdgeRoute(from: ID!, to: ID!, edge: RouteInput!): Route
+    updateEdgeRouteFromAirportToAirport(from: ID!, to: ID!, edge: RouteInput!): Route
+    deleteEdgeRouteFromAirportToAirport(from: ID!, to: ID!): Boolean
 }
 ```
 
 ### Re-apply your changes with --input-schema-changes-file
-You might want to modify the GraphQL source schema and run the utility again to get the latest schema from your Neptune database. Every time the utility discovers a new graphdb schema, it generates a new GraphQL schema. To inject your changes, you can manually edit the GraphQL source schema and run the utility again, using it as input instead of the Neptune database endpoint, or write your changes in the format below. As you run the utility with the added option `--input-schema-changes-file <your-changes-file>`, your changes will be applied at once.
+
+You might want to modify the GraphQL source schema and run the utility again to
+get the latest schema from your Neptune database. Every time the utility
+discovers a new graphdb schema, it generates a new GraphQL schema. To inject
+your changes, you can manually edit the GraphQL source schema and run the
+utility again, using it as input instead of the Neptune database endpoint, or
+write your changes in the format below. As you run the utility with the added
+option `--input-schema-changes-file <your-changes-file>`, your changes will be
+applied at once.
+
 ```json
 [
-     { "type": "graphQLTypeName",
-       "field": "graphQLFieldName",
-       "action": "remove|add",
-       "value": "value"
-    }
+  {
+    "type": "graphQLTypeName",
+    "field": "graphQLFieldName",
+    "action": "remove|add",
+    "value": "value"
+  }
 ]
 ```
+
 For Example:
 
 ```json
 [
-    { "type": "Airport", "field": "outboundRoutesCountAdd", "action": "add", "value":"outboundRoutesCountAdd: Int @graphQuery(statement: \"MATCH (this)-[r:route]->(a) RETURN count(r)\")"},    
-    { "type": "Mutation", "field": "deleteNodeVersion", "action": "remove", "value": "" },
-    { "type": "Mutation", "field": "createNodeVersion", "action": "remove", "value": "" }
+  {
+    "type": "Airport",
+    "field": "outboundRoutesCountAdd",
+    "action": "add",
+    "value": "outboundRoutesCountAdd: Int @graphQuery(statement: \"MATCH (this)-[r:route]->(a) RETURN count(r)\")"
+  },
+  {
+    "type": "Mutation",
+    "field": "deleteNodeVersion",
+    "action": "remove",
+    "value": ""
+  },
+  {
+    "type": "Mutation",
+    "field": "createNodeVersion",
+    "action": "remove",
+    "value": ""
+  }
 ]
 ```
-
 
 <br>
 
 # AWS resources for the GraphQL API
+
 You have three option to created the GraphQL API pipeline:
+
 - Let the utility create the AWS resources
 - Let the utility create a CDK file, then you run it
-- You manually create the AWS resources 
+- You manually create the AWS resources
 
-Independently of the method you or the utility will need to create the following resources:
+Independently of the method you or the utility will need to create the following
+resources:
+
 - Create an IAM role for Lambda called LambdaExecutionRole
 - Attach to the LambdaExecutionRole the IAM policy AWSLambdaBasicExecutionRole
-- For VPC (default) attach to the LambdaExecutionRole the IAM policy AWSLambdaVPCAccessExecutionRole
-- For IAM create and attach to the LambdaExecutionRole a new IAM policy that only allow to connect and query Neptune
+- For VPC (default) attach to the LambdaExecutionRole the IAM policy
+  AWSLambdaVPCAccessExecutionRole
+- For IAM create and attach to the LambdaExecutionRole a new IAM policy that
+  only allow to connect and query Neptune
 - Create a Lambda function with the LambdaExecutionRole
 - Create an IAM for AppSync API to call the Lambda called LambdaInvocationRole
 - Attach to the LambdaInvocationRole the policy LambdaInvokePolicy
-- Create the AppSync GraphQL API 
-- Add to the AppSync API a Function with the LambdaInvocationRole to call the Lambda
-
+- Create the AppSync GraphQL API
+- Add to the AppSync API a Function with the LambdaInvocationRole to call the
+  Lambda
 
 ### Let the utility create the resources
-With the CLI option `--create-update-aws-pipeline`, and its accessory options ([see the commands reference](https://github.com/aws/amazon-neptune-for-graphql/blob/main/doc/cliReference.md)), the utility automatically creates the resources.<br>
-You need to run the utility from a shell in which you installed the AWS CLI, and it is configured for a user with the permission of creating AWS resources. <br>
-The utility creates a file with the list of resources named *pipeline-name.resources.json*. Then it uses the file to modify the existing resources when the user runs the command again, or when the user wants to delete the AWS resources with the command option `--remove-aws-pipeline-name <value>`.
-The code of the utility uses the JavaScript AWS sdk v3, if you'd like to review the code, it is only in [this file](https://github.com/aws/amazon-neptune-for-graphql/blob/main/src/pipelineResources.js).
+
+With the CLI option `--create-update-aws-pipeline`, and its accessory
+options ([see the commands reference](https://github.com/aws/amazon-neptune-for-graphql/blob/main/doc/cliReference.md)),
+the utility automatically creates the resources.<br>
+You need to run the utility from a shell in which you installed the AWS CLI, and
+it is configured for a user with the permission of creating AWS resources. <br>
+The utility creates a file with the list of resources named
+*pipeline-name.resources.json*. Then it uses the file to modify the existing
+resources when the user runs the command again, or when the user wants to delete
+the AWS resources with the command option `--remove-aws-pipeline-name <value>`.
+The code of the utility uses the JavaScript AWS sdk v3, if you'd like to review
+the code, it is only
+in [this file](https://github.com/aws/amazon-neptune-for-graphql/blob/main/src/pipelineResources.js).
 
 ### I prefer a CDK file
-The option to trigger the creation of the CDK file starts with `--output-aws-pipeline-cdk`, and its accessory options ([see the commands reference](https://github.com/aws/amazon-neptune-for-graphql/blob/main/doc/cliReference.md)). <br> 
-After running, you will find in the *output* folder the file *CDK-pipeline-name-cdk.js* and *CDK-pipeline-name.zip*. The ZIP file is the code for the Lambda function.
-See CDK end to end example [here](https://github.com/aws/amazon-neptune-for-graphql/blob/main/doc/cdk.md).
+
+The option to trigger the creation of the CDK file starts with
+`--output-aws-pipeline-cdk`, and its accessory
+options ([see the commands reference](https://github.com/aws/amazon-neptune-for-graphql/blob/main/doc/cliReference.md)). <br>
+After running, you will find in the *output* folder the file
+*CDK-pipeline-name-cdk.js* and *CDK-pipeline-name.zip*. The ZIP file is the code
+for the Lambda function. See CDK end to end
+example [here](https://github.com/aws/amazon-neptune-for-graphql/blob/main/doc/cdk.md).
 
 ### Let me setup the resources manually or with my favorite DevOps toolchain
-[Here](https://github.com/aws/amazon-neptune-for-graphql/blob/main/doc/resources.md) is the detailed list of resources needed to configure the GraphQL API pipeline.
+
+[Here](https://github.com/aws/amazon-neptune-for-graphql/blob/main/doc/resources.md)
+is the detailed list of resources needed to configure the GraphQL API pipeline.
 <br>
 
 # Generate Apollo Server Artifacts
-If you prefer to use Apollo Server instead of AWS App Sync, the utility can generate a ZIP file of Apollo Server artifacts with the CLI option `--create-update-apollo-server` for a standalone server or `--create-update-apollo-server-subgraph` for federated systems.
 
-Example of starting with a neptune database with data from which to determine the graphQL schema:
+If you prefer to use Apollo Server instead of AWS App Sync, the utility can
+generate a ZIP file of Apollo Server artifacts with the CLI option
+`--create-update-apollo-server` for a standalone server or
+`--create-update-apollo-server-subgraph` for federated systems.
+
+Example of starting with a neptune database with data from which to determine
+the graphQL schema:
+
 ```
 neptune-for-graphql \
   --input-graphdb-schema-neptune-endpoint abc.us-west-2.neptune.amazonaws.com:8182 \
@@ -294,6 +464,7 @@ neptune-for-graphql \
 ```
 
 Example of starting with a graphQL schema file:
+
 ```
 neptune-for-graphql \
   --input-schema-file airports.source.schema.graphql \
@@ -302,48 +473,79 @@ neptune-for-graphql \
   --output-resolver-query-https
 ```
 
-The example commands above will generate the file `apollo-server-<identifier>-<timestamp>.zip`, which can then be deployed locally by following these steps:
+The example commands above will generate the file
+`apollo-server-<identifier>-<timestamp>.zip`, which can then be deployed locally
+by following these steps:
+
 1. unzip `apollo-server-<identifier>-<timestamp>.zip`
 2. change directory into the unzipped folder
 3. execute `npm install` to install required dependencies
 4. execute `node index.mjs` to start the Apollo Server
-5. access the graphQL application in a browser by visiting `http://localhost:4000/`
+5. access the graphQL application in a browser by visiting
+   `http://localhost:4000/`
 
-> [!NOTE] 
-> Node's default AWS credentials provider is used for authentication with Neptune. See [AWS SDK credential providers](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-credential-providers/#fromnodeproviderchain) for more information.
+> [!NOTE]
+> Node's default AWS credentials provider is used for authentication with
+> Neptune.
+> See [AWS SDK credential providers](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-credential-providers/#fromnodeproviderchain)
+> for more information.
 
 ### Using Custom Scalars with Apollo Server
-When using custom scalars in your schema (specified via `--input-schema-file`), you should add corresponding scalar resolvers to the index.mjs file in the generated Apollo Server artifact. Although queries will execute without these resolvers, the absence of the custom scalar resolvers will bypass important data validation for fields using custom scalar types. See [Apollo Custom Scalars](https://www.apollographql.com/docs/apollo-server/schema/custom-scalars) for more details on how to attach custom scalar resolvers with Apollo Server.
+
+When using custom scalars in your schema (specified via `--input-schema-file`),
+you should add corresponding scalar resolvers to the index.mjs file in the
+generated Apollo Server artifact. Although queries will execute without these
+resolvers, the absence of the custom scalar resolvers will bypass important data
+validation for fields using custom scalar types.
+See [Apollo Custom Scalars](https://www.apollographql.com/docs/apollo-server/schema/custom-scalars)
+for more details on how to attach custom scalar resolvers with Apollo Server.
 
 # Known limitations
-- @graphQuery using Gremlin works only if the query returns a scalar value, one elementMap(), or list as elementMap().fold(), this feature is under development.
+
+- @graphQuery using Gremlin works only if the query returns a scalar value, one
+  elementMap(), or list as elementMap().fold(), this feature is under
+  development.
 - Neptune RDF database and SPARQL language is not supported.
-- Querying Neptune via SDK is not yet supported for Apollo Server, only HTTPS is supported.
-- Schemas specified by `--input-schema-file` with `--create-update-aws-pipeline` may not contain custom scalars. See [AWS App Sync Scalar types in GraphQL](https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html) for more information.
-- Schemas specified by `--input-schema-file` with `--create-update-apollo-server` or `--create-update-apollo-server-subgraph` which contain custom scalars require manual steps to add custom scalar resolvers for additional query validation.
+- Querying Neptune via SDK is not yet supported for Apollo Server, only HTTPS is
+  supported.
+- Schemas specified by `--input-schema-file` with `--create-update-aws-pipeline`
+  may not contain custom scalars.
+  See [AWS App Sync Scalar types in GraphQL](https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html)
+  for more information.
+- Schemas specified by `--input-schema-file` with`--create-update-apollo-server`
+  or `--create-update-apollo-server-subgraph`which contain custom scalars
+  require manual steps to add custom scalar resolvers for additional query
+  validation.
 - Query fragments are supported for Apollo Server but not yet for App Sync
-- Inline fragments are not yet supported 
-- When working with sort values as variables, Apollo Server may not support an array variable but will accept variables inside an array. For example ```sort: $test``` with variable ```{"test": [{"country": "ASC"}]}``` may produce an error but can be modified to ```sort: [$test]``` with variable ```{"test": {"country": "ASC"}}```.  
-<br>
+- Inline fragments are not yet supported
+- When working with sort values as variables, Apollo Server may not support an
+  array variable but will accept variables inside an array. For example
+  ```sort: $test``` with variable ```{"test": [{"country": "ASC"}]}``` may
+  produce an error but can be modified to ```sort: [$test]``` with variable
+  ```{"test": {"country": "ASC"}}```.  
+  <br>
 
 # Roadmap
+
 - Gremlin resolver.
 - SPARQL resolver for RDF database.
 - Enhanced configurations for Apollo Server.
-<br>
+  <br>
 
 # License
-Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-Licensed under the Apache License, Version 2.0 (the "License").
-You may not use this file except in compliance with the License.
-A copy of the License is located at http://www.apache.org/licenses/LICENSE-2.0
-or in the "license" file accompanying this file. This file is distributed
-on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-express or implied. See the License for the specific language governing
-permissions and limitations under the License. [Full license page](/LICENSE.txt).
+
+Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved. Licensed
+under the Apache License, Version 2.0 (the "License"). You may not use this file
+except in compliance with the License. A copy of the License is located
+at http://www.apache.org/licenses/LICENSE-2.0
+or in the "license" file accompanying this file. This file is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+or implied. See the License for the specific language governing permissions and
+limitations under the License. [Full license page](/LICENSE.txt).
 <br>
 
 # Contributing
+
 Follow AWS open source practices.
 <br>
 [Contributing page.](/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ the [Air Routes Example](https://github.com/aws/amazon-neptune-for-graphql/blob/
 
 ```graphql
 type Airport @alias(property: "airport") {
-    ...
+  ...
   continentContainsIn: Continent @relationship(edgeType: "contains", direction: IN)
   countryContainsIn: Country @relationship(edgeType: "contains", direction: IN)
   airportRoutesOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "route", direction: OUT)

--- a/README.md
+++ b/README.md
@@ -237,10 +237,10 @@ the [Air Routes Example](https://github.com/aws/amazon-neptune-for-graphql/blob/
 ```graphql
 type Airport @alias(property: "airport") {
     ...
-continentContainsIn: Continent @relationship(edgeType: "contains", direction: IN)
-countryContainsIn: Country @relationship(edgeType: "contains", direction: IN)
-airportRoutesOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "route", direction: OUT)
-airportRoutesIn(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "route", direction: IN)
+  continentContainsIn: Continent @relationship(edgeType: "contains", direction: IN)
+  countryContainsIn: Country @relationship(edgeType: "contains", direction: IN)
+  airportRoutesOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "route", direction: OUT)
+  airportRoutesIn(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "route", direction: IN)
 }
 ```
 
@@ -255,7 +255,7 @@ the outbound routes:
 ```graphql
 type Airport @alias(property: "airport") {
     ...
-outboundRoutesCount: Int @graphQuery(statement: "MATCH (this)-[r:route]->(a) RETURN count(r)")
+    outboundRoutesCount: Int @graphQuery(statement: "MATCH (this)-[r:route]->(a) RETURN count(r)")
 }
 ```
 

--- a/doc/cdk.md
+++ b/doc/cdk.md
@@ -82,7 +82,7 @@ The original file looks like this:
 #!/usr/bin/env node
 
 const cdk = require('aws-cdk-lib');
-const {CdkStack} = require('../lib/cdk-stack');
+const { CdkStack } = require('../lib/cdk-stack');
 
 const app = new cdk.App();
 new CdkStack(app, 'CdkStack', {
@@ -118,7 +118,7 @@ The end result should look something like this:
 #!/usr/bin/env node
 
 const cdk = require('aws-cdk-lib');
-const {AppSyncNeptuneStack} = require('../lib/your-new-GraphQL-API-name-cdk');
+const { AppSyncNeptuneStack } = require('../lib/your-new-GraphQL-API-name-cdk');
 
 const app = new cdk.App();
 new AppSyncNeptuneStack(app, 'your-CdkStack-name', {

--- a/doc/cdk.md
+++ b/doc/cdk.md
@@ -1,66 +1,78 @@
 # Deploy the GraphQL API resources with CDK
 
-If your organization require using CDK to deploy AWS resources, here an end to
-end example.
-<br>
-Note: likely your organization has a CDK application that deploy other AWS
-resources. The team that maintain the CDK application can integrate the GraphQL
-API deployment using two files from the GraphQL utility output; the
-*output/your-new-GraphQL-API-name-cdk.js* and the
-*output/your-new-GraphQL-API-name.zip*.
+If your organization requires using CDK to deploy AWS resources, here is an end
+to end example.
+
+> [!NOTE]
+>
+> Likely your organization has a CDK application that deploys other AWS
+> resources. The team that maintains the CDK application can integrate the
+> GraphQL
+> API deployment using two files from the GraphQL utility output; the
+> `output/your-new-GraphQL-API-name-cdk.js` and the
+> `output/your-new-GraphQL-API-name.zip`.
 
 ## Create the CDK assets
 
 Example starting from an Amazon Neptune database endpoint. In this case the
 utility uses the Neptune endpoint to discover the region and database name.
 
-`neptune-for-graphql --input-graphdb-schema-neptune-endpoint `<
-*your-neptune-database-endpoint:port*>
-` --output-aws-pipeline-cdk --output-aws-pipeline-cdk-name` <
-*your-new-GraphQL-API-name*> `--output-resolver-query-https`
+```
+neptune-for-graphql \
+    --input-graphdb-schema-neptune-endpoint <your-neptune-database-endpoint:port> \
+    --output-aws-pipeline-cdk \
+    --output-aws-pipeline-cdk-name <your-new-GraphQL-API-name> \
+    --output-resolver-query-https \
+```
 
 Example starting from a GraphQL schema.
 
-`neptune-for-graphql --input-schema-file `<*your-graphql-schema-file*>
-` --output-aws-pipeline-cdk --output-aws-pipeline-cdk-name` <
-*your-new-GraphQL-API-name*>` --output-aws-pipeline-cdk-neptune-endpoint` <
-*your-neptune-database-endpoint:port*>` --output-resolver-query-https`
+```
+neptune-for-graphql \
+    --input-schema-file <your-graphql-schema-file> \
+    --output-aws-pipeline-cdk \
+    --output-aws-pipeline-cdk-name <your-new-GraphQL-API-name> \
+    --output-aws-pipeline-cdk-neptune-endpoint <your-neptune-database-endpoint:port> \
+    --output-resolver-query-https \
+```
 
 ## An example on how to test the CDK utility output
 
 ### Install the CDK
 
-`npm install -g aws-cdk`
-<br>
-`cdk --version`
+```
+npm install -g aws-cdk
+cdk --version
+```
 
 ### Create a CDK application
 
 Create a directory *your-CDK-dir* for your CDK application, CD in the new
 directory and initialize the CDK application.
 
-`md` *your-CDK-dir*
-<br>
-`cd ` *your-CDK-dir*
-<br>
-`cdk init app --language javascript`
+```
+mkdir your-CDK-dir
+cd your-CDK-dir
+cdk init app --language javascript
+```
 
 Install CDK libraries used by the GraphQL utility.
 
-`npm install @aws-cdk/aws-iam`
-<br>
-`npm install @aws-cdk/aws-ec2`
-<br>
-`npm install @aws-cdk/aws-appsync`
+```
+npm install @aws-cdk/aws-iam
+npm install @aws-cdk/aws-ec2
+npm install @aws-cdk/aws-appsync
+```
 
 ### Integrate the GraphQL utility CDK output to the CDK application
 
 Copy from the utility CDK output files from the *output* directory in the CDK
 application.
 
-`cp  output/`*your-new-GraphQL-API-name*`-cdk.js /lib`
-<br>
-`cp  output/`*your-new-GraphQL-API-name*`.zip .`
+```
+cp  output/your-new-GraphQL-API-name-cdk.js /lib
+cp  output/your-new-GraphQL-API-name.zip .
+```
 
 Update the CDK test project, editing the file `bin/`*your-CDK-dir*`.js`
 <br>

--- a/doc/cdk.md
+++ b/doc/cdk.md
@@ -1,29 +1,43 @@
-# Deploy the GraphQL API resources with CDK 
-If your organization require using CDK to deploy AWS resources, here an end to end example.
-<br>
-Note: likely your organization has a CDK application that deploy other AWS resources. The team that maintain the CDK application can integrate the GraphQL API deployment using two files from the GraphQL utility output; the *output/your-new-GraphQL-API-name-cdk.js* and the *output/your-new-GraphQL-API-name.zip*.
+# Deploy the GraphQL API resources with CDK
 
+If your organization require using CDK to deploy AWS resources, here an end to
+end example.
+<br>
+Note: likely your organization has a CDK application that deploy other AWS
+resources. The team that maintain the CDK application can integrate the GraphQL
+API deployment using two files from the GraphQL utility output; the
+*output/your-new-GraphQL-API-name-cdk.js* and the
+*output/your-new-GraphQL-API-name.zip*.
 
 ## Create the CDK assets
-Example starting from an Amazon Neptune database endpoint. In this case the utility uses the Neptune endpoint to discover the region and database name.
 
-`neptune-for-graphql --input-graphdb-schema-neptune-endpoint `<*your-neptune-database-endpoint:port*>` --output-aws-pipeline-cdk --output-aws-pipeline-cdk-name` <*your-new-GraphQL-API-name*> `--output-resolver-query-https`
+Example starting from an Amazon Neptune database endpoint. In this case the
+utility uses the Neptune endpoint to discover the region and database name.
+
+`neptune-for-graphql --input-graphdb-schema-neptune-endpoint `<
+*your-neptune-database-endpoint:port*>
+` --output-aws-pipeline-cdk --output-aws-pipeline-cdk-name` <
+*your-new-GraphQL-API-name*> `--output-resolver-query-https`
 
 Example starting from a GraphQL schema.
 
-`neptune-for-graphql --input-schema-file `<*your-graphql-schema-file*>` --output-aws-pipeline-cdk --output-aws-pipeline-cdk-name` <*your-new-GraphQL-API-name*>` --output-aws-pipeline-cdk-neptune-endpoint` <*your-neptune-database-endpoint:port*>` --output-resolver-query-https` 
-
-
+`neptune-for-graphql --input-schema-file `<*your-graphql-schema-file*>
+` --output-aws-pipeline-cdk --output-aws-pipeline-cdk-name` <
+*your-new-GraphQL-API-name*>` --output-aws-pipeline-cdk-neptune-endpoint` <
+*your-neptune-database-endpoint:port*>` --output-resolver-query-https`
 
 ## An example on how to test the CDK utility output
 
 ### Install the CDK
+
 `npm install -g aws-cdk`
 <br>
 `cdk --version`
 
 ### Create a CDK application
-Create a directory *your-CDK-dir* for your CDK application, CD in the new directory and initialize the CDK application.
+
+Create a directory *your-CDK-dir* for your CDK application, CD in the new
+directory and initialize the CDK application.
 
 `md` *your-CDK-dir*
 <br>
@@ -40,7 +54,9 @@ Install CDK libraries used by the GraphQL utility.
 `npm install @aws-cdk/aws-appsync`
 
 ### Integrate the GraphQL utility CDK output to the CDK application
-Copy from the utility CDK output files from the *output* directory in the CDK application.
+
+Copy from the utility CDK output files from the *output* directory in the CDK
+application.
 
 `cp  output/`*your-new-GraphQL-API-name*`-cdk.js /lib`
 <br>
@@ -49,59 +65,62 @@ Copy from the utility CDK output files from the *output* directory in the CDK ap
 Update the CDK test project, editing the file `bin/`*your-CDK-dir*`.js`
 <br>
 The original file looks like this:
+
 ```js
 #!/usr/bin/env node
 
 const cdk = require('aws-cdk-lib');
-const { CdkStack } = require('../lib/cdk-stack');
+const {CdkStack} = require('../lib/cdk-stack');
 
 const app = new cdk.App();
 new CdkStack(app, 'CdkStack', {
-  /* If you don't specify 'env', this stack will be environment-agnostic.
-   * Account/Region-dependent features and context lookups will not work,
-   * but a single synthesized template can be deployed anywhere. */
+    /* If you don't specify 'env', this stack will be environment-agnostic.
+     * Account/Region-dependent features and context lookups will not work,
+     * but a single synthesized template can be deployed anywhere. */
 
-  /* Uncomment the next line to specialize this stack for the AWS Account
-   * and Region that are implied by the current CLI configuration. */
-  // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
+    /* Uncomment the next line to specialize this stack for the AWS Account
+     * and Region that are implied by the current CLI configuration. */
+    // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
 
-  /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
+    /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
 });
 ```
 
-Update the require statement to reference the `AppSyncNeptuneStack` class from the  `-cdk.js` file that was copied to the `lib` directory:
+Update the require statement to reference the `AppSyncNeptuneStack` class from
+the  `-cdk.js` file that was copied to the `lib` directory:
 
 ```js
-const { AppSyncNeptuneStack } = require('../lib/your-new-GraphQL-API-name-cdk');
+const {AppSyncNeptuneStack} = require('../lib/your-new-GraphQL-API-name-cdk');
 ```
 
-Update the stack instantiation to reference `AppSyncNeptuneStack` and change the stack name if desired:
+Update the stack instantiation to reference `AppSyncNeptuneStack` and change the
+stack name if desired:
 
 ```js
 new AppSyncNeptuneStack(app, 'your-CdkStack-name', {
 ```
 
 The end result should look something like this:
+
 ```js
 #!/usr/bin/env node
 
 const cdk = require('aws-cdk-lib');
-const { AppSyncNeptuneStack } = require('../lib/your-new-GraphQL-API-name-cdk');
+const {AppSyncNeptuneStack} = require('../lib/your-new-GraphQL-API-name-cdk');
 
 const app = new cdk.App();
 new AppSyncNeptuneStack(app, 'your-CdkStack-name', {
-  /* If you don't specify 'env', this stack will be environment-agnostic.
-   * Account/Region-dependent features and context lookups will not work,
-   * but a single synthesized template can be deployed anywhere. */
+    /* If you don't specify 'env', this stack will be environment-agnostic.
+     * Account/Region-dependent features and context lookups will not work,
+     * but a single synthesized template can be deployed anywhere. */
 
-  /* Uncomment the next line to specialize this stack for the AWS Account
-   * and Region that are implied by the current CLI configuration. */
-  // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
+    /* Uncomment the next line to specialize this stack for the AWS Account
+     * and Region that are implied by the current CLI configuration. */
+    // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
 
-  /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
+    /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
 });
 ```
-
 
 ### Run the CDK application
 

--- a/doc/cliReference.md
+++ b/doc/cliReference.md
@@ -13,6 +13,7 @@ Version
 Logs to the console only the errors.
 
 ## Input
+
 `--input-schema <value>, -is <value>`<br>
 `--input-schema-file <value>, -isf <value>`
 <br>
@@ -20,64 +21,98 @@ The GraphQL schema with or without directives as data or file name.
 
 `--input-schema-changes-file <value>, -isc <value>`
 <br>
-The file that contains your GraphQL schema changes to be applied when you run the utility multiple time. When you run the utility pointing to a database multiple times, and you manually changed the GraphQL source schema, maybe adding a custom query, your changes will be lost. To avoid it, add your changes to the a json file and pass it to this option. See section [*Re-apply your changes*](#re-apply-your-changes-with---input-schema-changes-file) for the file format.
+The file that contains your GraphQL schema changes to be applied when you run
+the utility multiple time. When you run the utility pointing to a database
+multiple times, and you manually changed the GraphQL source schema, maybe adding
+a custom query, your changes will be lost. To avoid it, add your changes to the
+a json file and pass it to this option. See section [*Re-apply your
+changes*](#re-apply-your-changes-with---input-schema-changes-file) for the file
+format.
 
 ```json
 [
-     { "type": "graphQLTypeName",
-       "field": "graphQLFieldName",
-       "action": "remove|add",
-       "value": "value"
-    }
+  {
+    "type": "graphQLTypeName",
+    "field": "graphQLFieldName",
+    "action": "remove|add",
+    "value": "value"
+  }
 ]
 ```
 
 `--input-graphdb-schema <value>, -ig <value>`<br>
 `--input-graphdb-schema-file <value>, -igf <value>`
 <br>
-The graphdb schema as data or file name. Instead of pointing to a Neptune database you can edit a graphdb schema as use it as input.
+The graphdb schema as data or file name. Instead of pointing to a Neptune
+database you can edit a graphdb schema as use it as input.
 
 ```json
 {
-    "nodeStructures": [
-        { "label":"nodelabel1",
-            "properties": [
-                { "name":"name1", "type":"type1" }
-            ]
-        },
-        { "label":"nodelabel2",
-            "properties": [
-                { "name":"name2", "type":"type1" }
-        ]}
-    ],
-    "edgeStructures": [
-        { "label":"label1",
-            "directions": [
-                { "from":"nodelabel1", "to":"nodelabel2", "relationship":"ONE-ONE|ONE-MANY|MANY-MANY"  }
-            ],
-            "properties": [
-                { "name":"name1", "type":"type1" }
-            ]
-        }]
+  "nodeStructures": [
+    {
+      "label": "nodelabel1",
+      "properties": [
+        {
+          "name": "name1",
+          "type": "type1"
+        }
+      ]
+    },
+    {
+      "label": "nodelabel2",
+      "properties": [
+        {
+          "name": "name2",
+          "type": "type1"
+        }
+      ]
     }
+  ],
+  "edgeStructures": [
+    {
+      "label": "label1",
+      "directions": [
+        {
+          "from": "nodelabel1",
+          "to": "nodelabel2",
+          "relationship": "ONE-ONE|ONE-MANY|MANY-MANY"
+        }
+      ],
+      "properties": [
+        {
+          "name": "name1",
+          "type": "type1"
+        }
+      ]
+    }
+  ]
+}
 ```
 
 `--input-graphdb-schema-neptune-endpoint <value>, -ie <value>`
 <br>
-The Neptune database endpoint from which the utility extract the graphdb schema. Format: `host:port`
+The Neptune database endpoint from which the utility extract the graphdb schema.
+Format: `host:port`
 
 ## Output options
+
 `--output-folder-path <value>, -o <value>`
 <br>
 Changes the default output folder *./output*
 
 `--output-schema-file <value>, -os <value>`
 <br>
-The file name output for the GraphQL schema. If not specified the default is *output.schema.graphql*, or if a pipeline name is set with `--create-update-aws-pipeline-name` the file name is going to be *pipeline-name.schema.graphql*. 
+The file name output for the GraphQL schema. If not specified the default is
+*output.schema.graphql*, or if a pipeline name is set with
+`--create-update-aws-pipeline-name` the file name is going to be
+*pipeline-name.schema.graphql*.
 
 `--output-source-schema-file <value>, -oss <value>`
 <br>
-The file name output for the GraphQL schema with directives. If not specified the default is *output.source.schema.graphql*, or if a pipeline name is set with `--create-update-aws-pipeline-name` the file name is going to be *pipeline-name.source.schema.graphql*
+The file name output for the GraphQL schema with directives. If not specified
+the default is *output.source.schema.graphql*, or if a pipeline name is set with
+`--create-update-aws-pipeline-name` the file name is going to be
+*pipeline-name.source.schema.graphql*
 
 `--output-schema-no-mutations, -onm`
 <br>
@@ -85,18 +120,29 @@ The inferred GraphQL schema will not have mutations, just queries.
 
 `--output-neptune-schema-file <value>, -og <value>`
 <br>
-The file name output for discovered Neptune graphdb schema. If not specified the default is *output.graphdb.json*, or if a pipeline name is set with `--create-update-aws-pipeline-name` the file name is going to be *pipeline-name.graphdb.json*. 
+The file name output for discovered Neptune graphdb schema. If not specified the
+default is *output.graphdb.json*, or if a pipeline name is set with
+`--create-update-aws-pipeline-name` the file name is going to be
+*pipeline-name.graphdb.json*.
 
 `--output-js-resolver-file <value>, -or <value>`
 <br>
-The file name output for a copy of the resolver code. If not specified the default is *output.resolver.graphql.js*, or if a pipeline name is set with `--create-update-aws-pipeline-name` the file name is going to be *pipeline-name.resolver.graphql.js*. This file is also zipped in the code package uploaded to the Lambda function that run the resolver.
+The file name output for a copy of the resolver code. If not specified the
+default is *output.resolver.graphql.js*, or if a pipeline name is set with
+`--create-update-aws-pipeline-name` the file name is going to be
+*pipeline-name.resolver.graphql.js*. This file is also zipped in the code
+package uploaded to the Lambda function that run the resolver.
 
 `--output-resolver-query-sdk, -ors`
 `--output-resolver-query-https, -orh`
 <br>
-The default method for the Lambda uses to query Neptune is the Neptune-data SDK option `--output-resolver-query-sdk`. The SDK is available inly from Neptune version 1.2.1.0.R5. When the utility detect an older Neptune version, it stops suggesting to use the HTTPS Lambda option `--output-resolver-query-https`. If you prefer the HTTPS query method just use `--output-resolver-query-https`.
+The default method for the Lambda uses to query Neptune is the Neptune-data SDK
+option `--output-resolver-query-sdk`. The SDK is available inly from Neptune
+version 1.2.1.0.R5. When the utility detect an older Neptune version, it stops
+suggesting to use the HTTPS Lambda option `--output-resolver-query-https`. If
+you prefer the HTTPS query method just use `--output-resolver-query-https`.
 
-`--output-lambda-resolver-zip-file <value>, -olf <value>` 
+`--output-lambda-resolver-zip-file <value>, -olf <value>`
 <br>
 The file name for the Lambda zip package, the default is *output.lambda.zip*
 
@@ -104,48 +150,66 @@ The file name for the Lambda zip package, the default is *output.lambda.zip*
 <br>
 Does not create the Lambda zip file.
 
-
 ## Create AWS resources
+
 `--create-update-aws-pipeline, -p`
 <br>
-This trigger the creation of the AWS resources for the GraphQL API, including the AppSync GraphQL API and the Lambda that run the resolver.
+This trigger the creation of the AWS resources for the GraphQL API, including
+the AppSync GraphQL API and the Lambda that run the resolver.
 
 `--create-update-aws-pipeline-name <value>, -pn <value>`
 <br>
-This set the name for the pipeline like pipeline-nameAPI for the AppSync API or pipeline-nameFunction for the Lambda function. If not specifies and `--create-update-aws-pipeline` will use the Neptune database name.
+This set the name for the pipeline like pipeline-nameAPI for the AppSync API or
+pipeline-nameFunction for the Lambda function. If not specifies and
+`--create-update-aws-pipeline` will use the Neptune database name.
 
 `--create-update-aws-pipeline-region <value>, -pr <value>`
 <br>
-This set the AWS region in which the pipeline for the GraphQL API is created. If not specified will default to us-east-1, or use the Neptune database region from extracted from the database endpoint.
+This set the AWS region in which the pipeline for the GraphQL API is created. If
+not specified will default to us-east-1, or use the Neptune database region from
+extracted from the database endpoint.
 
 `--create-update-aws-pipeline-neptune-endpoint <value>, -pe <value>`
 <br>
-This set the Neptune database endpoint used by the Lambda function to query the Neptune database. If not set it used the endpoint set with `--input-graphdb-schema-neptune-endpoint`.
+This set the Neptune database endpoint used by the Lambda function to query the
+Neptune database. If not set it used the endpoint set with
+`--input-graphdb-schema-neptune-endpoint`.
 
 `--create-update-aws-pipeline-neptune-IAM, -pi`
 <br>
-Enable IAM authentication in the Lambda function that queries Neptune, the default is using the Neptune VPC.
+Enable IAM authentication in the Lambda function that queries Neptune, the
+default is using the Neptune VPC.
 
 `--remove-aws-pipeline-name <value>, -rp`
 <br>
-It removes the pipeline created with `--create-update-aws-pipeline`. The resources to remove are from a file called *pipeline-name.resources.json*.
+It removes the pipeline created with `--create-update-aws-pipeline`. The
+resources to remove are from a file called *pipeline-name.resources.json*.
 
 ## Create CDK files
+
 `--output-aws-pipeline-cdk, -c`
 <br>
-This trigger the creation of a CDK file to be use to create the AWS resources for the GraphQL API, including the AppSync GraphQL API and the Lambda that run the resolver.
+This trigger the creation of a CDK file to be use to create the AWS resources
+for the GraphQL API, including the AppSync GraphQL API and the Lambda that run
+the resolver.
 
 `--output-aws-pipeline-cdk-neptune-endpoint <value>, -ce <value>`
 <br>
-This set the Neptune database endpoint used by the Lambda function to query the Neptune database. If not set it used the endpoint set with `--input-graphdb-schema-neptune-endpoint`.
+This set the Neptune database endpoint used by the Lambda function to query the
+Neptune database. If not set it used the endpoint set with
+`--input-graphdb-schema-neptune-endpoint`.
 
 `--output-aws-pipeline-cdk-name <value>, -cn <value>`
 <br>
-This set the name for the pipeline like pipeline-nameAPI for the AppSync API or pipeline-nameFunction for the Lambda function. If not specifies and `--create-update-aws-pipeline` will use the Neptune database name.
+This set the name for the pipeline like pipeline-nameAPI for the AppSync API or
+pipeline-nameFunction for the Lambda function. If not specifies and
+`--create-update-aws-pipeline` will use the Neptune database name.
 
 `--output-aws-pipeline-cdk-region <value>, -cr <value>`
 <br>
-This set the AWS region in which the pipeline for the GraphQL API is created. If not specified will default to us-east-1, or use the Neptune database region from extracted from the database endpoint.
+This set the AWS region in which the pipeline for the GraphQL API is created. If
+not specified will default to us-east-1, or use the Neptune database region from
+extracted from the database endpoint.
 
 `--output-aws-pipeline-cdk-file <value>, -cf <name>`
 <br>
@@ -153,15 +217,18 @@ This set the CDK file name. If not set the default is *pipeline-name-cdk.js*.
 
 `--output-aws-pipeline-cdk-neptune-IAM, -ci`
 <br>
-Enable IAM authentication in the Lambda function that queries Neptune, the default is using the Neptune VPC.
+Enable IAM authentication in the Lambda function that queries Neptune, the
+default is using the Neptune VPC.
 
 ## Create Apollo Server files
 
-`--create-update-apollo-server, -asvr` 
+`--create-update-apollo-server, -asvr`
 <br>
-Triggers the creation of a zip file of artifacts for Apollo Server instead of App Sync
+Triggers the creation of a zip file of artifacts for Apollo Server instead of
+App Sync
 
 `--create-update-apollo-server-subgraph, -asub`
 <br>
-Triggers the creation of a zip file of artifacts for Apollo Server subgraph instead of App Sync
+Triggers the creation of a zip file of artifacts for Apollo Server subgraph
+instead of App Sync
 

--- a/doc/resources.md
+++ b/doc/resources.md
@@ -13,31 +13,40 @@ Steps:
 9. Attach to each GraphQL Schema operation the resolver function
 10. Test using the AppSync Queries
 
-The resources configuration change to access a Neptune Database in a VPC or with IAM enabled. The following instruction are marked (VPC) or (IAM) to differentiate it. 
+The resources configuration change to access a Neptune Database in a VPC or with
+IAM enabled. The following instruction are marked (VPC) or (IAM) to
+differentiate it.
 
 ## 1 . Run Neptune Graph Utility
 
-Run the Neptune GraphQL Utility to generate the resolver code for the Lambda, and the GraphQL schema for AppSync.
+Run the Neptune GraphQL Utility to generate the resolver code for the Lambda,
+and the GraphQL schema for AppSync.
 
-Starting from an existing Neptune database.
-Run the command below passing your Neptune cluster endpoint and port.
-You can run the utility from a personal computer where you setup an SSH tunnel to an EC2 instance in the same VPC of your Neptune DB (VPC), or run the utility from an EC2 instance in the same Neptune VPC (if VPC), or with a Neptune IAM role (if IAM).
+Starting from an existing Neptune database. Run the command below passing your
+Neptune cluster endpoint and port. You can run the utility from a personal
+computer where you setup an SSH tunnel to an EC2 instance in the same VPC of
+your Neptune DB (VPC), or run the utility from an EC2 instance in the same
+Neptune VPC (if VPC), or with a Neptune IAM role (if IAM).
 
-`neptune-for-graphql --input-graphdb-schema-neptune-endpoint` <*your-database-endpoint:port*>
+`neptune-for-graphql --input-graphdb-schema-neptune-endpoint` <
+*your-database-endpoint:port*>
 
-The default output location for the GraphQL schema file to use in AppSync schema is: ./output/output.schema.graphql
+The default output location for the GraphQL schema file to use in AppSync schema
+is: ./output/output.schema.graphql
 <br>
-The default output location of Lambda resolver file is: ./output/output.resolver.graphql.js
+The default output location of Lambda resolver file is:
+./output/output.resolver.graphql.js
 <br>
 The default output location of the Lambda zip: is: ./output/output.lambda.zip
 
-
 ## 3. Create the Lambda
 
-Create the AWS Lambda that will receive the AppSync query requests, resolve it into a Neptune graph query, query the Neptune database and return the result to AppSync.
-To create the Lambda you have two options:
+Create the AWS Lambda that will receive the AppSync query requests, resolve it
+into a Neptune graph query, query the Neptune database and return the result to
+AppSync. To create the Lambda you have two options:
 
 ### Create Lambda IAM execution role
+
 1. Create the Lambda execution role for the Lambda
     1. Create a new IAM Role for the Lambda function
     2. Attach the policy `AWSLambdaBasicExecutionRole`
@@ -55,13 +64,18 @@ To create the Lambda you have two options:
     ```
 
 
-1. go to the Neptune documentation here https://docs.aws.amazon.com/neptune/latest/userguide/get-started-cfn-lambda.html, can run the CloudFormation template that creates the Lambda. Lambda runtime is Node.js 18x.
-     (NOTE: the Neptune CloudFormation to create the Lambda is outdated, the nodejs12.x is no longer supported by Lambda)
+1. go to the Neptune documentation
+   here https://docs.aws.amazon.com/neptune/latest/userguide/get-started-cfn-lambda.html,
+   can run the CloudFormation template that creates the Lambda. Lambda runtime
+   is Node.js 18x.
+   (NOTE: the Neptune CloudFormation to create the Lambda is outdated, the
+   nodejs12.x is no longer supported by Lambda)
 2. go to Lambda console
     1. Create a new function, author from scratch
     2. Name the function ( you will point AppSync to this fucntion)
     3. Runtime: Node.js 18.x
-    4. Open Advance settings, enable VPC, and select your Neptune DB VPC, Subnets and Security Group.
+    4. Open Advance settings, enable VPC, and select your Neptune DB VPC,
+       Subnets and Security Group.
     5. Create the function
     6. Open the Lambda Environment Variables and add:
         1. NEPTUNE_HOST= your database endpoint
@@ -106,19 +120,20 @@ Select “Functions” from the AppSync menu of your new API
 import { util } from '@aws-appsync/utils';
 
 export function request(ctx) {
-  const {source, args} = ctx
-  return {
-    operation: 'Invoke',
-    payload: {
-        field: ctx.info.fieldName, 
-        arguments: args,
-        selectionSetGraphQL: ctx.info.selectionSetGraphQL,
-        source },
-  };
+    const {source, args} = ctx
+    return {
+        operation: 'Invoke',
+        payload: {
+            field: ctx.info.fieldName,
+            arguments: args,
+            selectionSetGraphQL: ctx.info.selectionSetGraphQL,
+            source
+        },
+    };
 }
 
 export function response(ctx) {
-  return ctx.result;
+    return ctx.result;
 }
 ```
 
@@ -126,17 +141,20 @@ export function response(ctx) {
 
 Select “Schema” from the AppSync menu of your new API
 
-1. Replace the AppSync Schema with the content of the Neptune GraphQL Utility output in the file with default named  ./output/output.schema.graphql.
+1. Replace the AppSync Schema with the content of the Neptune GraphQL Utility
+   output in the file with default named ./output/output.schema.graphql.
 2. Save Schema
 
 ## 9. Attach to each GraphQL Schema operation the resolver function
 
 1. Scroll through the “Resolvers” list to Query
     1. for each field in the Query section select “Attach”
-    2. In the “Create pipeline resolver” 
+    2. In the “Create pipeline resolver”
         1. “Add function“ selecting the AppSync function you just created
         2. Select “Create”
-2. Go back to the AppSync Schema, and repeat the step above for each field in the Resolvers Query and Mutation section. Note: you might have to repeat it 10-30 times :(
+2. Go back to the AppSync Schema, and repeat the step above for each field in
+   the Resolvers Query and Mutation section. Note: you might have to repeat it
+   10-30 times :(
 3. Congratulation you have now a GraphQL API for your Neptune database
 
 ## 10. Test using the AppSync Queries

--- a/doc/resources.md
+++ b/doc/resources.md
@@ -28,8 +28,9 @@ computer where you setup an SSH tunnel to an EC2 instance in the same VPC of
 your Neptune DB (VPC), or run the utility from an EC2 instance in the same
 Neptune VPC (if VPC), or with a Neptune IAM role (if IAM).
 
-`neptune-for-graphql --input-graphdb-schema-neptune-endpoint` <
-*your-database-endpoint:port*>
+```
+neptune-for-graphql --input-graphdb-schema-neptune-endpoint <your-database-endpoint:port>
+````
 
 The default output location for the GraphQL schema file to use in AppSync schema
 is: ./output/output.schema.graphql

--- a/doc/routesExample.md
+++ b/doc/routesExample.md
@@ -1,29 +1,40 @@
 # Air Routes Example: Starting from a Neptune database with data
-Amazon Neptune uses the Air Routes dataset in several Notebook tutorials. If you don't have a Neptune database with the Air Routes data you can create a new database, and follow one of the Notebook tutorials to seed it with the Air Routes data.
 
-Then, you can run the Neptune GraphQL Utility command below to create an AppSync GraphQL API.
+Amazon Neptune uses the Air Routes dataset in several Notebook tutorials. If you
+don't have a Neptune database with the Air Routes data you can create a new
+database, and follow one of the Notebook tutorials to seed it with the Air
+Routes data.
 
-`neptune-for-graphql --input-graphdb-schema-neptune-endpoint `<*your-neptune-database-endpoint:port*>` --create-update-aws-pipeline --create-update-aws-pipeline-name AriRoutesExample`
+Then, you can run the Neptune GraphQL Utility command below to create an AppSync
+GraphQL API.
 
-The command will log the graph database schema it finds, the files it creates, and the AWS resources it creates or modifies during execution. If you ever want to run the command while logging only errors, use the `--quiet` CLI option.
+`neptune-for-graphql --input-graphdb-schema-neptune-endpoint `<
+*your-neptune-database-endpoint:port*>
+` --create-update-aws-pipeline --create-update-aws-pipeline-name AriRoutesExample`
+
+The command will log the graph database schema it finds, the files it creates,
+and the AWS resources it creates or modifies during execution. If you ever want
+to run the command while logging only errors, use the `--quiet` CLI option.
 
 ![Running](https://github.com/aws/amazon-neptune-for-graphql/blob/main/doc/images/utilityRunning.gif)
 
-The utility creates these files naming them based on the `--create-update-aws-pipeline-name` option, in our case `AirRoutesExample`:
+The utility creates these files naming them based on the
+`--create-update-aws-pipeline-name` option, in our case `AirRoutesExample`:
 
-| *file*  | *description*        |
-|---------|----------------------|
-| AirRoutes.zip |the Lambda code zip file|
-| AirRoutesExample.source.schema.graphql | the GraphQL schema with directives |
-| AirRoutesExample.schema.graphql | the GraphQL schema|
-| AirRoutesExample.resolver.graphql.js | the JavaScript resolver |
-| AirRoutesExample.neptune.schema.json | the graph schema it discovered |
-| AirRoutesExample-resources.json | the list of AWS Resources it created |
+| *file*                                 | *description*                        |
+|----------------------------------------|--------------------------------------|
+| AirRoutes.zip                          | the Lambda code zip file             |
+| AirRoutesExample.source.schema.graphql | the GraphQL schema with directives   |
+| AirRoutesExample.schema.graphql        | the GraphQL schema                   |
+| AirRoutesExample.resolver.graphql.js   | the JavaScript resolver              |
+| AirRoutesExample.neptune.schema.json   | the graph schema it discovered       |
+| AirRoutesExample-resources.json        | the list of AWS Resources it created |
 
 ## The graph schema it discovered
-Below is the content of the file, AirRoutesExample.neptune.schema.json.
-The files contain nodes, edges, properties, and edges cardinality. 
-The utility then uses this data to inference the GraphQL schema.
+
+Below is the content of the file, AirRoutesExample.neptune.schema.json. The
+files contain nodes, edges, properties, and edges cardinality. The utility then
+uses this data to inference the GraphQL schema.
 
 ```json
 {
@@ -31,73 +42,186 @@ The utility then uses this data to inference the GraphQL schema.
     {
       "label": "continent",
       "properties": [
-        { "name": "code", "type": "String" },
-        { "name": "type", "type": "String" },
-        { "name": "desc", "type": "String" }]},
+        {
+          "name": "code",
+          "type": "String"
+        },
+        {
+          "name": "type",
+          "type": "String"
+        },
+        {
+          "name": "desc",
+          "type": "String"
+        }
+      ]
+    },
     {
       "label": "country",
       "properties": [
-        { "name": "code", "type": "String" },
-        { "name": "type", "type": "String" },
-        { "name": "desc", "type": "String" }]},
+        {
+          "name": "code",
+          "type": "String"
+        },
+        {
+          "name": "type",
+          "type": "String"
+        },
+        {
+          "name": "desc",
+          "type": "String"
+        }
+      ]
+    },
     {
       "label": "version",
       "properties": [
-        { "name": "date", "type": "String" },
-        { "name": "code", "type": "String" },
-        { "name": "author", "type": "String" },
-        { "name": "type", "type": "String" },
-        { "name": "desc", "type": "String" }]},
+        {
+          "name": "date",
+          "type": "String"
+        },
+        {
+          "name": "code",
+          "type": "String"
+        },
+        {
+          "name": "author",
+          "type": "String"
+        },
+        {
+          "name": "type",
+          "type": "String"
+        },
+        {
+          "name": "desc",
+          "type": "String"
+        }
+      ]
+    },
     {
       "label": "airport",
-      "properties": [ 
-        { "name": "country", "type": "String" },
-        { "name": "longest", "type": "Int" },
-        { "name": "code", "type": "String" },
-        { "name": "city", "type": "String" },
-        { "name": "elev", "type": "Int" },
-        { "name": "icao", "type": "String" },
-        { "name": "lon", "type": "Float" },
-        { "name": "runways", "type": "Int" },
-        { "name": "region", "type": "String" },
-        { "name": "type", "type": "String" },
-        { "name": "lat", "type": "Float" },
-        { "name": "desc", "type": "String" }]}
+      "properties": [
+        {
+          "name": "country",
+          "type": "String"
+        },
+        {
+          "name": "longest",
+          "type": "Int"
+        },
+        {
+          "name": "code",
+          "type": "String"
+        },
+        {
+          "name": "city",
+          "type": "String"
+        },
+        {
+          "name": "elev",
+          "type": "Int"
+        },
+        {
+          "name": "icao",
+          "type": "String"
+        },
+        {
+          "name": "lon",
+          "type": "Float"
+        },
+        {
+          "name": "runways",
+          "type": "Int"
+        },
+        {
+          "name": "region",
+          "type": "String"
+        },
+        {
+          "name": "type",
+          "type": "String"
+        },
+        {
+          "name": "lat",
+          "type": "Float"
+        },
+        {
+          "name": "desc",
+          "type": "String"
+        }
+      ]
+    }
   ],
   "edgeStructures": [
     {
       "label": "contains",
       "properties": [],
       "directions": [
-        { "from": "continent", "to": "airport", "relationship": "ONE-MANY" },
-        { "from": "country", "to": "airport", "relationship": "ONE-MANY" }
+        {
+          "from": "continent",
+          "to": "airport",
+          "relationship": "ONE-MANY"
+        },
+        {
+          "from": "country",
+          "to": "airport",
+          "relationship": "ONE-MANY"
+        }
       ]
     },
     {
       "label": "route",
       "properties": [
-        { "name": "dist", "type": "Int" }        
+        {
+          "name": "dist",
+          "type": "Int"
+        }
       ],
       "directions": [
-        { "from": "airport", "to": "airport", "relationship": "MANY-MANY" }
-      ]}
+        {
+          "from": "airport",
+          "to": "airport",
+          "relationship": "MANY-MANY"
+        }
+      ]
+    }
   ]
 }
 ```
 
 ## The GraphQL schema with directives
+
 Below is the GraphQL schema with directives, inferred by the utility.
 
-- The Air Routes nodes' labels are lower case, and GraphQL type names are typically in Pascal case, so the utility added the *@alias* directive to map the names between GraphQL and the Neptune Database.
-- Because the node labelled *continent* is connected to the *airport* using the edge *contains* and the cardinality is one to many, you can see the directive *@relationship* in the GraphQL type *Continent* and new field names *airportContainssOut* returning an array of *Airport*. The type Airport has an opposite field called *continentContainsIn* as single *Continent*. This tuple declaration will enable you to query the *Continent* from the *Airport* and the list of *Airport*/s from a *Continent*.
-- The edge *route* that connects an *airport* to another *airport* has a property called *dist*. You can find it in the type *Route*, and is added to the type *Airport* as well. We will later see how to query it.
-- For each type the utility also added inputs, which are used as helpers for queries and mutations.
-- For each node label the utility added two queries. One to retrieve a single node/type using an id or any of the type fields listed in the input, and the second to retrieve multiple values, again filtered using the input of that node/type.
-- For each node three mutations: create, update and delete. Selecting the node to delete using an id or the input for that node/type.
-- For edges two mutations: connect and delete. They take as input the ids of the from and to node, and in case the edge type has properties the correspondent input.
+- The Air Routes nodes' labels are lower case, and GraphQL type names are
+  typically in Pascal case, so the utility added the *@alias* directive to map
+  the names between GraphQL and the Neptune Database.
+- Because the node labelled *continent* is connected to the *airport* using the
+  edge *contains* and the cardinality is one to many, you can see the directive
+  *@relationship* in the GraphQL type *Continent* and new field names
+  *airportContainssOut* returning an array of *Airport*. The type Airport has an
+  opposite field called *continentContainsIn* as single *Continent*. This tuple
+  declaration will enable you to query the *Continent* from the *Airport* and
+  the list of *Airport*/s from a *Continent*.
+- The edge *route* that connects an *airport* to another *airport* has a
+  property called *dist*. You can find it in the type *Route*, and is added to
+  the type *Airport* as well. We will later see how to query it.
+- For each type the utility also added inputs, which are used as helpers for
+  queries and mutations.
+- For each node label the utility added two queries. One to retrieve a single
+  node/type using an id or any of the type fields listed in the input, and the
+  second to retrieve multiple values, again filtered using the input of that
+  node/type.
+- For each node three mutations: create, update and delete. Selecting the node
+  to delete using an id or the input for that node/type.
+- For edges two mutations: connect and delete. They take as input the ids of the
+  from and to node, and in case the edge type has properties the correspondent
+  input.
 
 > [!TIP]
-> The queries and mutations you see below are recognized by the resolver based on the name pattern. If you need to customize it, first look at the documentation section: *Customize the GraphQL schema with directives*.
+> The queries and mutations you see below are recognized by the resolver based
+> on the name pattern. If you need to customize it, first look at the
+> documentation section: *Customize the GraphQL schema with directives*.
 
 <details>
 
@@ -376,15 +500,24 @@ schema {
     mutation: Mutation
 }
 ```
+
 </details>
 
 ## Let's use our new GraphQL API from AppSync console
-Below is a snapshot of the AppSync Queries console used to test our new GraphQL API named *AirRoutesExampleAPI*.
-In the middle window, the Explorer shows you the queries and mutations. You can then pick a query, the input parameters and the return fields. 
 
-In this case it formed a GraphQL query that is looking for one *Airport*, with *code* equal *SEA*, and return the *city*, the outbound flights *airportsOut*, and for each destination the *city* and the *route* distance, *dist*. As mentioned earlier, in the graph database the nodes *airport* are connected with the edge type *route*, and *dist* is a property of the edge.
+Below is a snapshot of the AppSync Queries console used to test our new GraphQL
+API named *AirRoutesExampleAPI*. In the middle window, the Explorer shows you
+the queries and mutations. You can then pick a query, the input parameters and
+the return fields.
 
-You can then follow the AppSync documentation on how to call the GraphQL API from your application, enable caching and other AppSync API features.
+In this case it formed a GraphQL query that is looking for one *Airport*, with
+*code* equal *SEA*, and return the *city*, the outbound flights *airportsOut*,
+and for each destination the *city* and the *route* distance, *dist*. As
+mentioned earlier, in the graph database the nodes *airport* are connected with
+the edge type *route*, and *dist* is a property of the edge.
+
+You can then follow the AppSync documentation on how to call the GraphQL API
+from your application, enable caching and other AppSync API features.
 
 ![AppSync Queries UI](https://github.com/aws/amazon-neptune-for-graphql/blob/main/doc/images/AppSyncQuery.png)
 

--- a/doc/routesExample.md
+++ b/doc/routesExample.md
@@ -8,9 +8,12 @@ Routes data.
 Then, you can run the Neptune GraphQL Utility command below to create an AppSync
 GraphQL API.
 
-`neptune-for-graphql --input-graphdb-schema-neptune-endpoint `<
-*your-neptune-database-endpoint:port*>
-` --create-update-aws-pipeline --create-update-aws-pipeline-name AriRoutesExample`
+```
+neptune-for-graphql \
+  --input-graphdb-schema-neptune-endpoint <your-neptune-database-endpoint:port> \
+  --create-update-aws-pipeline \
+  --create-update-aws-pipeline-name AriRoutesExample
+```
 
 The command will log the graph database schema it finds, the files it creates,
 and the AWS resources it creates or modifies during execution. If you ever want

--- a/doc/todoExample.md
+++ b/doc/todoExample.md
@@ -1,10 +1,18 @@
 # TODO Example: Starting from a GraphQL schema with no directives
-You can start from a GraphQL schema without directives and an empty Neptune database. The utility will inference directives, input, queries and mutations, and create the the GraphQL API. Then, you can use GraphQL to create, mutate and query the data stored in a Neptune database without the need to know how to use a graph query language. 
 
-In this example we start from a TODO GraphQL schema, that you can find in the [samples](https://github.com/aws/amazon-neptune-for-graphql/blob/main/samples/todo.schema.graphql). Includes two types: *Todo* and *Comment*. The *Todo* has a field *comments* as list of *Comment* type.
+You can start from a GraphQL schema without directives and an empty Neptune
+database. The utility will inference directives, input, queries and mutations,
+and create the the GraphQL API. Then, you can use GraphQL to create, mutate and
+query the data stored in a Neptune database without the need to know how to use
+a graph query language.
+
+In this example we start from a TODO GraphQL schema, that you can find in
+the [samples](https://github.com/aws/amazon-neptune-for-graphql/blob/main/samples/todo.schema.graphql).
+Includes two types: *Todo* and *Comment*. The *Todo* has a field *comments* as
+list of *Comment* type.
 
 ```graphql
-type Todo {    
+type Todo {
     name: String
     description: String
     priority: Int
@@ -12,27 +20,45 @@ type Todo {
     comments: [Comment]
 }
 
-type Comment {        
+type Comment {
     content: String
 }
 ```
 
-Let's now run this schema through the utility and create the GraphQL API in AWS AppSync. *(Note: pls provide a reachable, empty Neptune database endpoint)*
+Let's now run this schema through the utility and create the GraphQL API in AWS
+AppSync. *(Note: pls provide a reachable, empty Neptune database endpoint)*
 
-`neptune-for-graphql --input-schema-file ./samples/todo.schema.graphql --create-update-aws-pipeline --create-update-aws-pipeline-name TodoExample --create-update-aws-pipeline-neptune-endpoint` <*your-neptune-database-endpoint:port*> ` --output-resolver-query-https`
+`neptune-for-graphql --input-schema-file ./samples/todo.schema.graphql --create-update-aws-pipeline --create-update-aws-pipeline-name TodoExample --create-update-aws-pipeline-neptune-endpoint` <
+*your-neptune-database-endpoint:port*> ` --output-resolver-query-https`
 
-The utility created a new file in the *output* folder called *TodoExample.source.graphql*, and the GraphQL API in AppSync. As you can see below, the utility inferenced:
+The utility created a new file in the *output* folder called
+*TodoExample.source.graphql*, and the GraphQL API in AppSync. As you can see
+below, the utility inferenced:
 
-- In the type *Todo* it added *@relationship* for a new type *CommentEdge*. This is instructing the resolver to connect *Todo* to *Comment* using a graph database edge called *CommentEdge*.
+- In the type *Todo* it added *@relationship* for a new type *CommentEdge*. This
+  is instructing the resolver to connect *Todo* to *Comment* using a graph
+  database edge called *CommentEdge*.
 - A new input called *TodoInput* was added to help with queries.
-- Two other new input types called *TodoCreateInput* and *TodoUpdateInput* were added to help with mutations.
-- The new input *TodoSort* was added to allow specifying sort order for the getNodeTodos query.
-- For each type (*Todo*, *Comment*) the utility added two queries. One to retrieve a single type using an id or any of the type fields listed in the input, and the second to retrive multiple values, filtered using the input of that type.
-- For each type three mutations: create, update and delete. Selecting the type to delete using an id or the input for that type. These mutation affect the data stored in The Neptune database.
-- For connections two mutations: connect and delete. They take as input the ids of the from and to. The ids are of used by Neptune, and the connection are edges in the graph database as mention earlier.
+- Two other new input types called *TodoCreateInput* and *TodoUpdateInput* were
+  added to help with mutations.
+- The new input *TodoSort* was added to allow specifying sort order for the
+  getNodeTodos query.
+- For each type (*Todo*, *Comment*) the utility added two queries. One to
+  retrieve a single type using an id or any of the type fields listed in the
+  input, and the second to retrive multiple values, filtered using the input of
+  that type.
+- For each type three mutations: create, update and delete. Selecting the type
+  to delete using an id or the input for that type. These mutation affect the
+  data stored in The Neptune database.
+- For connections two mutations: connect and delete. They take as input the ids
+  of the from and to. The ids are of used by Neptune, and the connection are
+  edges in the graph database as mention earlier.
 
 > [!TIP]
-> The queries and mutations you see below are recognized by the resolver based on the name pattern. If you need to customize it, first look at the documentation section: [Customize the GraphQL schema with directives](https://github.com/aws/amazon-neptune-for-graphql/blob/main/README.md/#customize-the-graphql-schema-with-directives).
+> The queries and mutations you see below are recognized by the resolver based
+> on the name pattern. If you need to customize it, first look at the
+> documentation
+> section: [Customize the GraphQL schema with directives](https://github.com/aws/amazon-neptune-for-graphql/blob/main/README.md/#customize-the-graphql-schema-with-directives).
 
 <details>
 
@@ -146,18 +172,22 @@ type Mutation {
 }
 
 schema {
-  query: Query
-  mutation: Mutation
+    query: Query
+    mutation: Mutation
 }
 ```
+
 </details>
 
-Now we are ready to create and query our data. 
+Now we are ready to create and query our data.
 
-Below is a snapshot of the AppSync Queries console used to test our new GraphQL API named *TodoExampleAPI*.
-In the middle window, the Explorer shows you the queries and mutations. You can then pick a query, the input parameters and the return fields. 
+Below is a snapshot of the AppSync Queries console used to test our new GraphQL
+API named *TodoExampleAPI*. In the middle window, the Explorer shows you the
+queries and mutations. You can then pick a query, the input parameters and the
+return fields.
 
-The picture shows the creation of a node type *Todo*, using the *createNodeTodo* mutation.
+The picture shows the creation of a node type *Todo*, using the *createNodeTodo*
+mutation.
 
 ![Create](https://github.com/aws/amazon-neptune-for-graphql/blob/main/doc/images/todoCreate.png)
 
@@ -165,10 +195,16 @@ Here, we are querying all the Todos with *getNodeTodos* query.
 
 ![Query](https://github.com/aws/amazon-neptune-for-graphql/blob/main/doc/images/todoGetTodos.png)
 
-After having created one *Comment* using *createNodeComment*, we use the Ids to connect them using the mutation *connectNodeTodoToNodeCommentEdgeCommentEdge*
+After having created one *Comment* using *createNodeComment*, we use the Ids to
+connect them using the mutation *connectNodeTodoToNodeCommentEdgeCommentEdge*
 
 Here is a nested query being used to retrieve Todos and their attached comments.
 
 ![Query](https://github.com/aws/amazon-neptune-for-graphql/blob/main/doc/images/todoNestedQuery.png)
 
-The solution illustrated in this example is fully functional and can be used as is. If you wish, you can make changes to the *TodoExample.source.graphql* file by following the instructions in the section: *Customize the GraphQL schema with directives*. The edited schema can then be used by running the utility again with the command, `--input-schema-file`. The utility will then modify the GraphQL API.
+The solution illustrated in this example is fully functional and can be used as
+is. If you wish, you can make changes to the *TodoExample.source.graphql* file
+by following the instructions in the section: *Customize the GraphQL schema with
+directives*. The edited schema can then be used by running the utility again
+with the command, `--input-schema-file`. The utility will then modify the
+GraphQL API.

--- a/doc/todoExample.md
+++ b/doc/todoExample.md
@@ -28,8 +28,14 @@ type Comment {
 Let's now run this schema through the utility and create the GraphQL API in AWS
 AppSync. *(Note: pls provide a reachable, empty Neptune database endpoint)*
 
-`neptune-for-graphql --input-schema-file ./samples/todo.schema.graphql --create-update-aws-pipeline --create-update-aws-pipeline-name TodoExample --create-update-aws-pipeline-neptune-endpoint` <
-*your-neptune-database-endpoint:port*> ` --output-resolver-query-https`
+```
+neptune-for-graphql \
+  --input-schema-file ./samples/todo.schema.graphql \
+  --create-update-aws-pipeline \
+  --create-update-aws-pipeline-name TodoExample \
+  --create-update-aws-pipeline-neptune-endpoint <your-neptune-database-endpoint:port> \
+  --output-resolver-query-https
+```
 
 The utility created a new file in the *output* folder called
 *TodoExample.source.graphql*, and the GraphQL API in AppSync. As you can see


### PR DESCRIPTION
Reformatted line wrapping of documentation to 80 characters. Also updated changelog to move features to the top and bug fixes to the bottom and used code fences where applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
