### PR TITLE
Include edge in WITH statement before ORDER BY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,3 +104,6 @@ permissions and limitations under the License.
 * Changed resolver to use `graphql` `parse` instead of `graphql-tag` `gql` to
   avoid stale values due to
   caching ([#109](https://github.com/aws/amazon-neptune-for-graphql/pull/109))
+* Fixed nested edge subqueries with sorting to pass the edge variable so that it
+  can be referenced further in the
+  query ([#114](https://github.com/aws/amazon-neptune-for-graphql/pull/114))

--- a/src/test/templates/JSResolverOCHTTPS.test.js
+++ b/src/test/templates/JSResolverOCHTTPS.test.js
@@ -236,7 +236,7 @@ test('should resolve app sync event with nested sort arguments', () => {
     expect(result).toEqual({
         query: 'MATCH (getNodeAirports_Airport:`airport`) WITH getNodeAirports_Airport ORDER BY getNodeAirports_Airport.desc ASC, getNodeAirports_Airport.code DESC\n' +
             'OPTIONAL MATCH (getNodeAirports_Airport)<-[getNodeAirports_Airport_airportRoutesIn_route:route]-(getNodeAirports_Airport_airportRoutesIn:`airport`) ' +
-            'WITH getNodeAirports_Airport, getNodeAirports_Airport_airportRoutesIn ORDER BY getNodeAirports_Airport_airportRoutesIn.country ASC, getNodeAirports_Airport_airportRoutesIn.city DESC\n' +
+            'WITH getNodeAirports_Airport, getNodeAirports_Airport_airportRoutesIn, getNodeAirports_Airport_airportRoutesIn_route ORDER BY getNodeAirports_Airport_airportRoutesIn.country ASC, getNodeAirports_Airport_airportRoutesIn.city DESC\n' +
             'WITH getNodeAirports_Airport, CASE WHEN getNodeAirports_Airport_airportRoutesIn IS NULL THEN [] ELSE COLLECT({country: getNodeAirports_Airport_airportRoutesIn.`country`, city: getNodeAirports_Airport_airportRoutesIn.`city`}) END AS getNodeAirports_Airport_airportRoutesIn_collect\n' +
             'RETURN collect({desc: getNodeAirports_Airport.`desc`, code: getNodeAirports_Airport.`code`, airportRoutesIn: getNodeAirports_Airport_airportRoutesIn_collect})',
         parameters: {},
@@ -269,9 +269,44 @@ test('should resolve app sync event with nested sort arguments and variables', (
 
     expect(result).toEqual({
         query: 'MATCH (getNodeAirports_Airport:`airport`) WITH getNodeAirports_Airport ORDER BY getNodeAirports_Airport.country ASC, getNodeAirports_Airport.city ASC LIMIT 1\n' +
-            'OPTIONAL MATCH (getNodeAirports_Airport)<-[getNodeAirports_Airport_airportRoutesIn_route:route]-(getNodeAirports_Airport_airportRoutesIn:`airport`) WITH getNodeAirports_Airport, getNodeAirports_Airport_airportRoutesIn ORDER BY getNodeAirports_Airport_airportRoutesIn.country DESC, getNodeAirports_Airport_airportRoutesIn.code DESC\n' +
+            'OPTIONAL MATCH (getNodeAirports_Airport)<-[getNodeAirports_Airport_airportRoutesIn_route:route]-(getNodeAirports_Airport_airportRoutesIn:`airport`) ' +
+            'WITH getNodeAirports_Airport, getNodeAirports_Airport_airportRoutesIn, getNodeAirports_Airport_airportRoutesIn_route ORDER BY getNodeAirports_Airport_airportRoutesIn.country DESC, getNodeAirports_Airport_airportRoutesIn.code DESC\n' +
             'WITH getNodeAirports_Airport, CASE WHEN getNodeAirports_Airport_airportRoutesIn IS NULL THEN [] ELSE COLLECT({_id:ID(getNodeAirports_Airport_airportRoutesIn), city: getNodeAirports_Airport_airportRoutesIn.`city`, code: getNodeAirports_Airport_airportRoutesIn.`code`, country: getNodeAirports_Airport_airportRoutesIn.`country`})[..1] END AS getNodeAirports_Airport_airportRoutesIn_collect\n' +
             'RETURN collect({_id:ID(getNodeAirports_Airport), city: getNodeAirports_Airport.`city`, code: getNodeAirports_Airport.`code`, country: getNodeAirports_Airport.`country`, airportRoutesIn: getNodeAirports_Airport_airportRoutesIn_collect})[..1]',
+        parameters: {},
+        language: 'opencypher',
+        refactorOutput: null
+    });
+});
+
+test('should resolve app sync event with nested sort and nested selection', () => {
+    const result = resolveGraphDBQueryFromAppSyncEvent({
+        field: 'getNodeAirports',
+        arguments: {},
+        variables: {
+            nestedSort: [ { country: 'DESC'} ]
+        },
+        selectionSetGraphQL: '{\n' +
+            '  code\n' +
+            '  airportRoutesIn(sort: $nestedSort) {\n' +
+            '    code\n' +
+            '    route {\n' +
+            '       dist\n' +
+            '    }\n' +
+            '  }\n' +
+            '}'
+    });
+
+    expect(result).toEqual({
+        query: 'MATCH (getNodeAirports_Airport:`airport`)\n' +
+            'OPTIONAL MATCH (getNodeAirports_Airport)<-[getNodeAirports_Airport_airportRoutesIn_route:route]-(getNodeAirports_Airport_airportRoutesIn:`airport`) ' +
+            'WITH getNodeAirports_Airport, getNodeAirports_Airport_airportRoutesIn, getNodeAirports_Airport_airportRoutesIn_route ' +
+            'ORDER BY getNodeAirports_Airport_airportRoutesIn.country DESC\n' +
+            'WITH getNodeAirports_Airport, getNodeAirports_Airport_airportRoutesIn, {dist: getNodeAirports_Airport_airportRoutesIn_route.`dist`} AS getNodeAirports_Airport_airportRoutesIn_route_one\n' +
+            'WITH getNodeAirports_Airport, CASE WHEN getNodeAirports_Airport_airportRoutesIn IS NULL THEN [] ' +
+            'ELSE COLLECT({code: getNodeAirports_Airport_airportRoutesIn.`code`, route: getNodeAirports_Airport_airportRoutesIn_route_one}) ' +
+            'END AS getNodeAirports_Airport_airportRoutesIn_collect\n' +
+            'RETURN collect({code: getNodeAirports_Airport.`code`, airportRoutesIn: getNodeAirports_Airport_airportRoutesIn_collect})',
         parameters: {},
         language: 'opencypher',
         refactorOutput: null
@@ -295,7 +330,8 @@ test('should resolve AppSync event with ID field as both top-level and nested so
 
     expect(result).toEqual({
         query: 'MATCH (getNodeAirports_Airport:`airport`) WITH getNodeAirports_Airport ORDER BY ID(getNodeAirports_Airport) ASC\n' +
-            'OPTIONAL MATCH (getNodeAirports_Airport)<-[getNodeAirports_Airport_airportRoutesIn_route:route]-(getNodeAirports_Airport_airportRoutesIn:`airport`) WITH getNodeAirports_Airport, getNodeAirports_Airport_airportRoutesIn ORDER BY ID(getNodeAirports_Airport_airportRoutesIn) DESC\n' +
+            'OPTIONAL MATCH (getNodeAirports_Airport)<-[getNodeAirports_Airport_airportRoutesIn_route:route]-(getNodeAirports_Airport_airportRoutesIn:`airport`) ' +
+            'WITH getNodeAirports_Airport, getNodeAirports_Airport_airportRoutesIn, getNodeAirports_Airport_airportRoutesIn_route ORDER BY ID(getNodeAirports_Airport_airportRoutesIn) DESC\n' +
             'WITH getNodeAirports_Airport, CASE WHEN getNodeAirports_Airport_airportRoutesIn IS NULL THEN [] ELSE COLLECT({_id:ID(getNodeAirports_Airport_airportRoutesIn)}) END AS getNodeAirports_Airport_airportRoutesIn_collect\n' +
             'RETURN collect({_id:ID(getNodeAirports_Airport), airportRoutesIn: getNodeAirports_Airport_airportRoutesIn_collect})',
         parameters: {},

--- a/templates/JSResolverOCHTTPS.js
+++ b/templates/JSResolverOCHTTPS.js
@@ -700,7 +700,9 @@ function createTypeFieldStatementAndRecurse({selection, fieldSchemaInfo, lastNam
     const argsAndWhereClauses = extractQueryArgsAndWhereClauses(selection.arguments, fieldSchemaInfo);
     const queryArgs = argsAndWhereClauses.queryArguments?.length > 0 ? `{${argsAndWhereClauses.queryArguments.join(',')}}` : '';
     const whereClause = argsAndWhereClauses.whereClauses?.length > 0 ? ` WHERE ${argsAndWhereClauses.whereClauses.join(' AND ')}` : '';
-    const orderByClause = fieldSchemaInfo.argOrderBy?.length ? ` WITH ${lastNamePath}, ${schemaTypeInfo.pathName} ORDER BY ${fieldSchemaInfo.argOrderBy.map(orderBy => `${orderBy.field === fieldSchemaInfo.graphDBIdArgName ? `ID(${schemaTypeInfo.pathName})` : `${schemaTypeInfo.pathName}.${orderBy.field}`} ${orderBy.direction}`).join(', ')}` : '';
+    const edgePath = schemaTypeInfo.isRelationship ? `${schemaTypeInfo.pathName}_${schemaTypeInfo.relationship.edgeType}` : '';
+    const withClause = `${[lastNamePath, schemaTypeInfo.pathName, edgePath].filter(path => path !== '').join(', ')}`;
+    const orderByClause = fieldSchemaInfo.argOrderBy?.length ? ` WITH ${withClause} ORDER BY ${fieldSchemaInfo.argOrderBy.map(orderBy => `${orderBy.field === fieldSchemaInfo.graphDBIdArgName ? `ID(${schemaTypeInfo.pathName})` : `${schemaTypeInfo.pathName}.${orderBy.field}`} ${orderBy.direction}`).join(', ')}` : '';
 
     if (schemaTypeInfo.isRelationship) {
         const arrows = ['<-', '-', '->'];


### PR DESCRIPTION
Fixed nested edge subqueries with sorting to pass along the edge in WITH statement before the ORDER BY, otherwise neptune will return a 400 bad request error if the edge is referenced later in the query.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
