### PR TITLE
Add util.js file missing from packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "./templates/CDKTemplate.js",
     "./templates/queryHttpNeptune.mjs",
     "./templates/JSResolverOCHTTPS.js",
+    "./templates/util.mjs",
     "./templates/Lambda4AppSyncHTTP/index.mjs",
     "./templates/Lambda4AppSyncHTTP/package.json",
     "./templates/Lambda4AppSyncSDK/index.mjs",


### PR DESCRIPTION
Add util.js file missing from packaging which is required for resolver execution.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
