### PR TITLE
Fix: Invalid schema generation when AWS AppSync scalars are used in input schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,3 +112,6 @@ permissions and limitations under the License.
 * Fixed deployment of AWS resources if a pipeline name is not provided as an
   input
   option ([#117](https://github.com/aws/amazon-neptune-for-graphql/pull/117))
+* Fixed invalid schema generation when AWS AppSync scalar types are used in 
+  an input 
+  schema ([#118](https://github.com/aws/amazon-neptune-for-graphql/pull/118))

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ You might want to use it as is, or change it. Below are ways to change it.
 ### Please no mutations in my schema
 
 In case you don't want your Graph API having the option of updating your
-database data, add the the CLI option `--output-schema-no-mutations`.
+database data, add the CLI option `--output-schema-no-mutations`.
 
 ### @alias
 
@@ -510,6 +510,34 @@ resolvers, the absence of the custom scalar resolvers will bypass important data
 validation for fields using custom scalar types.
 See [Apollo Custom Scalars](https://www.apollographql.com/docs/apollo-server/schema/custom-scalars)
 for more details on how to attach custom scalar resolvers with Apollo Server.
+
+### AWS AppSync Scalars
+
+AWS AppSync provides a set of extended scalar types that go beyond the default GraphQL 
+scalars like `String`, `Int`, and `Boolean`. 
+
+Refer to 
+[AWS AppSync scalars](https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html#graph-ql-aws-appsync-scalars)
+for more details on each of the scalar types.
+
+These scalar types can be used in your schema (specified via `--input-schema-file`) just
+like any other standard scalar when working with **AWS AppSync**. You simply reference 
+them in your schema, and AppSync handles the parsing and validation automatically. 
+For example, you can define a field as an `AWSEmail` or `AWSDateTime` without needing to 
+implement any custom logic as AppSync will enforce the correct format at runtime.
+
+```graphql
+type User {
+  id: ID!
+  email: AWSEmail!
+  createdAt: AWSDateTime!
+  metadata: AWSJSON
+}
+```
+
+However, it's important to note that these scalars are specific to AppSync and are not 
+part of the official GraphQL specification. Thus, these scalars types are **not automatically
+recognized by the Apollo Server** as it is with AppSync.
 
 # Known limitations
 

--- a/doc/todoExample.md
+++ b/doc/todoExample.md
@@ -2,7 +2,7 @@
 
 You can start from a GraphQL schema without directives and an empty Neptune
 database. The utility will inference directives, input, queries and mutations,
-and create the the GraphQL API. Then, you can use GraphQL to create, mutate and
+and create the GraphQL API. Then, you can use GraphQL to create, mutate and
 query the data stored in a Neptune database without the need to know how to use
 a graph query language.
 
@@ -23,6 +23,7 @@ type Todo {
 type Comment {
     content: String
 }
+
 ```
 
 Let's now run this schema through the utility and create the GraphQL API in AWS
@@ -39,7 +40,7 @@ neptune-for-graphql \
 
 The utility created a new file in the *output* folder called
 *TodoExample.source.graphql*, and the GraphQL API in AppSync. As you can see
-below, the utility inferenced:
+below, the utility inferences:
 
 - In the type *Todo* it added *@relationship* for a new type *CommentEdge*. This
   is instructing the resolver to connect *Todo* to *Comment* using a graph
@@ -51,7 +52,7 @@ below, the utility inferenced:
   getNodeTodos query.
 - For each type (*Todo*, *Comment*) the utility added two queries. One to
   retrieve a single type using an id or any of the type fields listed in the
-  input, and the second to retrive multiple values, filtered using the input of
+  input, and the second to retrieve multiple values, filtered using the input of
   that type.
 - For each type three mutations: create, update and delete. Selecting the type
   to delete using an id or the input for that type. These mutation affect the
@@ -71,11 +72,6 @@ below, the utility inferenced:
 <summary>Todo GraphQL Schema</summary>
 
 ```graphql
-enum SortingDirection {
-    ASC
-    DESC
-}
-
 type Todo {
     _id: ID! @id
     name: String
@@ -90,6 +86,11 @@ type Todo {
 type Comment {
     _id: ID! @id
     content: String
+}
+
+enum SortingDirection {
+  ASC
+  DESC
 }
 
 input TodoInput {

--- a/samples/todo.schema.graphql
+++ b/samples/todo.schema.graphql
@@ -1,4 +1,3 @@
-
 type Todo {
     name: String
     description: String

--- a/src/schemaModelValidator.js
+++ b/src/schemaModelValidator.js
@@ -21,7 +21,7 @@ const typesToAdd = [];
 const queriesToAdd = [];
 const mutationsToAdd = [];
 const enumTypes = [];
-const customScalarTypes = [];
+const customScalarTypes = ['AWSDate', 'AWSTime', 'AWSDateTime', 'AWSTimestamp', 'AWSEmail', 'AWSJSON', 'AWSPhone', 'AWSURL', 'AWSIPAddress'];
 
 function lowercaseFirstCharacter(inputString) {
     if (inputString.length === 0) {     

--- a/src/test/airports.customized.graphql
+++ b/src/test/airports.customized.graphql
@@ -45,6 +45,15 @@ type Country @alias(property: "country") {
   type: String
   code: String
   desc: String
+  foundingDate: AWSDate
+  localOfficeTime: AWSTime
+  updatedAt: AWSDateTime
+  createdTimestamp: AWSTimestamp
+  officialEmail: AWSEmail
+  metadataJson: AWSJSON
+  governmentSite: AWSURL
+  emergencyLine: AWSPhone
+  gatewayIp: AWSIPAddress
   airportContainssOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "contains", direction: OUT)
   contains: Contains
 }
@@ -54,6 +63,15 @@ _id: ID @id
 type: StringScalarFilters
 code: StringScalarFilters
 desc: StringScalarFilters
+foundingDate: AWSDate
+localOfficeTime: AWSTime
+updatedAt: AWSDateTime
+createdTimestamp: AWSTimestamp
+officialEmail: AWSEmail
+metadataJson: AWSJSON
+governmentSite: AWSURL
+emergencyLine: AWSPhone
+gatewayIp: AWSIPAddress
 }
 
 input CountryCreateInput {
@@ -61,6 +79,15 @@ input CountryCreateInput {
   type: String
   code: String
   desc: String
+  foundingDate: AWSDate
+  localOfficeTime: AWSTime
+  updatedAt: AWSDateTime
+  createdTimestamp: AWSTimestamp
+  officialEmail: AWSEmail
+  metadataJson: AWSJSON
+  governmentSite: AWSURL
+  emergencyLine: AWSPhone
+  gatewayIp: AWSIPAddress
 }
 
 input CountryUpdateInput {
@@ -68,6 +95,15 @@ input CountryUpdateInput {
   type: String
   code: String
   desc: String
+  foundingDate: AWSDate
+  localOfficeTime: AWSTime
+  updatedAt: AWSDateTime
+  createdTimestamp: AWSTimestamp
+  officialEmail: AWSEmail
+  metadataJson: AWSJSON
+  governmentSite: AWSURL
+  emergencyLine: AWSPhone
+  gatewayIp: AWSIPAddress
 }
 
 input CountrySort {
@@ -75,6 +111,15 @@ input CountrySort {
   type: SortingDirection
   code: SortingDirection
   desc: SortingDirection
+  foundingDate: SortingDirection
+  localOfficeTime: SortingDirection
+  updatedAt: SortingDirection
+  createdTimestamp: SortingDirection
+  officialEmail: SortingDirection
+  metadataJson: SortingDirection
+  governmentSite: SortingDirection
+  emergencyLine: SortingDirection
+  gatewayIp: SortingDirection
 }
 
 type Version @alias(property: "version") {

--- a/src/test/schemaModelValidator.test.js
+++ b/src/test/schemaModelValidator.test.js
@@ -28,9 +28,9 @@ describe('validatedSchemaModel', () => {
         const groupType = objTypeDefs.find(def => def.name.value === 'Group');
         const moderatorType = objTypeDefs.find(def => def.name.value === 'Moderator');
 
-        expect(userType.fields).toHaveLength(5);
-        expect(groupType.fields).toHaveLength(2);
-        expect(moderatorType.fields).toHaveLength(4);
+        expect(userType.fields).toHaveLength(10);
+        expect(groupType.fields).toHaveLength(4);
+        expect(moderatorType.fields).toHaveLength(6);
 
         const userIdFields = getIdFields(userType);
         const groupIdFields = getIdFields(groupType);

--- a/src/test/user-group-validated.graphql
+++ b/src/test/user-group-validated.graphql
@@ -4,17 +4,26 @@ type User {
   lastName: String
   role: Role
   email: EmailAddress
+  dateOfBirth: AWSDate
+  lastLoginTime: AWSDateTime
+  phoneNumber: AWSPhone
+  profilePictureUrl: AWSURL
+  ipAddress: AWSIPAddress
 }
 
 type Group {
   _id: ID! @id
   name: String
+  dailyMeetingTime: AWSTime
+  metadata: AWSJSON
 }
 
 type Moderator {
   moderatorId: ID! @id
   name: String
   moderates: Group @relationship(type: "GroupEdge", direction: OUT)
+  contactEmail: AWSEmail
+  appointedTimestamp: AWSTimestamp
   groupEdge: GroupEdge
 }
 
@@ -38,6 +47,11 @@ input UserInput {
   lastName: String
   role: Role
   email: EmailAddress
+  dateOfBirth: AWSDate
+  lastLoginTime: AWSDateTime
+  phoneNumber: AWSPhone
+  profilePictureUrl: AWSURL
+  ipAddress: AWSIPAddress
 }
 
 input UserCreateInput {
@@ -46,6 +60,11 @@ input UserCreateInput {
   lastName: String
   role: Role
   email: EmailAddress
+  dateOfBirth: AWSDate
+  lastLoginTime: AWSDateTime
+  phoneNumber: AWSPhone
+  profilePictureUrl: AWSURL
+  ipAddress: AWSIPAddress
 }
 
 input UserUpdateInput {
@@ -54,6 +73,11 @@ input UserUpdateInput {
   lastName: String
   role: Role
   email: EmailAddress
+  dateOfBirth: AWSDate
+  lastLoginTime: AWSDateTime
+  phoneNumber: AWSPhone
+  profilePictureUrl: AWSURL
+  ipAddress: AWSIPAddress
 }
 
 input UserSort {
@@ -62,46 +86,67 @@ input UserSort {
   lastName: SortDirection
   role: SortDirection
   email: SortDirection
+  dateOfBirth: SortDirection
+  lastLoginTime: SortDirection
+  phoneNumber: SortDirection
+  profilePictureUrl: SortDirection
+  ipAddress: SortDirection
 }
 
 input GroupInput {
   _id: ID! @id
   name: String
+  dailyMeetingTime: AWSTime
+  metadata: AWSJSON
 }
 
 input GroupCreateInput {
   _id: ID @id
   name: String
+  dailyMeetingTime: AWSTime
+  metadata: AWSJSON
 }
 
 input GroupUpdateInput {
   _id: ID! @id
   name: String
+  dailyMeetingTime: AWSTime
+  metadata: AWSJSON
 }
 
 input GroupSort {
   _id: SortDirection
   name: SortDirection
+  dailyMeetingTime: SortDirection
+  metadata: SortDirection
 }
 
 input ModeratorInput {
   moderatorId: ID! @id
   name: String
+  contactEmail: AWSEmail
+  appointedTimestamp: AWSTimestamp
 }
 
 input ModeratorCreateInput {
   moderatorId: ID @id
   name: String
+  contactEmail: AWSEmail
+  appointedTimestamp: AWSTimestamp
 }
 
 input ModeratorUpdateInput {
   moderatorId: ID! @id
   name: String
+  contactEmail: AWSEmail
+  appointedTimestamp: AWSTimestamp
 }
 
 input ModeratorSort {
   moderatorId: SortDirection
   name: SortDirection
+  contactEmail: SortDirection
+  appointedTimestamp: SortDirection
 }
 
 type GroupEdge {

--- a/src/test/user-group.graphql
+++ b/src/test/user-group.graphql
@@ -4,16 +4,25 @@ type User {
     lastName: String
     role: Role
     email: EmailAddress
+    dateOfBirth: AWSDate
+    lastLoginTime: AWSDateTime
+    phoneNumber: AWSPhone
+    profilePictureUrl: AWSURL
+    ipAddress: AWSIPAddress
 }
 
 type Group {
     name: String
+    dailyMeetingTime: AWSTime
+    metadata: AWSJSON
 }
 
 type Moderator {
     moderatorId: ID!
     name: String
     moderates: Group
+    contactEmail: AWSEmail
+    appointedTimestamp: AWSTimestamp
 }
 
 enum Role {

--- a/templates/Lambda4AppSyncGraphSDK/index.mjs
+++ b/templates/Lambda4AppSyncGraphSDK/index.mjs
@@ -1,6 +1,6 @@
 import { ExecuteQueryCommand, NeptuneGraphClient } from "@aws-sdk/client-neptune-graph";
 import { initSchema, resolveGraphDBQueryFromAppSyncEvent } from './output.resolver.graphql.js';
-import { decompressGzipToString } from './util.mjs';
+import { decompressGzipToString, injectAwsScalarDefinitions } from './util.mjs';
 
 const PROTOCOL = 'https';
 const QUERY_LANGUAGE = 'OPEN_CYPHER';
@@ -10,6 +10,7 @@ let client;
 
 const schemaDataModelJSON = await decompressGzipToString('output.resolver.schema.json.gz');
 const schemaModel = JSON.parse(schemaDataModelJSON);
+injectAwsScalarDefinitions(schemaModel);
 initSchema(schemaModel);
 
 function getClient() {

--- a/templates/Lambda4AppSyncHTTP/index.mjs
+++ b/templates/Lambda4AppSyncHTTP/index.mjs
@@ -3,7 +3,7 @@ import * as rax from 'retry-axios';
 import { aws4Interceptor } from "aws4-axios";
 import { initSchema, resolveGraphDBQueryFromAppSyncEvent } from './output.resolver.graphql.js';
 import { queryNeptune } from "./queryHttpNeptune.mjs";
-import { decompressGzipToString } from './util.mjs';
+import { decompressGzipToString, injectAwsScalarDefinitions } from './util.mjs';
 
 const LOGGING_ENABLED = process.env.LOGGING_ENABLED;
 
@@ -41,6 +41,7 @@ rax.attach();
 
 const schemaDataModelJSON = await decompressGzipToString('output.resolver.schema.json.gz');
 const schemaModel = JSON.parse(schemaDataModelJSON);
+injectAwsScalarDefinitions(schemaModel);
 initSchema(schemaModel);
 
 export const handler = async (event) => {

--- a/templates/Lambda4AppSyncSDK/index.mjs
+++ b/templates/Lambda4AppSyncSDK/index.mjs
@@ -8,7 +8,7 @@ import {
     refactorGremlinqueryOutput,
     resolveGraphDBQueryFromAppSyncEvent
 } from './output.resolver.graphql.js';
-import { decompressGzipToString } from './util.mjs';
+import { decompressGzipToString, injectAwsScalarDefinitions } from './util.mjs';
 
 const LOGGING_ENABLED = process.env.LOGGING_ENABLED;
 
@@ -18,6 +18,7 @@ const config = {
 
 const schemaDataModelJSON = await decompressGzipToString('output.resolver.schema.json.gz');
 const schemaModel = JSON.parse(schemaDataModelJSON);
+injectAwsScalarDefinitions(schemaModel);
 initSchema(schemaModel);
 
 let client;

--- a/templates/util.mjs
+++ b/templates/util.mjs
@@ -34,3 +34,37 @@ export function decompressGzipToString(inputFilePath) {
         readStream.pipe(gunzip);
     });
 }
+
+/**
+ * Injects AWS scalar type definitions into a GraphQL schema model.
+ *
+ * This function adds predefined AWS AppSync scalar types to the schema's definitions array.
+ *
+ * @param {Object} schemaModel - The GraphQL schema model object that contains a definitions array
+ */
+export function injectAwsScalarDefinitions(schemaModel) {
+    const awsScalarTypes = [
+        'AWSDate',
+        'AWSTime',
+        'AWSDateTime',
+        'AWSTimestamp',
+        'AWSEmail',
+        'AWSJSON',
+        'AWSPhone',
+        'AWSURL',
+        'AWSIPAddress'
+    ];
+
+    const awsScalars = awsScalarTypes
+        .map(scalarName => ({
+            kind: "ScalarTypeDefinition",
+            name: {
+                kind: "Name",
+                value: scalarName
+            },
+            directives: []
+        }));
+
+    // Add to the definitions array
+    schemaModel.definitions.push(...awsScalars);
+}


### PR DESCRIPTION
Invalid schema was generated if AWS AppSync scalars (AWSDate, AWSTime, AWSEmail, etc...) were referenced in an input schema. Updated code to recognize AWS AppSync scalars as scalar types to ensure that generated schema does not correct them as edges. 