### PR TITLE
feat: Added prefix option for query and mutation names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ permissions and limitations under the License.
   `limit` ([#102](https://github.com/aws/amazon-neptune-for-graphql/pull/102))
 * Added support for queries with
   sorting ([#105](https://github.com/aws/amazon-neptune-for-graphql/pull/105))
+* Added options to prefix query and mutation names ([#120](https://github.com/aws/amazon-neptune-for-graphql/pull/120))
 
 ### Improvements
 

--- a/doc/cliReference.md
+++ b/doc/cliReference.md
@@ -94,6 +94,14 @@ database you can edit a graphdb schema as use it as input.
 The Neptune database endpoint from which the utility extract the graphdb schema.
 Format: `host:port`
 
+`--query-prefix`
+<br>
+Optional prefix to add to generated query names in the GraphQL schema.
+
+`--mutation-prefix`
+<br>
+Optional prefix to add to generated mutation names in the GraphQL schema.
+
 ## Output options
 
 `--output-folder-path <value>, -o <value>`

--- a/src/help.js
+++ b/src/help.js
@@ -124,6 +124,8 @@ Parameters
 [--input-graphdb-schema <value>                             -ig  ]
 [--input-graphdb-schema-file <value>                        -igf ]
 [--input-graphdb-schema-neptune-endpoint <value>            -ie  ]
+[--query-prefix <value>                                     -qp  ]
+[--mutation-prefix <value>                                  -mp  ]
 
 [--output-folder-path <value>                               -o   ]  default: ./output
 [--output-schema-file <value>                               -os  ]  default: output.schema.graphql

--- a/src/main.js
+++ b/src/main.js
@@ -54,6 +54,8 @@ let inputGraphQLSchemaChangesFile = '';
 let inputGraphDBSchema = '';
 let inputGraphDBSchemaFile = '';
 let inputGraphDBSchemaNeptuneEndpoint = '';
+let inputQueryPrefix = '';
+let inputMutationPrefix = '';
 let queryLanguage = 'opencypher'; // or TODO 'gremlin' or 'sparql'
 let queryClient = 'sdk';          // or 'http'
 let isNeptuneIAMAuth = false;
@@ -167,6 +169,14 @@ function processArgs() {
             case '-og':
             case '--output-neptune-schema-file':
                 outputNeptuneSchemaFile = array[index + 1];
+            break;
+            case '-qp':
+            case '--query-prefix':
+                inputQueryPrefix = array[index + 1];
+            break;
+            case '-mp':
+            case '--mutation-prefix':
+                inputMutationPrefix = array[index + 1];
             break;
             case '-org':
             case '--output-resolver-query-gremlin':
@@ -409,7 +419,11 @@ async function main() {
     // Option 2: inference GraphQL schema from graphDB schema
     if (inputGraphDBSchema != '' && inputGraphQLSchema == '' && inputGraphQLSchemaFile == '') {
         loggerInfo('Inferencing GraphQL schema from graphDB schema', {toConsole: true});
-        inputGraphQLSchema = graphDBInferenceSchema(inputGraphDBSchema, outputSchemaMutations);
+        inputGraphQLSchema = graphDBInferenceSchema(inputGraphDBSchema, {
+            addMutations: outputSchemaMutations,
+            queryPrefix: inputQueryPrefix,
+            mutationPrefix: inputMutationPrefix
+        });
     }
 
     // Option 1: load
@@ -526,7 +540,10 @@ async function main() {
         schemaModel = schemaParser(inputGraphQLSchema);
         
         // Validate schema
-        schemaModel = validatedSchemaModel(schemaModel, quiet);
+        schemaModel = validatedSchemaModel(schemaModel, {
+            queryPrefix: inputQueryPrefix,
+            mutationPrefix: inputMutationPrefix
+        });
 
         // Generate schema for resolver
         const queryDataModelJSON = JSON.stringify(schemaModel, null, 2);

--- a/src/schemaParser.js
+++ b/src/schemaParser.js
@@ -10,15 +10,11 @@ express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 */
 
-import gql from 'graphql-tag';
-import { print, visit } from 'graphql';
+import { print, visit, parse } from 'graphql';
 
 
 function schemaParser (schema) {
-    const typeDefs = gql`
-        ${schema}
-    `;
-	return typeDefs;
+    return parse(schema);
 }
 
 function schemaStringify (schemaModel, directives = true) {

--- a/src/test/airports-mutations-mutation-prefix.graphql
+++ b/src/test/airports-mutations-mutation-prefix.graphql
@@ -1,0 +1,272 @@
+enum SortingDirection {
+  ASC
+  DESC
+}
+
+type Continent @alias(property:"continent") {
+  _id: ID! @id
+  type: String
+  code: String
+  desc: String
+  airportContainssOut(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport] @relationship(edgeType:"contains", direction:OUT)
+  contains:Contains
+}
+
+input ContinentInput {
+  _id: ID @id
+  type: StringScalarFilters
+  code: StringScalarFilters
+  desc: StringScalarFilters
+}
+
+input ContinentCreateInput {
+  _id: ID @id
+  type: String
+  code: String
+  desc: String
+}
+
+input ContinentUpdateInput {
+  _id: ID! @id
+  type: String
+  code: String
+  desc: String
+}
+
+input ContinentSort {
+  _id: SortingDirection
+  type: SortingDirection
+  code: SortingDirection
+  desc: SortingDirection
+}
+
+type Country @alias(property:"country") {
+  _id: ID! @id
+  type: String
+  code: String
+  desc: String
+  airportContainssOut(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport] @relationship(edgeType:"contains", direction:OUT)
+  contains:Contains
+}
+
+input CountryInput {
+  _id: ID @id
+  type: StringScalarFilters
+  code: StringScalarFilters
+  desc: StringScalarFilters
+}
+
+input CountryCreateInput {
+  _id: ID @id
+  type: String
+  code: String
+  desc: String
+}
+
+input CountryUpdateInput {
+  _id: ID! @id
+  type: String
+  code: String
+  desc: String
+}
+
+input CountrySort {
+  _id: SortingDirection
+  type: SortingDirection
+  code: SortingDirection
+  desc: SortingDirection
+}
+
+type Version @alias(property:"version") {
+  _id: ID! @id
+  date: String
+  desc: String
+  author: String
+  type: String
+  code: String
+}
+
+input VersionInput {
+  _id: ID @id
+  date: StringScalarFilters
+  desc: StringScalarFilters
+  author: StringScalarFilters
+  type: StringScalarFilters
+  code: StringScalarFilters
+}
+
+input VersionCreateInput {
+  _id: ID @id
+  date: String
+  desc: String
+  author: String
+  type: String
+  code: String
+}
+
+input VersionUpdateInput {
+  _id: ID! @id
+  date: String
+  desc: String
+  author: String
+  type: String
+  code: String
+}
+
+input VersionSort {
+  _id: SortingDirection
+  date: SortingDirection
+  desc: SortingDirection
+  author: SortingDirection
+  type: SortingDirection
+  code: SortingDirection
+}
+
+type Airport @alias(property:"airport") {
+  _id: ID! @id
+  type: String
+  city: String
+  icao: String
+  code: String
+  country: String
+  lat: Float
+  longest: Int
+  runways: Int
+  desc: String
+  lon: Float
+  region: String
+  elev: Int
+  continentContainsIn: Continent @relationship(edgeType:"contains", direction:IN)
+  countryContainsIn: Country @relationship(edgeType:"contains", direction:IN)
+  airportRoutesOut(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport] @relationship(edgeType:"route", direction:OUT)
+  airportRoutesIn(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport] @relationship(edgeType:"route", direction:IN)
+  contains:Contains
+  route:Route
+}
+
+input AirportInput {
+  _id: ID @id
+  type: StringScalarFilters
+  city: StringScalarFilters
+  icao: StringScalarFilters
+  code: StringScalarFilters
+  country: StringScalarFilters
+  lat: Float
+  longest: Int
+  runways: Int
+  desc: StringScalarFilters
+  lon: Float
+  region: StringScalarFilters
+  elev: Int
+}
+
+input AirportCreateInput {
+  _id: ID @id
+  type: String
+  city: String
+  icao: String
+  code: String
+  country: String
+  lat: Float
+  longest: Int
+  runways: Int
+  desc: String
+  lon: Float
+  region: String
+  elev: Int
+}
+
+input AirportUpdateInput {
+  _id: ID! @id
+  type: String
+  city: String
+  icao: String
+  code: String
+  country: String
+  lat: Float
+  longest: Int
+  runways: Int
+  desc: String
+  lon: Float
+  region: String
+  elev: Int
+}
+
+input AirportSort {
+  _id: SortingDirection
+  type: SortingDirection
+  city: SortingDirection
+  icao: SortingDirection
+  code: SortingDirection
+  country: SortingDirection
+  lat: SortingDirection
+  longest: SortingDirection
+  runways: SortingDirection
+  desc: SortingDirection
+  lon: SortingDirection
+  region: SortingDirection
+  elev: SortingDirection
+}
+
+type Contains @alias(property:"contains") {
+  _id: ID! @id
+}
+
+type Route @alias(property:"route") {
+  _id: ID! @id
+  dist: Int
+}
+
+input RouteInput {
+  dist: Int
+}
+
+input Options {
+  limit:Int
+  offset: Int
+}
+
+input StringScalarFilters {
+  eq: String
+  contains: String
+  endsWith: String
+  startsWith: String
+}
+
+type Query {
+  getNodeContinent(filter: ContinentInput): Continent
+  getNodeContinents(filter: ContinentInput, options: Options, sort: [ContinentSort!]): [Continent]
+  getNodeCountry(filter: CountryInput): Country
+  getNodeCountrys(filter: CountryInput, options: Options, sort: [CountrySort!]): [Country]
+  getNodeVersion(filter: VersionInput): Version
+  getNodeVersions(filter: VersionInput, options: Options, sort: [VersionSort!]): [Version]
+  getNodeAirport(filter: AirportInput): Airport
+  getNodeAirports(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport]
+}
+
+type Mutation {
+  airportsMutation_createNodeContinent(input: ContinentCreateInput!): Continent
+  airportsMutation_updateNodeContinent(input: ContinentUpdateInput!): Continent
+  airportsMutation_deleteNodeContinent(_id: ID!): Boolean
+  airportsMutation_createNodeCountry(input: CountryCreateInput!): Country
+  airportsMutation_updateNodeCountry(input: CountryUpdateInput!): Country
+  airportsMutation_deleteNodeCountry(_id: ID!): Boolean
+  airportsMutation_createNodeVersion(input: VersionCreateInput!): Version
+  airportsMutation_updateNodeVersion(input: VersionUpdateInput!): Version
+  airportsMutation_deleteNodeVersion(_id: ID!): Boolean
+  airportsMutation_createNodeAirport(input: AirportCreateInput!): Airport
+  airportsMutation_updateNodeAirport(input: AirportUpdateInput!): Airport
+  airportsMutation_deleteNodeAirport(_id: ID!): Boolean
+  airportsMutation_connectNodeContinentToNodeAirportEdgeContains(from_id: ID!, to_id: ID!): Contains
+  airportsMutation_deleteEdgeContainsFromContinentToAirport(from_id: ID!, to_id: ID!): Boolean
+  airportsMutation_connectNodeCountryToNodeAirportEdgeContains(from_id: ID!, to_id: ID!): Contains
+  airportsMutation_deleteEdgeContainsFromCountryToAirport(from_id: ID!, to_id: ID!): Boolean
+  airportsMutation_connectNodeAirportToNodeAirportEdgeRoute(from_id: ID!, to_id: ID!, edge: RouteInput!): Route
+  airportsMutation_updateEdgeRouteFromAirportToAirport(from_id: ID!, to_id: ID!, edge: RouteInput!): Route
+  airportsMutation_deleteEdgeRouteFromAirportToAirport(from_id: ID!, to_id: ID!): Boolean
+}
+
+schema {
+  query: Query
+  mutation: Mutation
+}

--- a/src/test/airports-mutations-query-prefix.graphql
+++ b/src/test/airports-mutations-query-prefix.graphql
@@ -1,0 +1,272 @@
+enum SortingDirection {
+  ASC
+  DESC
+}
+
+type Continent @alias(property:"continent") {
+  _id: ID! @id
+  type: String
+  code: String
+  desc: String
+  airportContainssOut(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport] @relationship(edgeType:"contains", direction:OUT)
+  contains:Contains
+}
+
+input ContinentInput {
+  _id: ID @id
+  type: StringScalarFilters
+  code: StringScalarFilters
+  desc: StringScalarFilters
+}
+
+input ContinentCreateInput {
+  _id: ID @id
+  type: String
+  code: String
+  desc: String
+}
+
+input ContinentUpdateInput {
+  _id: ID! @id
+  type: String
+  code: String
+  desc: String
+}
+
+input ContinentSort {
+  _id: SortingDirection
+  type: SortingDirection
+  code: SortingDirection
+  desc: SortingDirection
+}
+
+type Country @alias(property:"country") {
+  _id: ID! @id
+  type: String
+  code: String
+  desc: String
+  airportContainssOut(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport] @relationship(edgeType:"contains", direction:OUT)
+  contains:Contains
+}
+
+input CountryInput {
+  _id: ID @id
+  type: StringScalarFilters
+  code: StringScalarFilters
+  desc: StringScalarFilters
+}
+
+input CountryCreateInput {
+  _id: ID @id
+  type: String
+  code: String
+  desc: String
+}
+
+input CountryUpdateInput {
+  _id: ID! @id
+  type: String
+  code: String
+  desc: String
+}
+
+input CountrySort {
+  _id: SortingDirection
+  type: SortingDirection
+  code: SortingDirection
+  desc: SortingDirection
+}
+
+type Version @alias(property:"version") {
+  _id: ID! @id
+  date: String
+  desc: String
+  author: String
+  type: String
+  code: String
+}
+
+input VersionInput {
+  _id: ID @id
+  date: StringScalarFilters
+  desc: StringScalarFilters
+  author: StringScalarFilters
+  type: StringScalarFilters
+  code: StringScalarFilters
+}
+
+input VersionCreateInput {
+  _id: ID @id
+  date: String
+  desc: String
+  author: String
+  type: String
+  code: String
+}
+
+input VersionUpdateInput {
+  _id: ID! @id
+  date: String
+  desc: String
+  author: String
+  type: String
+  code: String
+}
+
+input VersionSort {
+  _id: SortingDirection
+  date: SortingDirection
+  desc: SortingDirection
+  author: SortingDirection
+  type: SortingDirection
+  code: SortingDirection
+}
+
+type Airport @alias(property:"airport") {
+  _id: ID! @id
+  type: String
+  city: String
+  icao: String
+  code: String
+  country: String
+  lat: Float
+  longest: Int
+  runways: Int
+  desc: String
+  lon: Float
+  region: String
+  elev: Int
+  continentContainsIn: Continent @relationship(edgeType:"contains", direction:IN)
+  countryContainsIn: Country @relationship(edgeType:"contains", direction:IN)
+  airportRoutesOut(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport] @relationship(edgeType:"route", direction:OUT)
+  airportRoutesIn(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport] @relationship(edgeType:"route", direction:IN)
+  contains:Contains
+  route:Route
+}
+
+input AirportInput {
+  _id: ID @id
+  type: StringScalarFilters
+  city: StringScalarFilters
+  icao: StringScalarFilters
+  code: StringScalarFilters
+  country: StringScalarFilters
+  lat: Float
+  longest: Int
+  runways: Int
+  desc: StringScalarFilters
+  lon: Float
+  region: StringScalarFilters
+  elev: Int
+}
+
+input AirportCreateInput {
+  _id: ID @id
+  type: String
+  city: String
+  icao: String
+  code: String
+  country: String
+  lat: Float
+  longest: Int
+  runways: Int
+  desc: String
+  lon: Float
+  region: String
+  elev: Int
+}
+
+input AirportUpdateInput {
+  _id: ID! @id
+  type: String
+  city: String
+  icao: String
+  code: String
+  country: String
+  lat: Float
+  longest: Int
+  runways: Int
+  desc: String
+  lon: Float
+  region: String
+  elev: Int
+}
+
+input AirportSort {
+  _id: SortingDirection
+  type: SortingDirection
+  city: SortingDirection
+  icao: SortingDirection
+  code: SortingDirection
+  country: SortingDirection
+  lat: SortingDirection
+  longest: SortingDirection
+  runways: SortingDirection
+  desc: SortingDirection
+  lon: SortingDirection
+  region: SortingDirection
+  elev: SortingDirection
+}
+
+type Contains @alias(property:"contains") {
+  _id: ID! @id
+}
+
+type Route @alias(property:"route") {
+  _id: ID! @id
+  dist: Int
+}
+
+input RouteInput {
+  dist: Int
+}
+
+input Options {
+  limit:Int
+  offset: Int
+}
+
+input StringScalarFilters {
+  eq: String
+  contains: String
+  endsWith: String
+  startsWith: String
+}
+
+type Query {
+  airportsQuery_getNodeContinent(filter: ContinentInput): Continent
+  airportsQuery_getNodeContinents(filter: ContinentInput, options: Options, sort: [ContinentSort!]): [Continent]
+  airportsQuery_getNodeCountry(filter: CountryInput): Country
+  airportsQuery_getNodeCountrys(filter: CountryInput, options: Options, sort: [CountrySort!]): [Country]
+  airportsQuery_getNodeVersion(filter: VersionInput): Version
+  airportsQuery_getNodeVersions(filter: VersionInput, options: Options, sort: [VersionSort!]): [Version]
+  airportsQuery_getNodeAirport(filter: AirportInput): Airport
+  airportsQuery_getNodeAirports(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport]
+}
+
+type Mutation {
+  createNodeContinent(input: ContinentCreateInput!): Continent
+  updateNodeContinent(input: ContinentUpdateInput!): Continent
+  deleteNodeContinent(_id: ID!): Boolean
+  createNodeCountry(input: CountryCreateInput!): Country
+  updateNodeCountry(input: CountryUpdateInput!): Country
+  deleteNodeCountry(_id: ID!): Boolean
+  createNodeVersion(input: VersionCreateInput!): Version
+  updateNodeVersion(input: VersionUpdateInput!): Version
+  deleteNodeVersion(_id: ID!): Boolean
+  createNodeAirport(input: AirportCreateInput!): Airport
+  updateNodeAirport(input: AirportUpdateInput!): Airport
+  deleteNodeAirport(_id: ID!): Boolean
+  connectNodeContinentToNodeAirportEdgeContains(from_id: ID!, to_id: ID!): Contains
+  deleteEdgeContainsFromContinentToAirport(from_id: ID!, to_id: ID!): Boolean
+  connectNodeCountryToNodeAirportEdgeContains(from_id: ID!, to_id: ID!): Contains
+  deleteEdgeContainsFromCountryToAirport(from_id: ID!, to_id: ID!): Boolean
+  connectNodeAirportToNodeAirportEdgeRoute(from_id: ID!, to_id: ID!, edge: RouteInput!): Route
+  updateEdgeRouteFromAirportToAirport(from_id: ID!, to_id: ID!, edge: RouteInput!): Route
+  deleteEdgeRouteFromAirportToAirport(from_id: ID!, to_id: ID!): Boolean
+}
+
+schema {
+  query: Query
+  mutation: Mutation
+}

--- a/src/test/airports-mutations-with-prefixes.graphql
+++ b/src/test/airports-mutations-with-prefixes.graphql
@@ -1,0 +1,272 @@
+enum SortingDirection {
+  ASC
+  DESC
+}
+
+type Continent @alias(property:"continent") {
+  _id: ID! @id
+  type: String
+  code: String
+  desc: String
+  airportContainssOut(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport] @relationship(edgeType:"contains", direction:OUT)
+  contains:Contains
+}
+
+input ContinentInput {
+  _id: ID @id
+  type: StringScalarFilters
+  code: StringScalarFilters
+  desc: StringScalarFilters
+}
+
+input ContinentCreateInput {
+  _id: ID @id
+  type: String
+  code: String
+  desc: String
+}
+
+input ContinentUpdateInput {
+  _id: ID! @id
+  type: String
+  code: String
+  desc: String
+}
+
+input ContinentSort {
+  _id: SortingDirection
+  type: SortingDirection
+  code: SortingDirection
+  desc: SortingDirection
+}
+
+type Country @alias(property:"country") {
+  _id: ID! @id
+  type: String
+  code: String
+  desc: String
+  airportContainssOut(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport] @relationship(edgeType:"contains", direction:OUT)
+  contains:Contains
+}
+
+input CountryInput {
+  _id: ID @id
+  type: StringScalarFilters
+  code: StringScalarFilters
+  desc: StringScalarFilters
+}
+
+input CountryCreateInput {
+  _id: ID @id
+  type: String
+  code: String
+  desc: String
+}
+
+input CountryUpdateInput {
+  _id: ID! @id
+  type: String
+  code: String
+  desc: String
+}
+
+input CountrySort {
+  _id: SortingDirection
+  type: SortingDirection
+  code: SortingDirection
+  desc: SortingDirection
+}
+
+type Version @alias(property:"version") {
+  _id: ID! @id
+  date: String
+  desc: String
+  author: String
+  type: String
+  code: String
+}
+
+input VersionInput {
+  _id: ID @id
+  date: StringScalarFilters
+  desc: StringScalarFilters
+  author: StringScalarFilters
+  type: StringScalarFilters
+  code: StringScalarFilters
+}
+
+input VersionCreateInput {
+  _id: ID @id
+  date: String
+  desc: String
+  author: String
+  type: String
+  code: String
+}
+
+input VersionUpdateInput {
+  _id: ID! @id
+  date: String
+  desc: String
+  author: String
+  type: String
+  code: String
+}
+
+input VersionSort {
+  _id: SortingDirection
+  date: SortingDirection
+  desc: SortingDirection
+  author: SortingDirection
+  type: SortingDirection
+  code: SortingDirection
+}
+
+type Airport @alias(property:"airport") {
+  _id: ID! @id
+  type: String
+  city: String
+  icao: String
+  code: String
+  country: String
+  lat: Float
+  longest: Int
+  runways: Int
+  desc: String
+  lon: Float
+  region: String
+  elev: Int
+  continentContainsIn: Continent @relationship(edgeType:"contains", direction:IN)
+  countryContainsIn: Country @relationship(edgeType:"contains", direction:IN)
+  airportRoutesOut(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport] @relationship(edgeType:"route", direction:OUT)
+  airportRoutesIn(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport] @relationship(edgeType:"route", direction:IN)
+  contains:Contains
+  route:Route
+}
+
+input AirportInput {
+  _id: ID @id
+  type: StringScalarFilters
+  city: StringScalarFilters
+  icao: StringScalarFilters
+  code: StringScalarFilters
+  country: StringScalarFilters
+  lat: Float
+  longest: Int
+  runways: Int
+  desc: StringScalarFilters
+  lon: Float
+  region: StringScalarFilters
+  elev: Int
+}
+
+input AirportCreateInput {
+  _id: ID @id
+  type: String
+  city: String
+  icao: String
+  code: String
+  country: String
+  lat: Float
+  longest: Int
+  runways: Int
+  desc: String
+  lon: Float
+  region: String
+  elev: Int
+}
+
+input AirportUpdateInput {
+  _id: ID! @id
+  type: String
+  city: String
+  icao: String
+  code: String
+  country: String
+  lat: Float
+  longest: Int
+  runways: Int
+  desc: String
+  lon: Float
+  region: String
+  elev: Int
+}
+
+input AirportSort {
+  _id: SortingDirection
+  type: SortingDirection
+  city: SortingDirection
+  icao: SortingDirection
+  code: SortingDirection
+  country: SortingDirection
+  lat: SortingDirection
+  longest: SortingDirection
+  runways: SortingDirection
+  desc: SortingDirection
+  lon: SortingDirection
+  region: SortingDirection
+  elev: SortingDirection
+}
+
+type Contains @alias(property:"contains") {
+  _id: ID! @id
+}
+
+type Route @alias(property:"route") {
+  _id: ID! @id
+  dist: Int
+}
+
+input RouteInput {
+  dist: Int
+}
+
+input Options {
+  limit:Int
+  offset: Int
+}
+
+input StringScalarFilters {
+  eq: String
+  contains: String
+  endsWith: String
+  startsWith: String
+}
+
+type Query {
+  airportsQueryTest_getNodeContinent(filter: ContinentInput): Continent
+  airportsQueryTest_getNodeContinents(filter: ContinentInput, options: Options, sort: [ContinentSort!]): [Continent]
+  airportsQueryTest_getNodeCountry(filter: CountryInput): Country
+  airportsQueryTest_getNodeCountrys(filter: CountryInput, options: Options, sort: [CountrySort!]): [Country]
+  airportsQueryTest_getNodeVersion(filter: VersionInput): Version
+  airportsQueryTest_getNodeVersions(filter: VersionInput, options: Options, sort: [VersionSort!]): [Version]
+  airportsQueryTest_getNodeAirport(filter: AirportInput): Airport
+  airportsQueryTest_getNodeAirports(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport]
+}
+
+type Mutation {
+  airportsMutationTest_createNodeContinent(input: ContinentCreateInput!): Continent
+  airportsMutationTest_updateNodeContinent(input: ContinentUpdateInput!): Continent
+  airportsMutationTest_deleteNodeContinent(_id: ID!): Boolean
+  airportsMutationTest_createNodeCountry(input: CountryCreateInput!): Country
+  airportsMutationTest_updateNodeCountry(input: CountryUpdateInput!): Country
+  airportsMutationTest_deleteNodeCountry(_id: ID!): Boolean
+  airportsMutationTest_createNodeVersion(input: VersionCreateInput!): Version
+  airportsMutationTest_updateNodeVersion(input: VersionUpdateInput!): Version
+  airportsMutationTest_deleteNodeVersion(_id: ID!): Boolean
+  airportsMutationTest_createNodeAirport(input: AirportCreateInput!): Airport
+  airportsMutationTest_updateNodeAirport(input: AirportUpdateInput!): Airport
+  airportsMutationTest_deleteNodeAirport(_id: ID!): Boolean
+  airportsMutationTest_connectNodeContinentToNodeAirportEdgeContains(from_id: ID!, to_id: ID!): Contains
+  airportsMutationTest_deleteEdgeContainsFromContinentToAirport(from_id: ID!, to_id: ID!): Boolean
+  airportsMutationTest_connectNodeCountryToNodeAirportEdgeContains(from_id: ID!, to_id: ID!): Contains
+  airportsMutationTest_deleteEdgeContainsFromCountryToAirport(from_id: ID!, to_id: ID!): Boolean
+  airportsMutationTest_connectNodeAirportToNodeAirportEdgeRoute(from_id: ID!, to_id: ID!, edge: RouteInput!): Route
+  airportsMutationTest_updateEdgeRouteFromAirportToAirport(from_id: ID!, to_id: ID!, edge: RouteInput!): Route
+  airportsMutationTest_deleteEdgeRouteFromAirportToAirport(from_id: ID!, to_id: ID!): Boolean
+}
+
+schema {
+  query: Query
+  mutation: Mutation
+}

--- a/src/test/airports.customized.graphql
+++ b/src/test/airports.customized.graphql
@@ -291,6 +291,7 @@ getNodeCountrys(filter: CountryInput, options: Options, sort: [CountrySort!]): [
 getNodeVersion(filter: VersionInput): Version
 getNodeVersions(filter: VersionInput, options: Options, sort: [VersionSort!]): [Version]
 getNodeAirport(filter: AirportInput): Airport
+airportQuery_getNodeAirport(filter: AirportInput): Airport
 getNodeAirports(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport]
 getAirportWithGremlin(code: String): Airport @graphQuery(statement: "g.V().has('airport', 'code', '$code').elementMap()")
 getCountriesCount: Int @graphQuery(statement: "g.V().hasLabel('country').count()")
@@ -298,10 +299,15 @@ getCountriesCount: Int @graphQuery(statement: "g.V().hasLabel('country').count()
 
 type Mutation {
 createNodeAirport(input: AirportCreateInput!): Airport
+airportMutation_createNodeAirport(input: AirportCreateInput!): Airport
 updateNodeAirport(input: AirportUpdateInput!): Airport
+airportMutation_updateNodeAirport(input: AirportUpdateInput!): Airport
 connectNodeCountryToNodeAirportEdgeContains(from_id: ID!, to_id: ID!): Contains
+airportMutation_connectNodeCountryToNodeAirportEdgeContains(from_id: ID!, to_id: ID!): Contains
 deleteEdgeContainsFromCountryToAirport(from_id: ID!, to_id: ID!): Boolean
+airportMutation_deleteEdgeContainsFromCountryToAirport(from_id: ID!, to_id: ID!): Boolean
 updateEdgeRouteFromAirportToAirport(from_id: ID!, to_id: ID!, edge: RouteInput!): Route
+airportMutation_updateEdgeRouteFromAirportToAirport(from_id: ID!, to_id: ID!, edge: RouteInput!): Route
 createAirport(input: AirportCreateInput!): Airport @graphQuery(statement: "CREATE (this:airport {$input}) RETURN this")
 }
 

--- a/src/test/graphdb.test.js
+++ b/src/test/graphdb.test.js
@@ -4,7 +4,7 @@ import { loggerInit } from "../logger.js";
 import * as prettier from "prettier";
 
 test('node with same property and edge label should add underscore prefix', () => {
-    expect(graphDBInferenceSchema(readFile('./src/test/node-edge-same-property-neptune-schema.json'), false)).toContain('_commonName:Commonname');
+    expect(graphDBInferenceSchema(readFile('./src/test/node-edge-same-property-neptune-schema.json'))).toContain('_commonName:Commonname');
 });
 
 test('should properly replace special chars in schema', async () => {
@@ -28,6 +28,34 @@ test('should output airport schema', async () => {
 test('should correctly generate mutation input types after outputting airport schema', async () => {
     const actual = await inferGraphQLSchema('./src/test/airports-neptune-schema.json', { addMutations: true });
     const expected = await loadGraphQLSchema('./src/test/airports-mutations.graphql');
+    expect(actual).toBe(expected);
+});
+
+test('should correctly generate airport schema with query prefixes', async () => {
+    const actual = await inferGraphQLSchema('./src/test/airports-neptune-schema.json', {
+        addMutations: true,
+        queryPrefix: 'airportsQuery_'
+    });
+    const expected = await loadGraphQLSchema('./src/test/airports-mutations-query-prefix.graphql');
+    expect(actual).toBe(expected);
+});
+
+test('should correctly generate airport schema with mutation prefixes', async () => {
+    const actual = await inferGraphQLSchema('./src/test/airports-neptune-schema.json', {
+        addMutations: true,
+        mutationPrefix: 'airportsMutation_'
+    });
+    const expected = await loadGraphQLSchema('./src/test/airports-mutations-mutation-prefix.graphql');
+    expect(actual).toBe(expected);
+});
+
+test('should correctly generate airport schema with both query and mutation prefixes', async () => {
+    const actual = await inferGraphQLSchema('./src/test/airports-neptune-schema.json', {
+        addMutations: true,
+        queryPrefix: 'airportsQueryTest_',
+        mutationPrefix: 'airportsMutationTest_'
+    });
+    const expected = await loadGraphQLSchema('./src/test/airports-mutations-with-prefixes.graphql');
     expect(actual).toBe(expected);
 });
 
@@ -68,9 +96,9 @@ test('should alias edge with same label as node', async () => {
     expect(actual).toBe(expected);
 });
 
-async function inferGraphQLSchema(neptuneSchemaFilePath, options = { addMutations: false }) {
+async function inferGraphQLSchema(neptuneSchemaFilePath, { addMutations = false, queryPrefix = '', mutationPrefix = ''} = {}) {
     let neptuneSchema = readFile(neptuneSchemaFilePath);
-    let inferredSchema = graphDBInferenceSchema(neptuneSchema, options.addMutations);
+    let inferredSchema = graphDBInferenceSchema(neptuneSchema, {addMutations, queryPrefix, mutationPrefix});
     return await sanitizeWhitespace(inferredSchema);
 }
 

--- a/src/test/user-group-validated-with-mutation-prefix.graphql
+++ b/src/test/user-group-validated-with-mutation-prefix.graphql
@@ -1,0 +1,194 @@
+type User {
+  userId: ID! @id
+  firstName: String
+  lastName: String
+  role: Role
+  email: EmailAddress
+  dateOfBirth: AWSDate
+  lastLoginTime: AWSDateTime
+  phoneNumber: AWSPhone
+  profilePictureUrl: AWSURL
+  ipAddress: AWSIPAddress
+}
+
+type Group {
+  _id: ID! @id
+  name: String
+  dailyMeetingTime: AWSTime
+  metadata: AWSJSON
+}
+
+type Moderator {
+  moderatorId: ID! @id
+  name: String
+  moderates: Group @relationship(type: "GroupEdge", direction: OUT)
+  contactEmail: AWSEmail
+  appointedTimestamp: AWSTimestamp
+  groupEdge: GroupEdge
+}
+
+enum Role {
+  ADMIN
+  USER
+  GUEST
+}
+
+"https://the-guild.dev/graphql/scalars/docs/scalars/email-address"
+scalar EmailAddress
+
+enum SortDirection {
+  ASC
+  DESC
+}
+
+input UserInput {
+  userId: ID! @id
+  firstName: String
+  lastName: String
+  role: Role
+  email: EmailAddress
+  dateOfBirth: AWSDate
+  lastLoginTime: AWSDateTime
+  phoneNumber: AWSPhone
+  profilePictureUrl: AWSURL
+  ipAddress: AWSIPAddress
+}
+
+input UserCreateInput {
+  userId: ID @id
+  firstName: String
+  lastName: String
+  role: Role
+  email: EmailAddress
+  dateOfBirth: AWSDate
+  lastLoginTime: AWSDateTime
+  phoneNumber: AWSPhone
+  profilePictureUrl: AWSURL
+  ipAddress: AWSIPAddress
+}
+
+input UserUpdateInput {
+  userId: ID! @id
+  firstName: String
+  lastName: String
+  role: Role
+  email: EmailAddress
+  dateOfBirth: AWSDate
+  lastLoginTime: AWSDateTime
+  phoneNumber: AWSPhone
+  profilePictureUrl: AWSURL
+  ipAddress: AWSIPAddress
+}
+
+input UserSort {
+  userId: SortDirection
+  firstName: SortDirection
+  lastName: SortDirection
+  role: SortDirection
+  email: SortDirection
+  dateOfBirth: SortDirection
+  lastLoginTime: SortDirection
+  phoneNumber: SortDirection
+  profilePictureUrl: SortDirection
+  ipAddress: SortDirection
+}
+
+input GroupInput {
+  _id: ID! @id
+  name: String
+  dailyMeetingTime: AWSTime
+  metadata: AWSJSON
+}
+
+input GroupCreateInput {
+  _id: ID @id
+  name: String
+  dailyMeetingTime: AWSTime
+  metadata: AWSJSON
+}
+
+input GroupUpdateInput {
+  _id: ID! @id
+  name: String
+  dailyMeetingTime: AWSTime
+  metadata: AWSJSON
+}
+
+input GroupSort {
+  _id: SortDirection
+  name: SortDirection
+  dailyMeetingTime: SortDirection
+  metadata: SortDirection
+}
+
+input ModeratorInput {
+  moderatorId: ID! @id
+  name: String
+  contactEmail: AWSEmail
+  appointedTimestamp: AWSTimestamp
+}
+
+input ModeratorCreateInput {
+  moderatorId: ID @id
+  name: String
+  contactEmail: AWSEmail
+  appointedTimestamp: AWSTimestamp
+}
+
+input ModeratorUpdateInput {
+  moderatorId: ID! @id
+  name: String
+  contactEmail: AWSEmail
+  appointedTimestamp: AWSTimestamp
+}
+
+input ModeratorSort {
+  moderatorId: SortDirection
+  name: SortDirection
+  contactEmail: SortDirection
+  appointedTimestamp: SortDirection
+}
+
+type GroupEdge {
+  _id: ID! @id
+}
+
+input Options {
+  limit: Int
+  offset: Int
+}
+
+input StringScalarFilters {
+  eq: String
+  contains: String
+  endsWith: String
+  startsWith: String
+}
+
+type Query {
+  getNodeUser(filter: UserInput): User
+  getNodeUsers(filter: UserInput, options: Options, sort: [UserSort!]): [User]
+  getNodeGroup(filter: GroupInput): Group
+  getNodeGroups(filter: GroupInput, options: Options, sort: [GroupSort!]): [Group]
+  getNodeModerator(filter: ModeratorInput): Moderator
+  getNodeModerators(filter: ModeratorInput, options: Options, sort: [ModeratorSort!]): [Moderator]
+}
+
+type Mutation {
+  userGroupMutation_createNodeUser(input: UserCreateInput!): User
+  userGroupMutation_updateNodeUser(input: UserUpdateInput!): User
+  userGroupMutation_deleteNodeUser(userId: ID!): Boolean
+  userGroupMutation_createNodeGroup(input: GroupCreateInput!): Group
+  userGroupMutation_updateNodeGroup(input: GroupUpdateInput!): Group
+  userGroupMutation_deleteNodeGroup(_id: ID!): Boolean
+  userGroupMutation_createNodeModerator(input: ModeratorCreateInput!): Moderator
+  userGroupMutation_updateNodeModerator(input: ModeratorUpdateInput!): Moderator
+  userGroupMutation_deleteNodeModerator(moderatorId: ID!): Boolean
+  userGroupMutation_connectNodeModeratorToNodeGroupEdgeGroupEdge(from_id: ID!, to_id: ID!): GroupEdge
+  userGroupMutation_deleteEdgeGroupEdgeFromModeratorToGroup(from_id: ID!, to_id: ID!): Boolean
+}
+
+schema {
+  query: Query
+  mutation: Mutation
+}

--- a/src/test/user-group-validated-with-prefixes.graphql
+++ b/src/test/user-group-validated-with-prefixes.graphql
@@ -1,0 +1,194 @@
+type User {
+  userId: ID! @id
+  firstName: String
+  lastName: String
+  role: Role
+  email: EmailAddress
+  dateOfBirth: AWSDate
+  lastLoginTime: AWSDateTime
+  phoneNumber: AWSPhone
+  profilePictureUrl: AWSURL
+  ipAddress: AWSIPAddress
+}
+
+type Group {
+  _id: ID! @id
+  name: String
+  dailyMeetingTime: AWSTime
+  metadata: AWSJSON
+}
+
+type Moderator {
+  moderatorId: ID! @id
+  name: String
+  moderates: Group @relationship(type: "GroupEdge", direction: OUT)
+  contactEmail: AWSEmail
+  appointedTimestamp: AWSTimestamp
+  groupEdge: GroupEdge
+}
+
+enum Role {
+  ADMIN
+  USER
+  GUEST
+}
+
+"https://the-guild.dev/graphql/scalars/docs/scalars/email-address"
+scalar EmailAddress
+
+enum SortDirection {
+  ASC
+  DESC
+}
+
+input UserInput {
+  userId: ID! @id
+  firstName: String
+  lastName: String
+  role: Role
+  email: EmailAddress
+  dateOfBirth: AWSDate
+  lastLoginTime: AWSDateTime
+  phoneNumber: AWSPhone
+  profilePictureUrl: AWSURL
+  ipAddress: AWSIPAddress
+}
+
+input UserCreateInput {
+  userId: ID @id
+  firstName: String
+  lastName: String
+  role: Role
+  email: EmailAddress
+  dateOfBirth: AWSDate
+  lastLoginTime: AWSDateTime
+  phoneNumber: AWSPhone
+  profilePictureUrl: AWSURL
+  ipAddress: AWSIPAddress
+}
+
+input UserUpdateInput {
+  userId: ID! @id
+  firstName: String
+  lastName: String
+  role: Role
+  email: EmailAddress
+  dateOfBirth: AWSDate
+  lastLoginTime: AWSDateTime
+  phoneNumber: AWSPhone
+  profilePictureUrl: AWSURL
+  ipAddress: AWSIPAddress
+}
+
+input UserSort {
+  userId: SortDirection
+  firstName: SortDirection
+  lastName: SortDirection
+  role: SortDirection
+  email: SortDirection
+  dateOfBirth: SortDirection
+  lastLoginTime: SortDirection
+  phoneNumber: SortDirection
+  profilePictureUrl: SortDirection
+  ipAddress: SortDirection
+}
+
+input GroupInput {
+  _id: ID! @id
+  name: String
+  dailyMeetingTime: AWSTime
+  metadata: AWSJSON
+}
+
+input GroupCreateInput {
+  _id: ID @id
+  name: String
+  dailyMeetingTime: AWSTime
+  metadata: AWSJSON
+}
+
+input GroupUpdateInput {
+  _id: ID! @id
+  name: String
+  dailyMeetingTime: AWSTime
+  metadata: AWSJSON
+}
+
+input GroupSort {
+  _id: SortDirection
+  name: SortDirection
+  dailyMeetingTime: SortDirection
+  metadata: SortDirection
+}
+
+input ModeratorInput {
+  moderatorId: ID! @id
+  name: String
+  contactEmail: AWSEmail
+  appointedTimestamp: AWSTimestamp
+}
+
+input ModeratorCreateInput {
+  moderatorId: ID @id
+  name: String
+  contactEmail: AWSEmail
+  appointedTimestamp: AWSTimestamp
+}
+
+input ModeratorUpdateInput {
+  moderatorId: ID! @id
+  name: String
+  contactEmail: AWSEmail
+  appointedTimestamp: AWSTimestamp
+}
+
+input ModeratorSort {
+  moderatorId: SortDirection
+  name: SortDirection
+  contactEmail: SortDirection
+  appointedTimestamp: SortDirection
+}
+
+type GroupEdge {
+  _id: ID! @id
+}
+
+input Options {
+  limit: Int
+  offset: Int
+}
+
+input StringScalarFilters {
+  eq: String
+  contains: String
+  endsWith: String
+  startsWith: String
+}
+
+type Query {
+  userGroupQueryTest_getNodeUser(filter: UserInput): User
+  userGroupQueryTest_getNodeUsers(filter: UserInput, options: Options, sort: [UserSort!]): [User]
+  userGroupQueryTest_getNodeGroup(filter: GroupInput): Group
+  userGroupQueryTest_getNodeGroups(filter: GroupInput, options: Options, sort: [GroupSort!]): [Group]
+  userGroupQueryTest_getNodeModerator(filter: ModeratorInput): Moderator
+  userGroupQueryTest_getNodeModerators(filter: ModeratorInput, options: Options, sort: [ModeratorSort!]): [Moderator]
+}
+
+type Mutation {
+  userGroupMutationTest_createNodeUser(input: UserCreateInput!): User
+  userGroupMutationTest_updateNodeUser(input: UserUpdateInput!): User
+  userGroupMutationTest_deleteNodeUser(userId: ID!): Boolean
+  userGroupMutationTest_createNodeGroup(input: GroupCreateInput!): Group
+  userGroupMutationTest_updateNodeGroup(input: GroupUpdateInput!): Group
+  userGroupMutationTest_deleteNodeGroup(_id: ID!): Boolean
+  userGroupMutationTest_createNodeModerator(input: ModeratorCreateInput!): Moderator
+  userGroupMutationTest_updateNodeModerator(input: ModeratorUpdateInput!): Moderator
+  userGroupMutationTest_deleteNodeModerator(moderatorId: ID!): Boolean
+  userGroupMutationTest_connectNodeModeratorToNodeGroupEdgeGroupEdge(from_id: ID!, to_id: ID!): GroupEdge
+  userGroupMutationTest_deleteEdgeGroupEdgeFromModeratorToGroup(from_id: ID!, to_id: ID!): Boolean
+}
+
+schema {
+  query: Query
+  mutation: Mutation
+}

--- a/src/test/user-group-validated-with-query-prefix.graphql
+++ b/src/test/user-group-validated-with-query-prefix.graphql
@@ -1,0 +1,194 @@
+type User {
+  userId: ID! @id
+  firstName: String
+  lastName: String
+  role: Role
+  email: EmailAddress
+  dateOfBirth: AWSDate
+  lastLoginTime: AWSDateTime
+  phoneNumber: AWSPhone
+  profilePictureUrl: AWSURL
+  ipAddress: AWSIPAddress
+}
+
+type Group {
+  _id: ID! @id
+  name: String
+  dailyMeetingTime: AWSTime
+  metadata: AWSJSON
+}
+
+type Moderator {
+  moderatorId: ID! @id
+  name: String
+  moderates: Group @relationship(type: "GroupEdge", direction: OUT)
+  contactEmail: AWSEmail
+  appointedTimestamp: AWSTimestamp
+  groupEdge: GroupEdge
+}
+
+enum Role {
+  ADMIN
+  USER
+  GUEST
+}
+
+"https://the-guild.dev/graphql/scalars/docs/scalars/email-address"
+scalar EmailAddress
+
+enum SortDirection {
+  ASC
+  DESC
+}
+
+input UserInput {
+  userId: ID! @id
+  firstName: String
+  lastName: String
+  role: Role
+  email: EmailAddress
+  dateOfBirth: AWSDate
+  lastLoginTime: AWSDateTime
+  phoneNumber: AWSPhone
+  profilePictureUrl: AWSURL
+  ipAddress: AWSIPAddress
+}
+
+input UserCreateInput {
+  userId: ID @id
+  firstName: String
+  lastName: String
+  role: Role
+  email: EmailAddress
+  dateOfBirth: AWSDate
+  lastLoginTime: AWSDateTime
+  phoneNumber: AWSPhone
+  profilePictureUrl: AWSURL
+  ipAddress: AWSIPAddress
+}
+
+input UserUpdateInput {
+  userId: ID! @id
+  firstName: String
+  lastName: String
+  role: Role
+  email: EmailAddress
+  dateOfBirth: AWSDate
+  lastLoginTime: AWSDateTime
+  phoneNumber: AWSPhone
+  profilePictureUrl: AWSURL
+  ipAddress: AWSIPAddress
+}
+
+input UserSort {
+  userId: SortDirection
+  firstName: SortDirection
+  lastName: SortDirection
+  role: SortDirection
+  email: SortDirection
+  dateOfBirth: SortDirection
+  lastLoginTime: SortDirection
+  phoneNumber: SortDirection
+  profilePictureUrl: SortDirection
+  ipAddress: SortDirection
+}
+
+input GroupInput {
+  _id: ID! @id
+  name: String
+  dailyMeetingTime: AWSTime
+  metadata: AWSJSON
+}
+
+input GroupCreateInput {
+  _id: ID @id
+  name: String
+  dailyMeetingTime: AWSTime
+  metadata: AWSJSON
+}
+
+input GroupUpdateInput {
+  _id: ID! @id
+  name: String
+  dailyMeetingTime: AWSTime
+  metadata: AWSJSON
+}
+
+input GroupSort {
+  _id: SortDirection
+  name: SortDirection
+  dailyMeetingTime: SortDirection
+  metadata: SortDirection
+}
+
+input ModeratorInput {
+  moderatorId: ID! @id
+  name: String
+  contactEmail: AWSEmail
+  appointedTimestamp: AWSTimestamp
+}
+
+input ModeratorCreateInput {
+  moderatorId: ID @id
+  name: String
+  contactEmail: AWSEmail
+  appointedTimestamp: AWSTimestamp
+}
+
+input ModeratorUpdateInput {
+  moderatorId: ID! @id
+  name: String
+  contactEmail: AWSEmail
+  appointedTimestamp: AWSTimestamp
+}
+
+input ModeratorSort {
+  moderatorId: SortDirection
+  name: SortDirection
+  contactEmail: SortDirection
+  appointedTimestamp: SortDirection
+}
+
+type GroupEdge {
+  _id: ID! @id
+}
+
+input Options {
+  limit: Int
+  offset: Int
+}
+
+input StringScalarFilters {
+  eq: String
+  contains: String
+  endsWith: String
+  startsWith: String
+}
+
+type Query {
+  userGroupQuery_getNodeUser(filter: UserInput): User
+  userGroupQuery_getNodeUsers(filter: UserInput, options: Options, sort: [UserSort!]): [User]
+  userGroupQuery_getNodeGroup(filter: GroupInput): Group
+  userGroupQuery_getNodeGroups(filter: GroupInput, options: Options, sort: [GroupSort!]): [Group]
+  userGroupQuery_getNodeModerator(filter: ModeratorInput): Moderator
+  userGroupQuery_getNodeModerators(filter: ModeratorInput, options: Options, sort: [ModeratorSort!]): [Moderator]
+}
+
+type Mutation {
+  createNodeUser(input: UserCreateInput!): User
+  updateNodeUser(input: UserUpdateInput!): User
+  deleteNodeUser(userId: ID!): Boolean
+  createNodeGroup(input: GroupCreateInput!): Group
+  updateNodeGroup(input: GroupUpdateInput!): Group
+  deleteNodeGroup(_id: ID!): Boolean
+  createNodeModerator(input: ModeratorCreateInput!): Moderator
+  updateNodeModerator(input: ModeratorUpdateInput!): Moderator
+  deleteNodeModerator(moderatorId: ID!): Boolean
+  connectNodeModeratorToNodeGroupEdgeGroupEdge(from_id: ID!, to_id: ID!): GroupEdge
+  deleteEdgeGroupEdgeFromModeratorToGroup(from_id: ID!, to_id: ID!): Boolean
+}
+
+schema {
+  query: Query
+  mutation: Mutation
+}

--- a/templates/JSResolverOCHTTPS.js
+++ b/templates/JSResolverOCHTTPS.js
@@ -1102,7 +1102,7 @@ function getReturnBlockFromSelection(selection, querySchemaInfo) {
 function resolveGrapgDBqueryForGraphQLMutation (queryAst, querySchemaInfo) {
 
     // createNode
-    if (querySchemaInfo.name.startsWith('createNode') && !querySchemaInfo.graphQuery) {
+    if (querySchemaInfo.name.includes('createNode') && !querySchemaInfo.graphQuery) {
         const queryFields = extractCypherFieldsFromArgumentFields(queryAst.definitions[0].selectionSet.selections[0].arguments[0].value.fields, querySchemaInfo);
         const formattedQueryFields = queryFields.map(arg => {
             const param = querySchemaInfo.pathName + '_' + arg.name;
@@ -1119,7 +1119,7 @@ function resolveGrapgDBqueryForGraphQLMutation (queryAst, querySchemaInfo) {
     }
 
     // updateNode
-    if (querySchemaInfo.name.startsWith('updateNode') && !querySchemaInfo.graphQuery) {
+    if (querySchemaInfo.name.includes('updateNode') && !querySchemaInfo.graphQuery) {
         const queryFields = extractCypherFieldsFromArgumentFields(queryAst.definitions[0].selectionSet.selections[0].arguments[0].value.fields, querySchemaInfo);
         
         const idField = queryFields.find(arg => arg.name === querySchemaInfo.graphDBIdArgName);
@@ -1154,7 +1154,7 @@ function resolveGrapgDBqueryForGraphQLMutation (queryAst, querySchemaInfo) {
     }
 
     // deleteNode
-    if (querySchemaInfo.name.startsWith('deleteNode') && !querySchemaInfo.graphQuery) {
+    if (querySchemaInfo.name.includes('deleteNode') && !querySchemaInfo.graphQuery) {
         const nodeID = queryAst.definitions[0].selectionSet.selections[0].arguments[0].value.value;
         const nodeName = querySchemaInfo.name + '_' + querySchemaInfo.returnType;
         let param  = nodeName + '_' + 'whereId';
@@ -1164,7 +1164,7 @@ function resolveGrapgDBqueryForGraphQLMutation (queryAst, querySchemaInfo) {
     }
 
     // connect
-    if (querySchemaInfo.name.startsWith('connectNode') && querySchemaInfo.graphQuery == null) {
+    if (querySchemaInfo.name.includes('connectNode') && querySchemaInfo.graphQuery == null) {
         let fromID = queryAst.definitions[0].selectionSet.selections[0].arguments[0].value.value;
         let toID = queryAst.definitions[0].selectionSet.selections[0].arguments[1].value.value;
         const edgeType = querySchemaInfo.name.match(new RegExp('Edge' + "(.*)" + ''))[1];
@@ -1182,7 +1182,7 @@ function resolveGrapgDBqueryForGraphQLMutation (queryAst, querySchemaInfo) {
     }
 
     // updateEdge
-    if (querySchemaInfo.name.startsWith('updateEdge') && querySchemaInfo.graphQuery == null) {
+    if (querySchemaInfo.name.includes('updateEdge') && querySchemaInfo.graphQuery == null) {
         let fromID = queryAst.definitions[0].selectionSet.selections[0].arguments[0].value.value;
         let toID = queryAst.definitions[0].selectionSet.selections[0].arguments[1].value.value;
         let edgeType = querySchemaInfo.name.match(new RegExp('updateEdge' + "(.*)" + 'From'))[1];
@@ -1209,7 +1209,7 @@ function resolveGrapgDBqueryForGraphQLMutation (queryAst, querySchemaInfo) {
     }
 
     // deleteEdge
-    if (querySchemaInfo.name.startsWith('deleteEdge') && querySchemaInfo.graphQuery == null) {
+    if (querySchemaInfo.name.includes('deleteEdge') && querySchemaInfo.graphQuery == null) {
         let fromID = queryAst.definitions[0].selectionSet.selections[0].arguments[0].value.value;
         let toID = queryAst.definitions[0].selectionSet.selections[0].arguments[1].value.value;
         const edgeName = querySchemaInfo.name + '_' + querySchemaInfo.returnType;

--- a/test/TestCases/Case01/input/airportsPrefix.source.schema.graphql
+++ b/test/TestCases/Case01/input/airportsPrefix.source.schema.graphql
@@ -1,0 +1,153 @@
+type Continent @alias(property: "continent") {
+  id: ID! @id
+  code: String
+  type: String
+  desc: String
+  airportContainssOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "contains", direction: OUT)
+  contains: Contains
+}
+
+input ContinentInput {
+  id: ID @id
+  code: String
+  type: String
+  desc: String
+}
+
+type Country @alias(property: "country") {
+  _id: ID! @id
+  code: String
+  type: String
+  desc: String
+  airportContainssOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "contains", direction: OUT)
+  contains: Contains
+}
+
+input CountryInput {
+  _id: ID @id
+  code: String
+  type: String
+  desc: String
+}
+
+type Version @alias(property: "version") {
+  _id: ID! @id
+  date: String
+  code: String
+  author: String
+  type: String
+  desc: String
+}
+
+input VersionInput {
+  _id: ID @id
+  date: String
+  code: String
+  author: String
+  type: String
+  desc: String
+}
+
+type Airport @alias(property: "airport") {
+  _id: ID! @id
+  country: String
+  longest: Int
+  code: String
+  city: String
+  elev: Int
+  icao: String
+  lon: Float
+  runways: Int
+  region: String
+  type: String
+  lat: Float
+  desc2: String @alias(property: "desc")
+  outboundRoutesCount: Int @graphQuery(statement: "MATCH (this)-[r:route]->(a) RETURN count(r)")
+  continentContainsIn: Continent @relationship(edgeType: "contains", direction: IN)
+  countryContainsIn: Country @relationship(edgeType: "contains", direction: IN)
+  airportRoutesOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "route", direction: OUT)
+  airportRoutesIn(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "route", direction: IN)
+  contains: Contains
+  route: Route
+}
+
+input AirportInput {
+  _id: ID @id
+  country: String
+  longest: Int
+  code: String
+  city: String
+  elev: Int
+  icao: String
+  lon: Float
+  runways: Int
+  region: String
+  type: String
+  lat: Float
+  desc: String
+}
+
+type Contains @alias(property: "contains") {
+  _id: ID! @id
+}
+
+type Route @alias(property: "route") {
+  _id: ID! @id
+  dist: Int
+}
+
+input RouteInput {
+  dist: Int
+}
+
+input Options {
+  limit: Int
+}
+
+type Query {
+  integrationTestQuery_getAirport(code: String): Airport
+  integrationTestQuery_getAirportConnection(fromCode: String!, toCode: String!): Airport @cypher(statement: "MATCH (:airport{code: '$fromCode'})-[:route]->(this:airport)-[:route]->(:airport{code:'$toCode'})")
+  integrationTestQuery_getAirportWithGremlin(code:String): Airport @graphQuery(statement: "g.V().has('airport', 'code', '$code').elementMap()")
+  integrationTestQuery_getContinentsWithGremlin: [Continent] @graphQuery(statement: "g.V().hasLabel('continent').elementMap().fold()")
+  integrationTestQuery_getCountriesCountGremlin: Int @graphQuery(statement: "g.V().hasLabel('country').count()")
+
+  integrationTestQuery_getNodeContinent(filter: ContinentInput): Continent
+  integrationTestQuery_getNodeContinents(filter: ContinentInput, options: Options): [Continent]
+  integrationTestQuery_getNodeCountry(filter: CountryInput): Country
+  integrationTestQuery_getNodeCountrys(filter: CountryInput, options: Options): [Country]
+  integrationTestQuery_getNodeVersion(filter: VersionInput): Version
+  integrationTestQuery_getNodeVersions(filter: VersionInput, options: Options): [Version]
+  integrationTestQuery_getNodeAirport(filter: AirportInput): Airport
+  integrationTestQuery_getNodeAirports(filter: AirportInput, options: Options): [Airport]
+}
+
+type Mutation {
+  integrationTestMutation_createAirport(input: AirportInput!): Airport @graphQuery(statement: "CREATE (this:airport {$input}) RETURN this")
+  integrationTestMutation_addRoute(fromAirportCode:String, toAirportCode:String, dist:Int): Route @graphQuery(statement: "MATCH (from:airport{code:'$fromAirportCode'}), (to:airport{code:'$toAirportCode'}) CREATE (from)-[this:route{dist:$dist}]->(to) RETURN this")
+  integrationTestMutation_deleteAirport(id: ID): Int @graphQuery(statement: "MATCH (this:airport) WHERE ID(this) = '$id' DETACH DELETE this")
+
+  integrationTestMutation_createNodeContinent(input: ContinentInput!): Continent
+  integrationTestMutation_updateNodeContinent(input: ContinentInput!): Continent
+  integrationTestMutation_deleteNodeContinent(_id: ID!): Boolean
+  integrationTestMutation_createNodeCountry(input: CountryInput!): Country
+  integrationTestMutation_updateNodeCountry(input: CountryInput!): Country
+  integrationTestMutation_deleteNodeCountry(_id: ID!): Boolean
+  integrationTestMutation_createNodeVersion(input: VersionInput!): Version
+  integrationTestMutation_updateNodeVersion(input: VersionInput!): Version
+  integrationTestMutation_deleteNodeVersion(_id: ID!): Boolean
+  integrationTestMutation_createNodeAirport(input: AirportInput!): Airport
+  integrationTestMutation_updateNodeAirport(input: AirportInput!): Airport
+  integrationTestMutation_deleteNodeAirport(_id: ID!): Boolean
+  integrationTestMutation_connectNodeContinentToNodeAirportEdgeContains(from_id: ID!, to_id: ID!): Contains
+  integrationTestMutation_deleteEdgeContainsFromContinentToAirport(from_id: ID!, to_id: ID!): Boolean
+  integrationTestMutation_connectNodeCountryToNodeAirportEdgeContains(from_id: ID!, to_id: ID!): Contains
+  integrationTestMutation_deleteEdgeContainsFromCountryToAirport(from_id: ID!, to_id: ID!): Boolean
+  integrationTestMutation_connectNodeAirportToNodeAirportEdgeRoute(from_id: ID!, to_id: ID!, edge: RouteInput!): Route
+  integrationTestMutation_updateEdgeRouteFromAirportToAirport(from_id: ID!, to_id: ID!, edge: RouteInput!): Route
+  integrationTestMutation_deleteEdgeRouteFromAirportToAirport(from_id: ID!, to_id: ID!): Boolean
+}
+
+schema {
+  query: Query
+  mutation: Mutation
+}

--- a/test/TestCases/Case01/outputReference/outputPrefix.schema.graphql
+++ b/test/TestCases/Case01/outputReference/outputPrefix.schema.graphql
@@ -1,0 +1,151 @@
+type Continent {
+  id: ID!
+  code: String
+  type: String
+  desc: String
+  airportContainssOut(filter: AirportInput, options: Options): [Airport]
+  contains: Contains
+}
+
+input ContinentInput {
+  id: ID
+  code: String
+  type: String
+  desc: String
+}
+
+type Country {
+  _id: ID!
+  code: String
+  type: String
+  desc: String
+  airportContainssOut(filter: AirportInput, options: Options): [Airport]
+  contains: Contains
+}
+
+input CountryInput {
+  _id: ID
+  code: String
+  type: String
+  desc: String
+}
+
+type Version {
+  _id: ID!
+  date: String
+  code: String
+  author: String
+  type: String
+  desc: String
+}
+
+input VersionInput {
+  _id: ID
+  date: String
+  code: String
+  author: String
+  type: String
+  desc: String
+}
+
+type Airport {
+  _id: ID!
+  country: String
+  longest: Int
+  code: String
+  city: String
+  elev: Int
+  icao: String
+  lon: Float
+  runways: Int
+  region: String
+  type: String
+  lat: Float
+  desc2: String
+  outboundRoutesCount: Int
+  continentContainsIn: Continent
+  countryContainsIn: Country
+  airportRoutesOut(filter: AirportInput, options: Options): [Airport]
+  airportRoutesIn(filter: AirportInput, options: Options): [Airport]
+  contains: Contains
+  route: Route
+}
+
+input AirportInput {
+  _id: ID
+  country: String
+  longest: Int
+  code: String
+  city: String
+  elev: Int
+  icao: String
+  lon: Float
+  runways: Int
+  region: String
+  type: String
+  lat: Float
+  desc: String
+}
+
+type Contains {
+  _id: ID!
+}
+
+type Route {
+  _id: ID!
+  dist: Int
+}
+
+input RouteInput {
+  dist: Int
+}
+
+input Options {
+  limit: Int
+}
+
+type Query {
+  integrationTestQuery_getAirport(code: String): Airport
+  integrationTestQuery_getAirportConnection(fromCode: String!, toCode: String!): Airport
+  integrationTestQuery_getAirportWithGremlin(code: String): Airport
+  integrationTestQuery_getContinentsWithGremlin: [Continent]
+  integrationTestQuery_getCountriesCountGremlin: Int
+  integrationTestQuery_getNodeContinent(filter: ContinentInput): Continent
+  integrationTestQuery_getNodeContinents(filter: ContinentInput, options: Options): [Continent]
+  integrationTestQuery_getNodeCountry(filter: CountryInput): Country
+  integrationTestQuery_getNodeCountrys(filter: CountryInput, options: Options): [Country]
+  integrationTestQuery_getNodeVersion(filter: VersionInput): Version
+  integrationTestQuery_getNodeVersions(filter: VersionInput, options: Options): [Version]
+  integrationTestQuery_getNodeAirport(filter: AirportInput): Airport
+  integrationTestQuery_getNodeAirports(filter: AirportInput, options: Options): [Airport]
+}
+
+type Mutation {
+  integrationTestMutation_createAirport(input: AirportInput!): Airport
+  integrationTestMutation_addRoute(fromAirportCode: String, toAirportCode: String, dist: Int): Route
+  integrationTestMutation_deleteAirport(id: ID): Int
+  integrationTestMutation_createNodeContinent(input: ContinentInput!): Continent
+  integrationTestMutation_updateNodeContinent(input: ContinentInput!): Continent
+  integrationTestMutation_deleteNodeContinent(_id: ID!): Boolean
+  integrationTestMutation_createNodeCountry(input: CountryInput!): Country
+  integrationTestMutation_updateNodeCountry(input: CountryInput!): Country
+  integrationTestMutation_deleteNodeCountry(_id: ID!): Boolean
+  integrationTestMutation_createNodeVersion(input: VersionInput!): Version
+  integrationTestMutation_updateNodeVersion(input: VersionInput!): Version
+  integrationTestMutation_deleteNodeVersion(_id: ID!): Boolean
+  integrationTestMutation_createNodeAirport(input: AirportInput!): Airport
+  integrationTestMutation_updateNodeAirport(input: AirportInput!): Airport
+  integrationTestMutation_deleteNodeAirport(_id: ID!): Boolean
+  integrationTestMutation_connectNodeContinentToNodeAirportEdgeContains(from_id: ID!, to_id: ID!): Contains
+  integrationTestMutation_deleteEdgeContainsFromContinentToAirport(from_id: ID!, to_id: ID!): Boolean
+  integrationTestMutation_connectNodeCountryToNodeAirportEdgeContains(from_id: ID!, to_id: ID!): Contains
+  integrationTestMutation_deleteEdgeContainsFromCountryToAirport(from_id: ID!, to_id: ID!): Boolean
+  integrationTestMutation_connectNodeAirportToNodeAirportEdgeRoute(from_id: ID!, to_id: ID!, edge: RouteInput!): Route
+  integrationTestMutation_updateEdgeRouteFromAirportToAirport(from_id: ID!, to_id: ID!, edge: RouteInput!): Route
+  integrationTestMutation_deleteEdgeRouteFromAirportToAirport(from_id: ID!, to_id: ID!): Boolean
+}
+
+schema {
+  query: Query
+  mutation: Mutation
+}

--- a/test/TestCases/Case01/outputReference/outputPrefix.source.schema.graphql
+++ b/test/TestCases/Case01/outputReference/outputPrefix.source.schema.graphql
@@ -1,0 +1,151 @@
+type Continent @alias(property: "continent") {
+  id: ID! @id
+  code: String
+  type: String
+  desc: String
+  airportContainssOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "contains", direction: OUT)
+  contains: Contains
+}
+
+input ContinentInput {
+  id: ID @id
+  code: String
+  type: String
+  desc: String
+}
+
+type Country @alias(property: "country") {
+  _id: ID! @id
+  code: String
+  type: String
+  desc: String
+  airportContainssOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "contains", direction: OUT)
+  contains: Contains
+}
+
+input CountryInput {
+  _id: ID @id
+  code: String
+  type: String
+  desc: String
+}
+
+type Version @alias(property: "version") {
+  _id: ID! @id
+  date: String
+  code: String
+  author: String
+  type: String
+  desc: String
+}
+
+input VersionInput {
+  _id: ID @id
+  date: String
+  code: String
+  author: String
+  type: String
+  desc: String
+}
+
+type Airport @alias(property: "airport") {
+  _id: ID! @id
+  country: String
+  longest: Int
+  code: String
+  city: String
+  elev: Int
+  icao: String
+  lon: Float
+  runways: Int
+  region: String
+  type: String
+  lat: Float
+  desc2: String @alias(property: "desc")
+  outboundRoutesCount: Int @graphQuery(statement: "MATCH (this)-[r:route]->(a) RETURN count(r)")
+  continentContainsIn: Continent @relationship(edgeType: "contains", direction: IN)
+  countryContainsIn: Country @relationship(edgeType: "contains", direction: IN)
+  airportRoutesOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "route", direction: OUT)
+  airportRoutesIn(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "route", direction: IN)
+  contains: Contains
+  route: Route
+}
+
+input AirportInput {
+  _id: ID @id
+  country: String
+  longest: Int
+  code: String
+  city: String
+  elev: Int
+  icao: String
+  lon: Float
+  runways: Int
+  region: String
+  type: String
+  lat: Float
+  desc: String
+}
+
+type Contains @alias(property: "contains") {
+  _id: ID! @id
+}
+
+type Route @alias(property: "route") {
+  _id: ID! @id
+  dist: Int
+}
+
+input RouteInput {
+  dist: Int
+}
+
+input Options {
+  limit: Int
+}
+
+type Query {
+  integrationTestQuery_getAirport(code: String): Airport
+  integrationTestQuery_getAirportConnection(fromCode: String!, toCode: String!): Airport @cypher(statement: "MATCH (:airport{code: '$fromCode'})-[:route]->(this:airport)-[:route]->(:airport{code:'$toCode'})")
+  integrationTestQuery_getAirportWithGremlin(code: String): Airport @graphQuery(statement: "g.V().has('airport', 'code', '$code').elementMap()")
+  integrationTestQuery_getContinentsWithGremlin: [Continent] @graphQuery(statement: "g.V().hasLabel('continent').elementMap().fold()")
+  integrationTestQuery_getCountriesCountGremlin: Int @graphQuery(statement: "g.V().hasLabel('country').count()")
+  integrationTestQuery_getNodeContinent(filter: ContinentInput): Continent
+  integrationTestQuery_getNodeContinents(filter: ContinentInput, options: Options): [Continent]
+  integrationTestQuery_getNodeCountry(filter: CountryInput): Country
+  integrationTestQuery_getNodeCountrys(filter: CountryInput, options: Options): [Country]
+  integrationTestQuery_getNodeVersion(filter: VersionInput): Version
+  integrationTestQuery_getNodeVersions(filter: VersionInput, options: Options): [Version]
+  integrationTestQuery_getNodeAirport(filter: AirportInput): Airport
+  integrationTestQuery_getNodeAirports(filter: AirportInput, options: Options): [Airport]
+}
+
+type Mutation {
+  integrationTestMutation_createAirport(input: AirportInput!): Airport @graphQuery(statement: "CREATE (this:airport {$input}) RETURN this")
+  integrationTestMutation_addRoute(fromAirportCode: String, toAirportCode: String, dist: Int): Route @graphQuery(statement: "MATCH (from:airport{code:'$fromAirportCode'}), (to:airport{code:'$toAirportCode'}) CREATE (from)-[this:route{dist:$dist}]->(to) RETURN this")
+  integrationTestMutation_deleteAirport(id: ID): Int @graphQuery(statement: "MATCH (this:airport) WHERE ID(this) = '$id' DETACH DELETE this")
+  integrationTestMutation_createNodeContinent(input: ContinentInput!): Continent
+  integrationTestMutation_updateNodeContinent(input: ContinentInput!): Continent
+  integrationTestMutation_deleteNodeContinent(_id: ID!): Boolean
+  integrationTestMutation_createNodeCountry(input: CountryInput!): Country
+  integrationTestMutation_updateNodeCountry(input: CountryInput!): Country
+  integrationTestMutation_deleteNodeCountry(_id: ID!): Boolean
+  integrationTestMutation_createNodeVersion(input: VersionInput!): Version
+  integrationTestMutation_updateNodeVersion(input: VersionInput!): Version
+  integrationTestMutation_deleteNodeVersion(_id: ID!): Boolean
+  integrationTestMutation_createNodeAirport(input: AirportInput!): Airport
+  integrationTestMutation_updateNodeAirport(input: AirportInput!): Airport
+  integrationTestMutation_deleteNodeAirport(_id: ID!): Boolean
+  integrationTestMutation_connectNodeContinentToNodeAirportEdgeContains(from_id: ID!, to_id: ID!): Contains
+  integrationTestMutation_deleteEdgeContainsFromContinentToAirport(from_id: ID!, to_id: ID!): Boolean
+  integrationTestMutation_connectNodeCountryToNodeAirportEdgeContains(from_id: ID!, to_id: ID!): Contains
+  integrationTestMutation_deleteEdgeContainsFromCountryToAirport(from_id: ID!, to_id: ID!): Boolean
+  integrationTestMutation_connectNodeAirportToNodeAirportEdgeRoute(from_id: ID!, to_id: ID!, edge: RouteInput!): Route
+  integrationTestMutation_updateEdgeRouteFromAirportToAirport(from_id: ID!, to_id: ID!, edge: RouteInput!): Route
+  integrationTestMutation_deleteEdgeRouteFromAirportToAirport(from_id: ID!, to_id: ID!): Boolean
+}
+
+schema {
+  query: Query
+  mutation: Mutation
+}

--- a/test/TestCases/Case05/Case05.04.test.js
+++ b/test/TestCases/Case05/Case05.04.test.js
@@ -1,0 +1,15 @@
+
+import { jest } from '@jest/globals';
+import { readJSONFile } from '../../testLib';
+import { main } from "../../../src/main";
+
+const casetest = readJSONFile('./test/TestCases/Case05/pipeline-with-prefixes.json');
+
+async function executeUtility() {    
+    process.argv = casetest.argv;
+    await main();
+}
+
+test('Execute utility: ' + casetest.argv.join(' '), async () => {
+    expect(await executeUtility()).not.toBe(null);    
+}, 600000);

--- a/test/TestCases/Case05/Case05.05.test.js
+++ b/test/TestCases/Case05/Case05.05.test.js
@@ -1,0 +1,67 @@
+import { checkFolderContainsFiles, executeAppSyncQuery, unzipAndGetContents } from '../../testLib';
+import fs from "fs";
+import path from "path";
+
+const outputFolderPath = './test/TestCases/Case05/output';
+
+describe('Validate pipeline with prefixes content', () => {
+    checkFolderContainsFiles(outputFolderPath, [
+        'AirportsJestPrefixTest.resolver.graphql.js',
+        'AirportsJestPrefixTest.resolver.schema.json.gz',
+        'AirportsJestPrefixTest-resources.json',
+        'AirportsJestPrefixTest.schema.graphql',
+        'AirportsJestPrefixTest.source.schema.graphql',
+        'AirportsJestPrefixTest.zip'
+    ]);
+
+    test('Zip file contains expected files', () => {
+        const expectedFiles = [
+            'index.mjs',
+            'node_modules',
+            'output.resolver.graphql.js',
+            'output.resolver.schema.json.gz',
+            'package-lock.json',
+            'package.json',
+            'queryHttpNeptune.mjs',
+            'util.mjs'
+        ];
+        
+        
+        const unzippedFolder = path.join(outputFolderPath, 'unzipped');
+        const actualFiles = unzipAndGetContents(unzippedFolder, path.join(outputFolderPath, 'AirportsJestPrefixTest.zip'));
+        expect(actualFiles.toSorted()).toEqual(expectedFiles.toSorted());
+    });
+
+    test('Can query app sync API successfully with prefixes', async () => {
+        const awsResources = JSON.parse(fs.readFileSync(path.join(outputFolderPath, 'AirportsJestPrefixTest-resources.json'), 'utf8'));
+        const apiId = awsResources.AppSyncAPI;
+        const region = awsResources.region;
+        const results = await executeAppSyncQuery(apiId, 'query {airportsQueryPrefix_getNodeContinents {code}}', {}, region);
+        const codes = results.data.airportsQueryPrefix_getNodeContinents.map(continent => continent.code).sort();
+        expect(codes).toEqual(['AF', 'AN', 'AS', 'EU', 'NA', 'OC', 'SA']);
+    }, 600000);
+
+    test('Can execute a create and delete mutation on app sync API successfully with prefix', async () => {
+        const awsResources = JSON.parse(fs.readFileSync(path.join(outputFolderPath, 'AirportsJestPrefixTest-resources.json'), 'utf8'));
+        const apiId = awsResources.AppSyncAPI;
+        const region = awsResources.region;
+
+        const mutation = `mutation {
+            airportsMutationPrefix_createNodeAirport(input: {
+                code: "TEST"
+            }) {
+                _id
+                code
+            }
+        }`;
+
+        const results = await executeAppSyncQuery(apiId, mutation, {}, region);
+        const createdCode = results.data.airportsMutationPrefix_createNodeAirport.code;
+        expect(createdCode).toBe("TEST");
+
+        const deleteMutation = `mutation {airportsMutationPrefix_deleteNodeAirport(_id: "${results.data.airportsMutationPrefix_createNodeAirport._id}")}`;
+        const deleteResults = await executeAppSyncQuery(apiId, deleteMutation, {}, region);
+        const deleteResult = deleteResults.data.airportsMutationPrefix_deleteNodeAirport;
+        expect(deleteResult).toBe(true);
+    }, 600000);
+});

--- a/test/TestCases/Case05/Case05.06.test.js
+++ b/test/TestCases/Case05/Case05.06.test.js
@@ -1,0 +1,20 @@
+import { readJSONFile } from '../../testLib';
+import { main } from "../../../src/main";
+import fs from "fs";
+
+const casetest = readJSONFile('./test/TestCases/Case05/remove-pipeline-with-prefixes.json');
+
+async function executeUtility() {    
+    process.argv = casetest.argv;
+    await main();
+}
+
+describe('Cleanup resources', () => {
+    afterAll(() => {
+        fs.rmSync('./test/TestCases/Case05/output', {recursive: true});
+    });
+
+    test('Execute utility: ' + casetest.argv.join(' '), async () => {
+        expect(await executeUtility()).not.toBe(null);
+    }, 600000);
+});

--- a/test/TestCases/Case05/input/airportsPrefix.source.schema.graphql
+++ b/test/TestCases/Case05/input/airportsPrefix.source.schema.graphql
@@ -1,0 +1,153 @@
+type Continent @alias(property: "continent") {
+  id: ID! @id
+  code: String
+  type: String
+  desc: String
+  airportContainssOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "contains", direction: OUT)
+  contains: Contains
+}
+
+input ContinentInput {
+  id: ID @id
+  code: String
+  type: String
+  desc: String
+}
+
+type Country @alias(property: "country") {
+  _id: ID! @id
+  code: String
+  type: String
+  desc: String
+  airportContainssOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "contains", direction: OUT)
+  contains: Contains
+}
+
+input CountryInput {
+  _id: ID @id
+  code: String
+  type: String
+  desc: String
+}
+
+type Version @alias(property: "version") {
+  _id: ID! @id
+  date: String
+  code: String
+  author: String
+  type: String
+  desc: String
+}
+
+input VersionInput {
+  _id: ID @id
+  date: String
+  code: String
+  author: String
+  type: String
+  desc: String
+}
+
+type Airport @alias(property: "airport") {
+  _id: ID! @id
+  country: String
+  longest: Int
+  code: String
+  city: String
+  elev: Int
+  icao: String
+  lon: Float
+  runways: Int
+  region: String
+  type: String
+  lat: Float
+  desc2: String @alias(property: "desc")
+  outboundRoutesCount: Int @graphQuery(statement: "MATCH (this)-[r:route]->(a) RETURN count(r)")
+  continentContainsIn: Continent @relationship(edgeType: "contains", direction: IN)
+  countryContainsIn: Country @relationship(edgeType: "contains", direction: IN)
+  airportRoutesOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "route", direction: OUT)
+  airportRoutesIn(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "route", direction: IN)
+  contains: Contains
+  route: Route
+}
+
+input AirportInput {
+  _id: ID @id
+  country: String
+  longest: Int
+  code: String
+  city: String
+  elev: Int
+  icao: String
+  lon: Float
+  runways: Int
+  region: String
+  type: String
+  lat: Float
+  desc: String
+}
+
+type Contains @alias(property: "contains") {
+  _id: ID! @id
+}
+
+type Route @alias(property: "route") {
+  _id: ID! @id
+  dist: Int
+}
+
+input RouteInput {
+  dist: Int
+}
+
+input Options {
+  limit: Int
+}
+
+type Query {
+  airportsQueryPrefix_getAirport(code: String): Airport
+  airportsQueryPrefix_getAirportConnection(fromCode: String!, toCode: String!): Airport @cypher(statement: "MATCH (:airport{code: '$fromCode'})-[:route]->(this:airport)-[:route]->(:airport{code:'$toCode'})")
+  airportsQueryPrefix_getAirportWithGremlin(code:String): Airport @graphQuery(statement: "g.V().has('airport', 'code', '$code').elementMap()")
+  airportsQueryPrefix_getContinentsWithGremlin: [Continent] @graphQuery(statement: "g.V().hasLabel('continent').elementMap().fold()")
+  airportsQueryPrefix_getCountriesCountGremlin: Int @graphQuery(statement: "g.V().hasLabel('country').count()")
+
+  airportsQueryPrefix_getNodeContinent(filter: ContinentInput): Continent
+  airportsQueryPrefix_getNodeContinents(filter: ContinentInput, options: Options): [Continent]
+  airportsQueryPrefix_getNodeCountry(filter: CountryInput): Country
+  airportsQueryPrefix_getNodeCountrys(filter: CountryInput, options: Options): [Country]
+  airportsQueryPrefix_getNodeVersion(filter: VersionInput): Version
+  airportsQueryPrefix_getNodeVersions(filter: VersionInput, options: Options): [Version]
+  airportsQueryPrefix_getNodeAirport(filter: AirportInput): Airport
+  airportsQueryPrefix_getNodeAirports(filter: AirportInput, options: Options): [Airport]
+}
+
+type Mutation {
+  airportsMutationPrefix_createAirport(input: AirportInput!): Airport @graphQuery(statement: "CREATE (this:airport {$input}) RETURN this")
+  airportsMutationPrefix_addRoute(fromAirportCode:String, toAirportCode:String, dist:Int): Route @graphQuery(statement: "MATCH (from:airport{code:'$fromAirportCode'}), (to:airport{code:'$toAirportCode'}) CREATE (from)-[this:route{dist:$dist}]->(to) RETURN this")
+  airportsMutationPrefix_deleteAirport(id: ID): Int @graphQuery(statement: "MATCH (this:airport) WHERE ID(this) = '$id' DETACH DELETE this")
+
+  airportsMutationPrefix_createNodeContinent(input: ContinentInput!): Continent
+  airportsMutationPrefix_updateNodeContinent(input: ContinentInput!): Continent
+  airportsMutationPrefix_deleteNodeContinent(_id: ID!): Boolean
+  airportsMutationPrefix_createNodeCountry(input: CountryInput!): Country
+  airportsMutationPrefix_updateNodeCountry(input: CountryInput!): Country
+  airportsMutationPrefix_deleteNodeCountry(_id: ID!): Boolean
+  airportsMutationPrefix_createNodeVersion(input: VersionInput!): Version
+  airportsMutationPrefix_updateNodeVersion(input: VersionInput!): Version
+  airportsMutationPrefix_deleteNodeVersion(_id: ID!): Boolean
+  airportsMutationPrefix_createNodeAirport(input: AirportInput!): Airport
+  airportsMutationPrefix_updateNodeAirport(input: AirportInput!): Airport
+  airportsMutationPrefix_deleteNodeAirport(_id: ID!): Boolean
+  airportsMutationPrefix_connectNodeContinentToNodeAirportEdgeContains(from_id: ID!, to_id: ID!): Contains
+  airportsMutationPrefix_deleteEdgeContainsFromContinentToAirport(from_id: ID!, to_id: ID!): Boolean
+  airportsMutationPrefix_connectNodeCountryToNodeAirportEdgeContains(from_id: ID!, to_id: ID!): Contains
+  airportsMutationPrefix_deleteEdgeContainsFromCountryToAirport(from_id: ID!, to_id: ID!): Boolean
+  airportsMutationPrefix_connectNodeAirportToNodeAirportEdgeRoute(from_id: ID!, to_id: ID!, edge: RouteInput!): Route
+  airportsMutationPrefix_updateEdgeRouteFromAirportToAirport(from_id: ID!, to_id: ID!, edge: RouteInput!): Route
+  airportsMutationPrefix_deleteEdgeRouteFromAirportToAirport(from_id: ID!, to_id: ID!): Boolean
+}
+
+schema {
+  query: Query
+  mutation: Mutation
+}

--- a/test/TestCases/Case05/pipeline-with-prefixes.json
+++ b/test/TestCases/Case05/pipeline-with-prefixes.json
@@ -1,0 +1,17 @@
+{
+    "name": "Unit Test (Air Routes) Pipeline with Prefixes",
+    "description":"Create pipeline with query and mutation prefixes",
+    "argv":["--quiet",
+            "--input-schema-file", "./test/TestCases/Case05/input/airportsPrefix.source.schema.graphql",
+            "--query-prefix", "airportsQueryPrefix_",
+            "--mutation-prefix", "airportsMutationPrefix_",
+            "--output-folder-path", "./test/TestCases/Case05/output",
+            "--create-update-aws-pipeline",
+            "--create-update-aws-pipeline-name", "AirportsJestPrefixTest",
+            "--create-update-aws-pipeline-neptune-endpoint", "<AIR_ROUTES_DB_HOST>:<AIR_ROUTES_DB_PORT>",
+            "--output-resolver-query-https"],
+    "host": "<AIR_ROUTES_DB_HOST>",
+    "port": "<AIR_ROUTES_DB_PORT>",
+    "testOutputFilesSize": ["output.resolver.graphql.js", "output.schema.graphql", "output.source.schema.graphql"],
+    "testOutputFilesContent": ["output.schema.graphql", "output.source.schema.graphql"]
+}

--- a/test/TestCases/Case05/remove-pipeline-with-prefixes.json
+++ b/test/TestCases/Case05/remove-pipeline-with-prefixes.json
@@ -1,0 +1,11 @@
+{
+  "name": "Unit Test (Air Routes) Remove Pipeline with Prefixes",
+  "description":"Remove pipeline with prefixes",
+  "argv":["--quiet",
+    "--remove-aws-pipeline-name", "AirportsJestPrefixTest",
+    "--output-folder-path", "./test/TestCases/Case05/output"],
+  "host": "<AIR_ROUTES_DB_HOST>",
+  "port": "<AIR_ROUTES_DB_HOST>",
+  "testOutputFilesSize": ["output.resolver.graphql.js", "output.schema.graphql", "output.source.schema.graphql"],
+  "testOutputFilesContent": ["output.schema.graphql", "output.source.schema.graphql"]
+}


### PR DESCRIPTION
Added an option to add a custom prefix to generated query and mutation names

- added new --query-prefix option
- value is added to the beginning of generated query names
ex) --query-prefix airport_ will generate airport_getContinent
- added new --query-prefix option to list outputted when user enters -h

- added new --mutation-prefix option
- value is added to the beginning of generated mutation names
ex) --mutation-prefix set to test_ will generate test_createNodeAirport
- added new --mutation-prefix option to list outputted when user enters -h

Added unit tests for changed files to check that the generated schema outputs the correct prefix on query and mutation names.