### PR TITLE
fix: Updated index.mjs file to be modified for Apollo subgraph Federation 2 features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,5 +117,5 @@ permissions and limitations under the License.
 * Fixed invalid schema generation when AWS AppSync scalar types are used in 
   an input 
   schema ([#118](https://github.com/aws/amazon-neptune-for-graphql/pull/118))
-* Updated index.mjs file to be modified for Apollo subgraph Federation 2 
+* Updated Apollo subgraph to allow use of Federation 2 features.
   features ([#126](https://github.com/aws/amazon-neptune-for-graphql/pull/126))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,3 +117,5 @@ permissions and limitations under the License.
 * Fixed invalid schema generation when AWS AppSync scalar types are used in 
   an input 
   schema ([#118](https://github.com/aws/amazon-neptune-for-graphql/pull/118))
+* Updated index.mjs file to be modified for Apollo subgraph Federation 2 
+  features ([#126](https://github.com/aws/amazon-neptune-for-graphql/pull/126))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,4 +120,4 @@ permissions and limitations under the License.
 * Fixed duplicated nodes and edges from nodes with 
   multi-labels ([#125](https://github.com/aws/amazon-neptune-for-graphql/pull/125))
 * Updated Apollo subgraph to allow use of Federation 2 features.
-  features ([#126](https://github.com/aws/amazon-neptune-for-graphql/pull/126))
+  ([#126](https://github.com/aws/amazon-neptune-for-graphql/pull/126))

--- a/src/zipPackage.js
+++ b/src/zipPackage.js
@@ -49,7 +49,7 @@ async function createZip({targetZipFilePath, includePaths = [], includeContent =
         output.on('close', () => resolve());
         archive.on('error', err => reject(err));
     });
-    
+
     archive.pipe(output);
 
     includePaths.forEach(includePath => {

--- a/templates/ApolloServer/index.mjs
+++ b/templates/ApolloServer/index.mjs
@@ -8,7 +8,15 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-const typeDefs = parse(readFileSync('./output.schema.graphql', 'utf-8'));
+const fileContent = readFileSync('./output.schema.graphql', 'utf-8');
+let schema = fileContent;
+if (process.env.SUBGRAPH === 'true') {
+    schema = `extend schema @link(
+        url: "https://specs.apollo.dev/federation/v2.0"
+        import: ["@key", "@shareable"]
+    )${fileContent}`;
+}
+const typeDefs = parse(schema);
 const queryDefinition = typeDefs.definitions.find(
     definition => definition.kind === 'ObjectTypeDefinition' && definition.name.value === 'Query'
 );

--- a/test/testLib.js
+++ b/test/testLib.js
@@ -226,6 +226,9 @@ async function testApolloArtifacts(outputFolderPath, testDbInfo, subgraph = fals
         ];
         const actualEnvContent = fs.readFileSync(path.join(outputFolderPath, 'unzipped', '.env'), 'utf8');
         expect(actualEnvContent).toEqual(expectedEnvContent.join('\n'));
+
+        const actualIndexContent = fs.readFileSync(path.join(outputFolderPath, 'unzipped', 'index.mjs'), 'utf8');
+        expect(actualIndexContent).toContain('https://specs.apollo.dev/federation/v2.0');
     });
 }
 


### PR DESCRIPTION
There was an issue with the index.mjs file when generated with `--create-update-apollo-server-subgraph` as it did not include support for the Apollo Subgraph Federation 2 features. 

Updated so that when user runs `--create-update-apollo-server-subgraph` the index.mjs file includes the support for the subgraph federation 2 features and if run with just `--create-update-apollo-server`, the index.mjs file is not modified and same as the original template.

Also added an index.mjs file check to the apollo subgraph integration test (Case09) to ensure the index.mjs file is always modified correctly to add support for the subgraph federation 2 features.