### PR TITLE
Fixed deployment of aws resources if a pipeline name is not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,3 +109,6 @@ permissions and limitations under the License.
   query ([#114](https://github.com/aws/amazon-neptune-for-graphql/pull/114))
 * Fixed Apollo template to reference `graphql` `parse` instead of `graphql-tag`
   `gql` ([#116](https://github.com/aws/amazon-neptune-for-graphql/pull/116))
+* Fixed deployment of AWS resources if a pipeline name is not provided as an
+  input
+  option ([#117](https://github.com/aws/amazon-neptune-for-graphql/pull/117))

--- a/src/CDKPipelineApp.js
+++ b/src/CDKPipelineApp.js
@@ -54,10 +54,9 @@ async function getSchemaFields(typeName) {
     return r;
 }
 
-async function createDeploymentFile(templateFolderPath, resolverFilePath) {
+async function createDeploymentFile({templateFolderPath, resolverFilePath, resolverSchemaFilePath}) {
     try {
         const zipFilePath = path.join(RELATIVE_OUTPUT_PATH, `${NAME}.zip`);
-        const resolverSchemaFilePath = path.join(RELATIVE_OUTPUT_PATH, `${NAME}.resolver.schema.json.gz`)
         await createLambdaDeploymentPackage({
             outputZipFilePath: zipFilePath,
             templateFolderPath: templateFolderPath,
@@ -85,6 +84,7 @@ async function createAWSpipelineCDK({
                                         neptunePort,
                                         outputFolderPath,
                                         resolverFilePath,
+                                        resolverSchemaFilePath,
                                         neptuneType
                                     }) {
 
@@ -153,7 +153,11 @@ async function createAWSpipelineCDK({
     }
          
     if (!quiet) spinner = ora('Creating ZIP ...').start();
-    await createDeploymentFile(lambdaFilesPath, resolverFilePath);
+    await createDeploymentFile({
+        templateFolderPath: lambdaFilesPath,
+        resolverFilePath: resolverFilePath,
+        resolverSchemaFilePath: resolverSchemaFilePath
+    });
     if (!quiet) spinner.succeed('Created ZIP File: ' + yellow(LAMBDA_ZIP_FILE));
     
     APPSYNC_ATTACH_QUERY = await getSchemaFields('Query');

--- a/src/logger.js
+++ b/src/logger.js
@@ -72,7 +72,7 @@ function loggerError(errorMessage, error) {
     let toLog = removeYellow(errorMessage);
     if (error) {
         toConsole = toConsole + ': ' + error.message + ' - Please see ' + logFileDestination + ' for more details';
-        toLog = toLog + '\n' + JSON.stringify(error, null, 4);
+        toLog = toLog + ': ' + error.message + '\n' + JSON.stringify(error, null, 4);
     }
     console.error(toConsole);
     fileLogger.error(toLog);

--- a/src/zipPackage.js
+++ b/src/zipPackage.js
@@ -84,18 +84,19 @@ async function createZip({targetZipFilePath, includePaths = [], includeContent =
  * @returns {Promise<Buffer<ArrayBufferLike>>}
  */
 export async function createLambdaDeploymentPackage({outputZipFilePath, templateFolderPath, resolverFilePath, resolverSchemaFilePath}) {
-    const filePaths = [{source: templateFolderPath}, {source: resolverFilePath, target: 'output.resolver.graphql.js'}];
     const modulePath = getModulePath();
+    const filePaths = [
+        {source: templateFolderPath},
+        {source: resolverFilePath, target: 'output.resolver.graphql.js'},
+        {source: resolverSchemaFilePath, target: 'output.resolver.schema.json.gz'},
+        {source: path.join(modulePath, '/../templates/util.mjs')}
+    ];
+
     if (templateFolderPath.includes('HTTP')) {
         filePaths.push({
             source: path.join(modulePath, '/../templates/queryHttpNeptune.mjs')
         })
     }
-
-    filePaths.push({
-        source: resolverSchemaFilePath,
-        target: 'output.resolver.schema.json.gz'
-    }, {source: path.join(modulePath, '/../templates/util.mjs')});
 
     await createZip({
         targetZipFilePath: outputZipFilePath,

--- a/templates/CDKTemplate.js
+++ b/templates/CDKTemplate.js
@@ -163,11 +163,15 @@ class AppSyncNeptuneStack extends Stack {
                 ]       
             })
         );
-                
-        // AppSync: DataSource
-        const dataSource = new CfnDataSource(this, NAME + 'DataSource', {
+
+       // some resources names cannot have dashes
+       const sanitizedName = NAME.replaceAll('-', '_');
+       
+       // AppSync: DataSource
+       const dataSourceName = `${sanitizedName}DataSource`;
+       const dataSource = new CfnDataSource(this, dataSourceName, {
             apiId: itemsGraphQLApi.attrApiId,
-            name: NAME + 'DataSource',
+            name: dataSourceName,
             type: 'AWS_LAMBDA',
             lambdaConfig: {
                 lambdaFunctionArn: LAMBDA_ARN,
@@ -181,10 +185,11 @@ class AppSyncNeptuneStack extends Stack {
 
                
         // AppSync: Function        
-        const functionappSync = new CfnFunctionConfiguration(this, NAME + 'Function', {
+       const functionName = `${sanitizedName}Function`;
+       const functionappSync = new CfnFunctionConfiguration(this, functionName, {
             apiId: itemsGraphQLApi.attrApiId,
-            dataSourceName: NAME + 'DataSource',
-            name: NAME + 'Function',
+            dataSourceName: dataSourceName,
+            name: functionName,
             runtime: {
                 name: "APPSYNC_JS",
                 runtimeVersion: "1.0.0",

--- a/test/TestCases/Case04/Case04.01.test.js
+++ b/test/TestCases/Case04/Case04.01.test.js
@@ -3,7 +3,7 @@ import { jest } from '@jest/globals';
 import { readJSONFile } from '../../testLib';
 import { main } from "../../../src/main";
 
-const casetest = readJSONFile('./test/TestCases/Case04/case.json');
+const casetest = readJSONFile('./test/TestCases/Case04/get-db-schema.json');
 
 async function executeUtility() {    
     process.argv = casetest.argv;

--- a/test/TestCases/Case04/Case04.02.test.js
+++ b/test/TestCases/Case04/Case04.02.test.js
@@ -7,7 +7,7 @@ const casetest = readJSONFile('./test/TestCases/Case04/case.json');
 const testDbInfo = parseNeptuneEndpoint(casetest.host + ':' + casetest.port);
 const outputFolderPath = './test/TestCases/Case04/output';
 
-const schemaFile = `${testDbInfo.graphName}.output.neptune.schema.json`;
+const schemaFile = `${testDbInfo.graphName}.neptune.schema.json`;
 const neptuneSchema = readJSONFile(`./test/TestCases/Case04/output/${schemaFile}`);
 const refSchemaFile = `output.neptune.${testDbInfo.neptuneType.replace('neptune-', '')}.schema.json`;
 const refNeptuneSchema = readJSONFile(`./test/TestCases/Case04/outputReference/${refSchemaFile}`);
@@ -18,10 +18,10 @@ describe('Validate output content', () => {
     });
 
     checkFolderContainsFiles(outputFolderPath, [
-        `${testDbInfo.graphName}.output.resolver.graphql.js`,
-        `${testDbInfo.graphName}.output.resolver.schema.json.gz`,
-        `${testDbInfo.graphName}.output.schema.graphql`,
-        `${testDbInfo.graphName}.output.source.schema.graphql`
+        `${testDbInfo.graphName}.resolver.graphql.js`,
+        `${testDbInfo.graphName}.resolver.schema.json.gz`,
+        `${testDbInfo.graphName}.schema.graphql`,
+        `${testDbInfo.graphName}.source.schema.graphql`
     ]);
 
     // note that this test can be flaky depending on how the air routes sample data was loaded into neptune

--- a/test/TestCases/Case04/Case04.02.test.js
+++ b/test/TestCases/Case04/Case04.02.test.js
@@ -2,13 +2,14 @@ import { readJSONFile, checkOutputFileContent, checkFolderContainsFiles } from '
 import { sortNeptuneSchema } from './util';
 import fs from "fs";
 import { parseNeptuneEndpoint } from "../../../src/util.js";
+import path from "path";
 
-const casetest = readJSONFile('./test/TestCases/Case04/case.json');
+const casetest = readJSONFile('./test/TestCases/Case04/get-db-schema.json');
 const testDbInfo = parseNeptuneEndpoint(casetest.host + ':' + casetest.port);
-const outputFolderPath = './test/TestCases/Case04/output';
+const outputFolderPath = './test/TestCases/Case04/get-db-schema-output';
 
 const schemaFile = `${testDbInfo.graphName}.neptune.schema.json`;
-const neptuneSchema = readJSONFile(`./test/TestCases/Case04/output/${schemaFile}`);
+const neptuneSchema = readJSONFile(path.join(outputFolderPath, schemaFile));
 const refSchemaFile = `output.neptune.${testDbInfo.neptuneType.replace('neptune-', '')}.schema.json`;
 const refNeptuneSchema = readJSONFile(`./test/TestCases/Case04/outputReference/${refSchemaFile}`);
 

--- a/test/TestCases/Case04/get-db-schema.json
+++ b/test/TestCases/Case04/get-db-schema.json
@@ -3,7 +3,7 @@
     "description":"",
     "argv":["--quiet",
             "--input-graphdb-schema-neptune-endpoint", "<AIR_ROUTES_DB_HOST>:<AIR_ROUTES_DB_PORT>",
-            "--output-folder-path", "./test/TestCases/Case04/output",
+            "--output-folder-path", "./test/TestCases/Case04/get-db-schema-output",
             "--output-no-lambda-zip"],
     "host": "<AIR_ROUTES_DB_HOST>",
     "port": "<AIR_ROUTES_DB_PORT>",

--- a/test/TestCases/Case06/Case06.01.test.js
+++ b/test/TestCases/Case06/Case06.01.test.js
@@ -1,7 +1,7 @@
 import { readJSONFile } from '../../testLib';
 import { main } from "../../../src/main";
 
-const casetest = readJSONFile('./test/TestCases/Case06/case01.json');
+const casetest = readJSONFile('./test/TestCases/Case06/cdk-pipeline-http-resolver.json');
 
 async function executeUtility() {    
     process.argv = casetest.argv;

--- a/test/TestCases/Case06/Case06.02.test.js
+++ b/test/TestCases/Case06/Case06.02.test.js
@@ -2,12 +2,12 @@ import { checkFileContains, checkFolderContainsFiles, readJSONFile, unzipAndGetC
 import fs from "fs";
 import path from "path";
 
-const casetest = readJSONFile('./test/TestCases/Case06/case01.json');
+const casetest = readJSONFile('./test/TestCases/Case06/cdk-pipeline-http-resolver.json');
 let neptuneType = 'neptune-db';
 if (casetest.host.includes('neptune-graph')) {
     neptuneType = 'neptune-graph';
 }
-const outputFolderPath = './test/TestCases/Case06/case01-output';
+const outputFolderPath = './test/TestCases/Case06/cdk-pipeline-http-resolver-output';
 
 describe('Validate cdk pipeline with http resolver output content', () => {
     afterAll(() => {

--- a/test/TestCases/Case06/Case06.02.test.js
+++ b/test/TestCases/Case06/Case06.02.test.js
@@ -1,4 +1,4 @@
-import { checkFileContains, readJSONFile, unzipAndGetContents } from '../../testLib';
+import { checkFileContains, checkFolderContainsFiles, readJSONFile, unzipAndGetContents } from '../../testLib';
 import fs from "fs";
 import path from "path";
 
@@ -13,6 +13,15 @@ describe('Validate cdk pipeline with http resolver output content', () => {
     afterAll(() => {
         fs.rmSync(outputFolderPath, {recursive: true});
     });
+
+    checkFolderContainsFiles(outputFolderPath, [
+        'AirportCDKTestJest.resolver.graphql.js',
+        'AirportCDKTestJest.resolver.schema.json.gz',
+        'AirportCDKTestJest.schema.graphql',
+        'AirportCDKTestJest.source.schema.graphql',
+        'AirportCDKTestJest-cdk.js',
+        'AirportCDKTestJest.zip'
+    ]);
 
     test('Zip file contains expected files', () => {
         const expectedFiles = [

--- a/test/TestCases/Case06/Case06.03.test.js
+++ b/test/TestCases/Case06/Case06.03.test.js
@@ -1,7 +1,7 @@
 import { readJSONFile } from '../../testLib';
 import { main } from "../../../src/main";
 
-const casetest = readJSONFile('./test/TestCases/Case06/case02.json');
+const casetest = readJSONFile('./test/TestCases/Case06/cdk-pipeline-sdk-resolver.json');
 
 async function executeUtility() {    
     process.argv = casetest.argv;

--- a/test/TestCases/Case06/Case06.04.test.js
+++ b/test/TestCases/Case06/Case06.04.test.js
@@ -1,4 +1,4 @@
-import { unzipAndGetContents } from '../../testLib';
+import { checkFolderContainsFiles, unzipAndGetContents } from '../../testLib';
 import fs from "fs";
 import path from "path";
 
@@ -8,6 +8,15 @@ describe('Validate cdk pipeline with sdk resolver output content', () => {
     afterAll(() => {
         fs.rmSync(outputFolderPath, {recursive: true});
     });
+
+    checkFolderContainsFiles(outputFolderPath, [
+        'AirportCDKSDKTestJest.resolver.graphql.js',
+        'AirportCDKSDKTestJest.resolver.schema.json.gz',
+        'AirportCDKSDKTestJest.schema.graphql',
+        'AirportCDKSDKTestJest.source.schema.graphql',
+        'AirportCDKSDKTestJest-cdk.js',
+        'AirportCDKSDKTestJest.zip'
+    ]);
 
     test('Zip file contains expected files', () => {
         const expectedFiles = [

--- a/test/TestCases/Case06/Case06.04.test.js
+++ b/test/TestCases/Case06/Case06.04.test.js
@@ -2,7 +2,7 @@ import { checkFolderContainsFiles, unzipAndGetContents } from '../../testLib';
 import fs from "fs";
 import path from "path";
 
-const outputFolderPath = './test/TestCases/Case06/case02-output';
+const outputFolderPath = './test/TestCases/Case06/cdk-pipeline-sdk-resolver-output';
 
 describe('Validate cdk pipeline with sdk resolver output content', () => {
     afterAll(() => {

--- a/test/TestCases/Case06/Case06.05.test.js
+++ b/test/TestCases/Case06/Case06.05.test.js
@@ -1,0 +1,13 @@
+import { readJSONFile } from '../../testLib';
+import { main } from "../../../src/main";
+
+const casetest = readJSONFile('./test/TestCases/Case06/case03.json');
+
+async function executeUtility() {    
+    process.argv = casetest.argv;
+    await main();
+}
+
+test('Execute utility: ' + casetest.argv.join(' '), async () => {
+    expect(await executeUtility()).not.toBe(null);    
+}, 600000);

--- a/test/TestCases/Case06/Case06.05.test.js
+++ b/test/TestCases/Case06/Case06.05.test.js
@@ -1,7 +1,7 @@
 import { readJSONFile } from '../../testLib';
 import { main } from "../../../src/main";
 
-const casetest = readJSONFile('./test/TestCases/Case06/case03.json');
+const casetest = readJSONFile('./test/TestCases/Case06/cdk-pipeline-no-name.json');
 
 async function executeUtility() {    
     process.argv = casetest.argv;

--- a/test/TestCases/Case06/Case06.06.test.js
+++ b/test/TestCases/Case06/Case06.06.test.js
@@ -1,0 +1,42 @@
+import { checkFolderContainsFiles, unzipAndGetContents } from '../../testLib';
+import path from "path";
+import { parseNeptuneEndpoint } from "../../../src/util.js";
+import fs from "fs";
+
+const outputFolderPath = './test/TestCases/Case06/case03-output';
+const dbHost = process.env['AIR_ROUTES_DB_HOST'];
+const dbPort = process.env['AIR_ROUTES_DB_PORT'];
+const neptuneInfo = parseNeptuneEndpoint(`${dbHost}:${dbPort}`);
+const graphName = neptuneInfo.graphName;
+const zipFile = `${graphName}.zip`;
+
+describe('Validate cdk pipeline without specified pipeline name', () => {
+    afterAll(() => {
+        fs.rmSync(outputFolderPath, {recursive: true});
+    });
+
+    checkFolderContainsFiles(outputFolderPath, [
+        `${graphName}.resolver.graphql.js`,
+        `${graphName}.resolver.schema.json.gz`,
+        `${graphName}.schema.graphql`,
+        `${graphName}.source.schema.graphql`,
+        `${graphName}-cdk.js`,
+        zipFile
+    ]);
+
+    test('Zip file contains expected files', () => {
+        const expectedFiles = [
+            'index.mjs',
+            'node_modules',
+            'output.resolver.graphql.js',
+            'output.resolver.schema.json.gz',
+            'package-lock.json',
+            'package.json',
+            'queryHttpNeptune.mjs',
+            'util.mjs'
+        ];
+        const unzippedFolder = path.join(outputFolderPath, 'cdk-unzipped');
+        const actualFiles = unzipAndGetContents(unzippedFolder, path.join(outputFolderPath, zipFile));
+        expect(actualFiles.toSorted()).toEqual(expectedFiles.toSorted());
+    });
+});

--- a/test/TestCases/Case06/Case06.06.test.js
+++ b/test/TestCases/Case06/Case06.06.test.js
@@ -3,7 +3,7 @@ import path from "path";
 import { parseNeptuneEndpoint } from "../../../src/util.js";
 import fs from "fs";
 
-const outputFolderPath = './test/TestCases/Case06/case03-output';
+const outputFolderPath = './test/TestCases/Case06/cdk-pipeline-no-name-output';
 const dbHost = process.env['AIR_ROUTES_DB_HOST'];
 const dbPort = process.env['AIR_ROUTES_DB_PORT'];
 const neptuneInfo = parseNeptuneEndpoint(`${dbHost}:${dbPort}`);

--- a/test/TestCases/Case06/case03.json
+++ b/test/TestCases/Case06/case03.json
@@ -1,0 +1,13 @@
+{
+    "name": "Integration Test (Air Routes) CDK HTTP Pipeline",
+    "description":"Create CDK pipeline without pipeline name",
+    "argv":["--quiet", 
+            "--input-schema-file", "./test/TestCases/airports.source.schema.graphql",
+            "--output-folder-path", "./test/TestCases/Case06/case03-output",
+            "--output-aws-pipeline-cdk",
+            "--output-aws-pipeline-cdk-region", "us-east-1",
+            "--output-aws-pipeline-cdk-neptune-endpoint", "<AIR_ROUTES_DB_HOST>:<AIR_ROUTES_DB_PORT>",
+            "--output-resolver-query-https"],
+    "host": "<AIR_ROUTES_DB_HOST>",
+    "port": "<AIR_ROUTES_DB_PORT>"
+}

--- a/test/TestCases/Case06/cdk-pipeline-http-resolver.json
+++ b/test/TestCases/Case06/cdk-pipeline-http-resolver.json
@@ -3,7 +3,7 @@
     "description":"Create CDK pipeline with http resolver",
     "argv":["--quiet", 
             "--input-schema-file", "./test/TestCases/airports.source.schema.graphql",
-            "--output-folder-path", "./test/TestCases/Case06/case01-output",
+            "--output-folder-path", "./test/TestCases/Case06/cdk-pipeline-http-resolver-output",
             "--output-aws-pipeline-cdk",
             "--output-aws-pipeline-cdk-name", "AirportCDKTestJest",
             "--output-aws-pipeline-cdk-neptune-database-name", "airport00",

--- a/test/TestCases/Case06/cdk-pipeline-no-name.json
+++ b/test/TestCases/Case06/cdk-pipeline-no-name.json
@@ -3,7 +3,7 @@
     "description":"Create CDK pipeline without pipeline name",
     "argv":["--quiet", 
             "--input-schema-file", "./test/TestCases/airports.source.schema.graphql",
-            "--output-folder-path", "./test/TestCases/Case06/case03-output",
+            "--output-folder-path", "./test/TestCases/Case06/cdk-pipeline-no-name-output",
             "--output-aws-pipeline-cdk",
             "--output-aws-pipeline-cdk-region", "us-east-1",
             "--output-aws-pipeline-cdk-neptune-endpoint", "<AIR_ROUTES_DB_HOST>:<AIR_ROUTES_DB_PORT>",

--- a/test/TestCases/Case06/cdk-pipeline-sdk-resolver.json
+++ b/test/TestCases/Case06/cdk-pipeline-sdk-resolver.json
@@ -3,7 +3,7 @@
     "description":"Create CDK pipeline with sdk resolver",
     "argv":["--quiet", 
             "--input-schema-file", "./test/TestCases/airports.source.schema.graphql",
-            "--output-folder-path", "./test/TestCases/Case06/case02-output",
+            "--output-folder-path", "./test/TestCases/Case06/cdk-pipeline-sdk-resolver-output",
             "--output-aws-pipeline-cdk",
             "--output-aws-pipeline-cdk-name", "AirportCDKSDKTestJest",
             "--output-aws-pipeline-cdk-neptune-database-name", "airport00",

--- a/test/TestCases/Case09/Case09.01.test.js
+++ b/test/TestCases/Case09/Case09.01.test.js
@@ -1,7 +1,7 @@
 import {readJSONFile} from '../../testLib';
 import {main} from "../../../src/main";
 
-const casetest = readJSONFile('./test/TestCases/Case09/case01.json');
+const casetest = readJSONFile('./test/TestCases/Case09/apollo-subgraph.json');
 
 async function executeUtility() {
     process.argv = casetest.argv;

--- a/test/TestCases/Case09/Case09.02.test.js
+++ b/test/TestCases/Case09/Case09.02.test.js
@@ -12,11 +12,11 @@ describe('Validate Apollo Server Subgraph output artifacts', () => {
     });
 
     checkFolderContainsFiles(outputFolderPath, [
-        `${testDbInfo.graphName}.output.neptune.schema.json`,
-        `${testDbInfo.graphName}.output.resolver.graphql.js`,
-        `${testDbInfo.graphName}.output.resolver.schema.json.gz`,
-        `${testDbInfo.graphName}.output.schema.graphql`,
-        `${testDbInfo.graphName}.output.source.schema.graphql`
+        `${testDbInfo.graphName}.neptune.schema.json`,
+        `${testDbInfo.graphName}.resolver.graphql.js`,
+        `${testDbInfo.graphName}.resolver.schema.json.gz`,
+        `${testDbInfo.graphName}.schema.graphql`,
+        `${testDbInfo.graphName}.source.schema.graphql`
     ]);
 
     testApolloArtifacts(outputFolderPath, testDbInfo, true);

--- a/test/TestCases/Case09/Case09.02.test.js
+++ b/test/TestCases/Case09/Case09.02.test.js
@@ -2,10 +2,10 @@ import { checkFolderContainsFiles, readJSONFile, testApolloArtifacts } from '../
 import fs from "fs";
 import {parseNeptuneEndpoint} from "../../../src/util.js";
 
-const testCase = readJSONFile('./test/TestCases/Case09/case01.json');
+const testCase = readJSONFile('./test/TestCases/Case09/apollo-subgraph.json');
 const testDbInfo = parseNeptuneEndpoint(testCase.host + ':' + testCase.port);
 
-const outputFolderPath = './test/TestCases/Case09/output';
+const outputFolderPath = './test/TestCases/Case09/apollo-subgraph-output';
 describe('Validate Apollo Server Subgraph output artifacts', () => {
     afterAll(() => {
         fs.rmSync(outputFolderPath, {recursive: true});

--- a/test/TestCases/Case09/Case09.03.test.js
+++ b/test/TestCases/Case09/Case09.03.test.js
@@ -1,7 +1,7 @@
 import {readJSONFile} from '../../testLib';
 import {main} from "../../../src/main";
 
-const casetest = readJSONFile('./test/TestCases/Case09/case02.json');
+const casetest = readJSONFile('./test/TestCases/Case09/apollo-subgraph-input-schema.json');
 
 async function executeUtility() {
     process.argv = casetest.argv;

--- a/test/TestCases/Case09/Case09.04.test.js
+++ b/test/TestCases/Case09/Case09.04.test.js
@@ -2,9 +2,9 @@ import {readJSONFile, testApolloArtifacts} from '../../testLib';
 import fs from "fs";
 import {parseNeptuneEndpoint} from "../../../src/util.js";
 
-const testCase = readJSONFile('./test/TestCases/Case09/case02.json');
+const testCase = readJSONFile('./test/TestCases/Case09/apollo-subgraph-input-schema.json');
 const testDbInfo = parseNeptuneEndpoint(testCase.host + ':' + testCase.port);
-const outputFolderPath = './test/TestCases/Case09/case09-02-output';
+const outputFolderPath = './test/TestCases/Case09/apollo-subgraph-input-schema-output';
 
 describe('Validate Apollo Server Subgraph output artifacts are created when using an input schema file', () => {
     afterAll(async () => {

--- a/test/TestCases/Case09/apollo-subgraph-input-schema.json
+++ b/test/TestCases/Case09/apollo-subgraph-input-schema.json
@@ -4,7 +4,7 @@
     "argv":["--quiet",
             "--input-schema-file", "./test/TestCases/airports.source.schema.graphql",
             "--create-update-apollo-server-neptune-endpoint", "<AIR_ROUTES_DB_HOST>:<AIR_ROUTES_DB_PORT>",
-            "--output-folder-path", "./test/TestCases/Case09/case09-02-output",
+            "--output-folder-path", "./test/TestCases/Case09/apollo-subgraph-input-schema-output",
             "--create-update-apollo-server-subgraph",
             "--output-resolver-query-https"],
     "host": "<AIR_ROUTES_DB_HOST>",

--- a/test/TestCases/Case09/apollo-subgraph.json
+++ b/test/TestCases/Case09/apollo-subgraph.json
@@ -3,7 +3,7 @@
     "description":"Test creation of Apollo Server Subgraph ZIP",
     "argv":["--quiet",
             "--input-graphdb-schema-neptune-endpoint", "<AIR_ROUTES_DB_HOST>:<AIR_ROUTES_DB_PORT>",
-            "--output-folder-path", "./test/TestCases/Case09/output",
+            "--output-folder-path", "./test/TestCases/Case09/apollo-subgraph-output",
             "--create-update-apollo-server-subgraph",
             "--output-resolver-query-https"],
     "host": "<AIR_ROUTES_DB_HOST>",

--- a/test/TestCases/Case10/Case10.01.test.js
+++ b/test/TestCases/Case10/Case10.01.test.js
@@ -1,0 +1,13 @@
+import { readJSONFile } from '../../testLib';
+import { main } from "../../../src/main";
+
+const casetest = readJSONFile('./test/TestCases/Case10/case01.json');
+
+async function executeUtility() {
+    process.argv = casetest.argv;
+    await main();
+}
+
+test('Execute utility: ' + casetest.argv.join(' '), async () => {
+    expect(await executeUtility()).not.toBe(null);
+}, 600000);

--- a/test/TestCases/Case10/Case10.01.test.js
+++ b/test/TestCases/Case10/Case10.01.test.js
@@ -1,7 +1,7 @@
 import { readJSONFile } from '../../testLib';
 import { main } from "../../../src/main";
 
-const casetest = readJSONFile('./test/TestCases/Case10/case01.json');
+const casetest = readJSONFile('./test/TestCases/Case10/pipeline-no-name.json');
 
 async function executeUtility() {
     process.argv = casetest.argv;

--- a/test/TestCases/Case10/Case10.02.test.js
+++ b/test/TestCases/Case10/Case10.02.test.js
@@ -3,7 +3,7 @@ import path from "path";
 import { parseNeptuneEndpoint } from "../../../src/util.js";
 import fs from "fs";
 
-const outputFolderPath = './test/TestCases/Case10/output';
+const outputFolderPath = './test/TestCases/Case10/pipeline-no-name-output';
 const dbHost = process.env['AIR_ROUTES_DB_HOST'];
 const dbPort = process.env['AIR_ROUTES_DB_PORT'];
 const neptuneInfo = parseNeptuneEndpoint(`${dbHost}:${dbPort}`);

--- a/test/TestCases/Case10/Case10.02.test.js
+++ b/test/TestCases/Case10/Case10.02.test.js
@@ -1,0 +1,43 @@
+import { checkFolderContainsFiles, unzipAndGetContents } from '../../testLib';
+import path from "path";
+import { parseNeptuneEndpoint } from "../../../src/util.js";
+import fs from "fs";
+
+const outputFolderPath = './test/TestCases/Case10/output';
+const dbHost = process.env['AIR_ROUTES_DB_HOST'];
+const dbPort = process.env['AIR_ROUTES_DB_PORT'];
+const neptuneInfo = parseNeptuneEndpoint(`${dbHost}:${dbPort}`);
+const graphName = neptuneInfo.graphName;
+
+describe('Validate pipeline output files created without specifying pipeline name', () => {
+    afterAll(async () => {
+        fs.rmSync(outputFolderPath, {recursive: true});
+    });
+
+    // db graph name should be used to prefix the output files if the user didn't specify a pipeline name
+    const zipFile = `${graphName}.lambda.zip`;
+    checkFolderContainsFiles(outputFolderPath, [
+        `${graphName}.resolver.graphql.js`,
+        `${graphName}.resolver.schema.json.gz`,
+        `${graphName}.schema.graphql`,
+        `${graphName}.source.schema.graphql`,
+        zipFile
+    ]);
+
+    test('Zip file contains expected files', () => {
+        const expectedFiles = [
+            'index.mjs',
+            'node_modules',
+            'output.resolver.graphql.js',
+            'output.resolver.schema.json.gz',
+            'package-lock.json',
+            'package.json',
+            'queryHttpNeptune.mjs',
+            'util.mjs'
+        ];
+
+        const unzippedFolder = path.join(outputFolderPath, 'unzipped');
+        const actualFiles = unzipAndGetContents(unzippedFolder, path.join(outputFolderPath, zipFile));
+        expect(actualFiles.toSorted()).toEqual(expectedFiles.toSorted());
+    });
+});

--- a/test/TestCases/Case10/case01.json
+++ b/test/TestCases/Case10/case01.json
@@ -1,0 +1,11 @@
+{
+    "name": "Unit Test (Air Routes) Pipeline",
+    "description":"Create pipeline zip without specifying pipeline name",
+    "argv":["--quiet",
+            "--input-schema-file", "./test/TestCases/airports.source.schema.graphql",
+            "--output-folder-path", "./test/TestCases/Case10/output",
+            "--create-update-aws-pipeline-neptune-endpoint", "<AIR_ROUTES_DB_HOST>:<AIR_ROUTES_DB_PORT>",
+            "--output-resolver-query-https"],
+    "host": "<AIR_ROUTES_DB_HOST>",
+    "port": "<AIR_ROUTES_DB_PORT>"
+}

--- a/test/TestCases/Case10/pipeline-no-name.json
+++ b/test/TestCases/Case10/pipeline-no-name.json
@@ -3,7 +3,7 @@
     "description":"Create pipeline zip without specifying pipeline name",
     "argv":["--quiet",
             "--input-schema-file", "./test/TestCases/airports.source.schema.graphql",
-            "--output-folder-path", "./test/TestCases/Case10/output",
+            "--output-folder-path", "./test/TestCases/Case10/pipeline-no-name-output",
             "--create-update-aws-pipeline-neptune-endpoint", "<AIR_ROUTES_DB_HOST>:<AIR_ROUTES_DB_PORT>",
             "--output-resolver-query-https"],
     "host": "<AIR_ROUTES_DB_HOST>",


### PR DESCRIPTION
Fixed deployment of aws resources which would fail if option `--create-update-aws-pipeline-name` was not specified:
* corrected mismatch of resolver schema file name when creating the lambda zip file by passing the generated schema file name to the function which is creating the zip file
* changed the output file prefix to only have the `.output` suffix if there is no discovered graph name
* changed App Sync Function and DataSource resource names to replace any dashes `-` with underscores as dashes are not allowed (but can be present in Neptune db/graph names)
* added integration tests to validate that correct output files and zip file content are created if no pipeline name is provided

Other minor changes:
* changed file error logging to include the `error.message` as the error message was output to console but missing from the file
* added validation of output folder files to CDK integration tests
* modified affected test cases to have descriptive file names and output folders

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
