### PR TITLE
Fixed apollo to use graphql.parse instead of graphql-tag.gql.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,3 +107,5 @@ permissions and limitations under the License.
 * Fixed nested edge subqueries with sorting to pass the edge variable so that it
   can be referenced further in the
   query ([#114](https://github.com/aws/amazon-neptune-for-graphql/pull/114))
+* Fixed Apollo template to reference `graphql` `parse` instead of `graphql-tag`
+  `gql` ([#116](https://github.com/aws/amazon-neptune-for-graphql/pull/116))

--- a/templates/ApolloServer/index.mjs
+++ b/templates/ApolloServer/index.mjs
@@ -2,13 +2,13 @@ import {ApolloServer} from '@apollo/server';
 import {startStandaloneServer} from '@apollo/server/standalone';
 import {buildSubgraphSchema} from '@apollo/subgraph';
 import {readFileSync} from 'fs';
-import {gql} from 'graphql-tag';
+import {parse} from 'graphql';
 import {resolveEvent} from './neptune.mjs'
 import dotenv from 'dotenv';
 
 dotenv.config();
 
-const typeDefs = gql(readFileSync('./output.schema.graphql', 'utf-8'));
+const typeDefs = parse(readFileSync('./output.schema.graphql', 'utf-8'));
 const queryDefinition = typeDefs.definitions.find(
     definition => definition.kind === 'ObjectTypeDefinition' && definition.name.value === 'Query'
 );


### PR DESCRIPTION
Fixed apollo to use `graphql.parse` instead of `graphql-tag.gql` which was missed as part of https://github.com/aws/amazon-neptune-for-graphql/pull/110.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
