### PR TITLE
bug: Accommodated for special characters in edge labels to ensure correct Cypher translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,12 +112,12 @@ permissions and limitations under the License.
 * Fixed Apollo template to reference `graphql` `parse` instead of `graphql-tag`
   `gql` ([#116](https://github.com/aws/amazon-neptune-for-graphql/pull/116))
 * Fixed deployment of AWS resources if a pipeline name is not provided as an
-  input
-  option ([#117](https://github.com/aws/amazon-neptune-for-graphql/pull/117))
+  input option ([#117](https://github.com/aws/amazon-neptune-for-graphql/pull/117))
 * Fixed invalid schema generation when AWS AppSync scalar types are used in 
-  an input 
-  schema ([#118](https://github.com/aws/amazon-neptune-for-graphql/pull/118))
+  an input schema ([#118](https://github.com/aws/amazon-neptune-for-graphql/pull/118))
 * Fixed duplicated nodes and edges from nodes with 
   multi-labels ([#125](https://github.com/aws/amazon-neptune-for-graphql/pull/125))
 * Updated Apollo subgraph to allow use of Federation 2 features.
   ([#126](https://github.com/aws/amazon-neptune-for-graphql/pull/126))
+* Accommodated for special characters in edge labels to ensure proper Cypher
+  translation ([#127](https://github.com/aws/amazon-neptune-for-graphql/pull/127))

--- a/src/test/airports.customized.graphql
+++ b/src/test/airports.customized.graphql
@@ -8,15 +8,15 @@ type Continent @alias(property: "continent") {
   type: String
   code: String
   desc: String
-  airportContainssOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "contains", direction: OUT)
+  airportContainssOut(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport] @relationship(edgeType: "contains", direction: OUT)
   contains: Contains
 }
 
 input ContinentInput {
-_id: ID @id
-type: StringScalarFilters
-code: StringScalarFilters
-desc: StringScalarFilters
+  _id: ID @id
+  type: StringScalarFilters
+  code: StringScalarFilters
+  desc: StringScalarFilters
 }
 
 input ContinentCreateInput {
@@ -54,24 +54,24 @@ type Country @alias(property: "country") {
   governmentSite: AWSURL
   emergencyLine: AWSPhone
   gatewayIp: AWSIPAddress
-  airportContainssOut(filter: AirportInput, options: Options): [Airport] @relationship(edgeType: "contains", direction: OUT)
+  airportContainssOut(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport] @relationship(edgeType: "contains", direction: OUT)
   contains: Contains
 }
 
 input CountryInput {
-_id: ID @id
-type: StringScalarFilters
-code: StringScalarFilters
-desc: StringScalarFilters
-foundingDate: AWSDate
-localOfficeTime: AWSTime
-updatedAt: AWSDateTime
-createdTimestamp: AWSTimestamp
-officialEmail: AWSEmail
-metadataJson: AWSJSON
-governmentSite: AWSURL
-emergencyLine: AWSPhone
-gatewayIp: AWSIPAddress
+  _id: ID @id
+  type: StringScalarFilters
+  code: StringScalarFilters
+  desc: StringScalarFilters
+  foundingDate: AWSDate
+  localOfficeTime: AWSTime
+  updatedAt: AWSDateTime
+  createdTimestamp: AWSTimestamp
+  officialEmail: AWSEmail
+  metadataJson: AWSJSON
+  governmentSite: AWSURL
+  emergencyLine: AWSPhone
+  gatewayIp: AWSIPAddress
 }
 
 input CountryCreateInput {
@@ -129,16 +129,17 @@ type Version @alias(property: "version") {
   author: String
   type: String
   code: String
-  dataSourcePulledFromOut(filter: DataSourceInput, options: Options): [DataSource] @relationship(edgeType: "pulled:From", direction: OUT)
+  dataSourcePulled_cn_fromOut(filter: DataSourceInput, options: Options): [DataSource] @relationship(edgeType: "pulled:From", direction: OUT)
+  pulled_cn_From: Pulled_cn_from
 }
 
 input VersionInput {
-_id: ID @id
-date: StringScalarFilters
-desc: StringScalarFilters
-author: StringScalarFilters
-type: StringScalarFilters
-code: StringScalarFilters
+  _id: ID @id
+  date: StringScalarFilters
+  desc: StringScalarFilters
+  author: StringScalarFilters
+  type: StringScalarFilters
+  code: StringScalarFilters
 }
 
 input VersionCreateInput {
@@ -192,19 +193,19 @@ type Airport @alias(property: "airport") {
 }
 
 input AirportInput {
-_id: ID @id
-type: StringScalarFilters
-city: StringScalarFilters
-icao: StringScalarFilters
-code: StringScalarFilters
-country: StringScalarFilters
-lat: Float
-longest: Int
-runways: Int
-desc: StringScalarFilters
-lon: Float
-region: StringScalarFilters
-elev: Int
+  _id: ID @id
+  type: StringScalarFilters
+  city: StringScalarFilters
+  icao: StringScalarFilters
+  code: StringScalarFilters
+  country: StringScalarFilters
+  lat: Float
+  longest: Int
+  runways: Int
+  desc: StringScalarFilters
+  lon: Float
+  region: StringScalarFilters
+  elev: Int
 }
 
 input AirportCreateInput {
@@ -263,7 +264,8 @@ type DataSource @alias(property: "dataSource") {
   description: String
   lastUpdated: String
   isActive: Boolean
-  versionPulledFromIn(filter: VersionInput, options: Options): [Version] @relationship(edgeType: "pulled:From", direction: IN)
+  versionPulled_cn_fromsIn(filter: VersionInput, options: Options, sort: [VersionSort!]): [Version] @relationship(edgeType: "pulled:From", direction: IN)
+  pulled_cn_From: Pulled_cn_from
 }
 
 input DataSourceInput {
@@ -306,65 +308,67 @@ input DataSourceSort {
   isActive: SortingDirection
 }
 
-type Contains @alias(property:"contains") {
-_id: ID! @id
+type Contains @alias(property: "contains") {
+  _id: ID! @id
 }
 
-type Route @alias(property:"route") {
-_id: ID! @id
-dist: Int
+type Route @alias(property: "route") {
+  _id: ID! @id
+  dist: Int
 }
 
 input RouteInput {
-dist: Int
+  dist: Int
 }
 
-type PulledFrom @alias(property:"pulled:From") {
+type Pulled_cn_from @alias(property: "pulled:From") {
   _id: ID! @id
 }
 
 input Options {
-limit:Int
-offset:Int
+  limit: Int
+  offset: Int
 }
 
 input StringScalarFilters {
-eq: String
-contains: String
-endsWith: String
-startsWith: String
+  eq: String
+  contains: String
+  endsWith: String
+  startsWith: String
 }
 
 type Query {
-getAirportByCode(code: String): Airport
-getAirportConnection(fromCode: String!, toCode: String!): Airport @cypher(statement: "MATCH (:airport{code: '$fromCode'})-[:route]->(this:airport)-[:route]->(:airport{code:'$toCode'})")
-getContinentsWithGremlin: [Continent] @graphQuery(statement: "g.V().hasLabel('continent').elementMap().fold()")
-getCountriesCountGremlin: Int @graphQuery(statement: "g.V().hasLabel('country').count()")
-getContinent(filter: ContinentInput): Continent
-getContinents(filter: ContinentInput, options: Options, sort: [ContinentSort!]): [Continent]
-getCountry(filter: CountryInput): Country
-getCountrys(filter: CountryInput, options: Options, sort: [CountrySort!]): [Country]
-getVersion(filter: VersionInput): Version
-getVersions(filter: VersionInput, options: Options, sort: [VersionSort!]): [Version]
-getAirport(filter: AirportInput): Airport
-airportQuery_getAirport(filter: AirportInput): Airport
-getAirports(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport]
-getAirportWithGremlin(code: String): Airport @graphQuery(statement: "g.V().has('airport', 'code', '$code').elementMap()")
-getCountriesCount: Int @graphQuery(statement: "g.V().hasLabel('country').count()")
+  getAirportByCode(code: String): Airport
+  getAirportConnection(fromCode: String!, toCode: String!): Airport @cypher(statement: "MATCH (:airport{code: '$fromCode'})-[:route]->(this:airport)-[:route]->(:airport{code:'$toCode'})")
+  getContinentsWithGremlin: [Continent] @graphQuery(statement: "g.V().hasLabel('continent').elementMap().fold()")
+  getCountriesCountGremlin: Int @graphQuery(statement: "g.V().hasLabel('country').count()")
+  getContinent(filter: ContinentInput): Continent
+  getContinents(filter: ContinentInput, options: Options, sort: [ContinentSort!]): [Continent]
+  getCountry(filter: CountryInput): Country
+  getCountrys(filter: CountryInput, options: Options, sort: [CountrySort!]): [Country]
+  getVersion(filter: VersionInput): Version
+  getVersions(filter: VersionInput, options: Options, sort: [VersionSort!]): [Version]
+  getAirport(filter: AirportInput): Airport
+  airportQuery_getAirport(filter: AirportInput): Airport
+  getAirports(filter: AirportInput, options: Options, sort: [AirportSort!]): [Airport]
+  getAirportWithGremlin(code: String): Airport @graphQuery(statement: "g.V().has('airport', 'code', '$code').elementMap()")
+  getCountriesCount: Int @graphQuery(statement: "g.V().hasLabel('country').count()")
 }
 
 type Mutation {
-createAirport(input: AirportCreateInput!): Airport
-airportMutation_createAirport(input: AirportCreateInput!): Airport
-updateAirport(input: AirportUpdateInput!): Airport
-airportMutation_updateAirport(input: AirportUpdateInput!): Airport
-connectCountryToAirportThroughContains(from_id: ID!, to_id: ID!): Contains
-airportMutation_connectCountryToAirportThroughContains(from_id: ID!, to_id: ID!): Contains
-deleteContainsConnectionFromCountryToAirport(from_id: ID!, to_id: ID!): Boolean
-airportMutation_deleteContainsConnectionFromCountryToAirport(from_id: ID!, to_id: ID!): Boolean
-updateRouteConnectionFromAirportToAirport(from_id: ID!, to_id: ID!, edge: RouteInput!): Route
-airportMutation_updateRouteConnectionFromAirportToAirport(from_id: ID!, to_id: ID!, edge: RouteInput!): Route
-createAirportCustom(input: AirportCreateInput!): Airport @graphQuery(statement: "CREATE (this:airport {$input}) RETURN this")
+  createAirport(input: AirportCreateInput!): Airport
+  airportMutation_createAirport(input: AirportCreateInput!): Airport
+  updateAirport(input: AirportUpdateInput!): Airport
+  airportMutation_updateAirport(input: AirportUpdateInput!): Airport
+  connectCountryToAirportThroughContains(from_id: ID!, to_id: ID!): Contains
+  airportMutation_connectCountryToAirportThroughContains(from_id: ID!, to_id: ID!): Contains
+  deleteContainsConnectionFromCountryToAirport(from_id: ID!, to_id: ID!): Boolean
+  airportMutation_deleteContainsConnectionFromCountryToAirport(from_id: ID!, to_id: ID!): Boolean
+  updateRouteConnectionFromAirportToAirport(from_id: ID!, to_id: ID!, edge: RouteInput!): Route
+  airportMutation_updateRouteConnectionFromAirportToAirport(from_id: ID!, to_id: ID!, edge: RouteInput!): Route
+  connectVersionToDataSourceThroughPulled_cn_from(from_id: ID!, to_id: ID!): Pulled_cn_from
+  deletePulled_cn_fromConnectionFromVersionToDataSource(from_id: ID!, to_id: ID!): Boolean
+  createAirportCustom(input: AirportCreateInput!): Airport @graphQuery(statement: "CREATE (this:airport {$input}) RETURN this")
 }
 
 schema {

--- a/src/test/airports.customized.graphql
+++ b/src/test/airports.customized.graphql
@@ -129,6 +129,7 @@ type Version @alias(property: "version") {
   author: String
   type: String
   code: String
+  dataSourcePulledFromOut(filter: DataSourceInput, options: Options): [DataSource] @relationship(edgeType: "pulled:From", direction: OUT)
 }
 
 input VersionInput {
@@ -254,6 +255,57 @@ input AirportSort {
   elev: SortingDirection
 }
 
+type DataSource @alias(property: "dataSource") {
+  _id: ID! @id
+  name: String
+  type: String
+  url: String
+  description: String
+  lastUpdated: String
+  isActive: Boolean
+  versionPulledFromIn(filter: VersionInput, options: Options): [Version] @relationship(edgeType: "pulled:From", direction: IN)
+}
+
+input DataSourceInput {
+  _id: ID @id
+  name: StringScalarFilters
+  type: StringScalarFilters
+  url: StringScalarFilters
+  description: StringScalarFilters
+  lastUpdated: StringScalarFilters
+  isActive: Boolean
+}
+
+input DataSourceCreateInput {
+  _id: ID @id
+  name: String
+  type: String
+  url: String
+  description: String
+  lastUpdated: String
+  isActive: Boolean
+}
+
+input DataSourceUpdateInput {
+  _id: ID! @id
+  name: String
+  type: String
+  url: String
+  description: String
+  lastUpdated: String
+  isActive: Boolean
+}
+
+input DataSourceSort {
+  _id: SortingDirection
+  name: SortingDirection
+  type: SortingDirection
+  url: SortingDirection
+  description: SortingDirection
+  lastUpdated: SortingDirection
+  isActive: SortingDirection
+}
+
 type Contains @alias(property:"contains") {
 _id: ID! @id
 }
@@ -265,6 +317,10 @@ dist: Int
 
 input RouteInput {
 dist: Int
+}
+
+type PulledFrom @alias(property:"pulled:From") {
+  _id: ID! @id
 }
 
 input Options {

--- a/src/test/templates/JSResolverOCHTTPS.test.js
+++ b/src/test/templates/JSResolverOCHTTPS.test.js
@@ -253,7 +253,7 @@ test('should resolve app sync event with nested sort arguments', () => {
     expect(result).toEqual({
         query: 'MATCH (getAirports_Airport:`airport`) WITH getAirports_Airport ORDER BY getAirports_Airport.desc ASC, getAirports_Airport.code DESC\n' +
             'OPTIONAL MATCH (getAirports_Airport)<-[`getAirports_Airport_airportRoutesIn_route`:`route`]-(getAirports_Airport_airportRoutesIn:`airport`) ' +
-            'WITH getAirports_Airport, getAirports_Airport_airportRoutesIn, getAirports_Airport_airportRoutesIn_route ORDER BY getAirports_Airport_airportRoutesIn.country ASC, getAirports_Airport_airportRoutesIn.city DESC\n' +
+            'WITH getAirports_Airport, getAirports_Airport_airportRoutesIn, `getAirports_Airport_airportRoutesIn_route` ORDER BY getAirports_Airport_airportRoutesIn.country ASC, getAirports_Airport_airportRoutesIn.city DESC\n' +
             'WITH getAirports_Airport, CASE WHEN getAirports_Airport_airportRoutesIn IS NULL THEN [] ELSE COLLECT({country: getAirports_Airport_airportRoutesIn.`country`, city: getAirports_Airport_airportRoutesIn.`city`}) END AS getAirports_Airport_airportRoutesIn_collect\n' +
             'RETURN collect({desc: getAirports_Airport.`desc`, code: getAirports_Airport.`code`, airportRoutesIn: getAirports_Airport_airportRoutesIn_collect})',
         parameters: {},
@@ -287,7 +287,7 @@ test('should resolve app sync event with nested sort arguments and variables', (
     expect(result).toEqual({
         query: 'MATCH (getAirports_Airport:`airport`) WITH getAirports_Airport ORDER BY getAirports_Airport.country ASC, getAirports_Airport.city ASC LIMIT 1\n' +
             'OPTIONAL MATCH (getAirports_Airport)<-[`getAirports_Airport_airportRoutesIn_route`:`route`]-(getAirports_Airport_airportRoutesIn:`airport`) ' +
-            'WITH getAirports_Airport, getAirports_Airport_airportRoutesIn, getAirports_Airport_airportRoutesIn_route ORDER BY getAirports_Airport_airportRoutesIn.country DESC, getAirports_Airport_airportRoutesIn.code DESC\n' +
+            'WITH getAirports_Airport, getAirports_Airport_airportRoutesIn, `getAirports_Airport_airportRoutesIn_route` ORDER BY getAirports_Airport_airportRoutesIn.country DESC, getAirports_Airport_airportRoutesIn.code DESC\n' +
             'WITH getAirports_Airport, CASE WHEN getAirports_Airport_airportRoutesIn IS NULL THEN [] ELSE COLLECT({_id:ID(getAirports_Airport_airportRoutesIn), city: getAirports_Airport_airportRoutesIn.`city`, code: getAirports_Airport_airportRoutesIn.`code`, country: getAirports_Airport_airportRoutesIn.`country`})[..1] END AS getAirports_Airport_airportRoutesIn_collect\n' +
             'RETURN collect({_id:ID(getAirports_Airport), city: getAirports_Airport.`city`, code: getAirports_Airport.`code`, country: getAirports_Airport.`country`, airportRoutesIn: getAirports_Airport_airportRoutesIn_collect})[..1]',
         parameters: {},
@@ -317,7 +317,7 @@ test('should resolve app sync event with nested sort and nested selection', () =
     expect(result).toEqual({
         query: 'MATCH (getAirports_Airport:`airport`)\n' +
             'OPTIONAL MATCH (getAirports_Airport)<-[`getAirports_Airport_airportRoutesIn_route`:`route`]-(getAirports_Airport_airportRoutesIn:`airport`) ' +
-            'WITH getAirports_Airport, getAirports_Airport_airportRoutesIn, getAirports_Airport_airportRoutesIn_route ' +
+            'WITH getAirports_Airport, getAirports_Airport_airportRoutesIn, `getAirports_Airport_airportRoutesIn_route` ' +
             'ORDER BY getAirports_Airport_airportRoutesIn.country DESC\n' +
             'WITH getAirports_Airport, getAirports_Airport_airportRoutesIn, {dist: getAirports_Airport_airportRoutesIn_route.`dist`} AS getAirports_Airport_airportRoutesIn_route_one\n' +
             'WITH getAirports_Airport, CASE WHEN getAirports_Airport_airportRoutesIn IS NULL THEN [] ' +
@@ -348,7 +348,7 @@ test('should resolve app sync event with ID field as both top-level and nested s
     expect(result).toEqual({
         query: 'MATCH (getAirports_Airport:`airport`) WITH getAirports_Airport ORDER BY ID(getAirports_Airport) ASC\n' +
             'OPTIONAL MATCH (getAirports_Airport)<-[`getAirports_Airport_airportRoutesIn_route`:`route`]-(getAirports_Airport_airportRoutesIn:`airport`) ' +
-            'WITH getAirports_Airport, getAirports_Airport_airportRoutesIn, getAirports_Airport_airportRoutesIn_route ORDER BY ID(getAirports_Airport_airportRoutesIn) DESC\n' +
+            'WITH getAirports_Airport, getAirports_Airport_airportRoutesIn, `getAirports_Airport_airportRoutesIn_route` ORDER BY ID(getAirports_Airport_airportRoutesIn) DESC\n' +
             'WITH getAirports_Airport, CASE WHEN getAirports_Airport_airportRoutesIn IS NULL THEN [] ELSE COLLECT({_id:ID(getAirports_Airport_airportRoutesIn)}) END AS getAirports_Airport_airportRoutesIn_collect\n' +
             'RETURN collect({_id:ID(getAirports_Airport), airportRoutesIn: getAirports_Airport_airportRoutesIn_collect})',
         parameters: {},
@@ -1172,12 +1172,12 @@ test('should resolve query with special characters in edge label', () => {
     const result = resolveGraphDBQueryFromAppSyncEvent({
         field: 'getVersions',
         arguments: {},
-        selectionSetGraphQL: '{ _id date desc dataSourcePulled_cn_fromOut { _id name type } }'
+        selectionSetGraphQL: '{ _id date desc dataSourcePulled_cn_fromOut(sort: [{ name: ASC }]) { _id name type } }'
     });
 
     expect(result).toEqual({
         query: 'MATCH (getVersions_Version:`version`)\n' +
-            'OPTIONAL MATCH (getVersions_Version)-[`getVersions_Version_dataSourcePulled_cn_fromOut_pulled:From`:`pulled:From`]->(getVersions_Version_dataSourcePulled_cn_fromOut:`dataSource`)\n' +
+            'OPTIONAL MATCH (getVersions_Version)-[`getVersions_Version_dataSourcePulled_cn_fromOut_pulled:From`:`pulled:From`]->(getVersions_Version_dataSourcePulled_cn_fromOut:`dataSource`) WITH getVersions_Version, getVersions_Version_dataSourcePulled_cn_fromOut, `getVersions_Version_dataSourcePulled_cn_fromOut_pulled:From` ORDER BY getVersions_Version_dataSourcePulled_cn_fromOut.name ASC\n' +
             'WITH getVersions_Version, CASE WHEN getVersions_Version_dataSourcePulled_cn_fromOut IS NULL THEN [] ELSE COLLECT({_id:ID(getVersions_Version_dataSourcePulled_cn_fromOut), name: getVersions_Version_dataSourcePulled_cn_fromOut.`name`, type: getVersions_Version_dataSourcePulled_cn_fromOut.`type`}) END AS getVersions_Version_dataSourcePulled_cn_fromOut_collect\n' +
             'RETURN collect({_id:ID(getVersions_Version), date: getVersions_Version.`date`, desc: getVersions_Version.`desc`, dataSourcePulled_cn_fromOut: getVersions_Version_dataSourcePulled_cn_fromOut_collect})',
         parameters: {},

--- a/src/test/templates/JSResolverOCHTTPS.test.js
+++ b/src/test/templates/JSResolverOCHTTPS.test.js
@@ -201,7 +201,7 @@ test('should resolve app sync event with nested edge filters and variables', () 
         query: "MATCH (getAirports_Airport:`airport`) " +
             "WHERE getAirports_Airport.country = $getAirports_Airport_country " +
             "WITH getAirports_Airport LIMIT 6\n" +
-            "OPTIONAL MATCH (getAirports_Airport)-[getAirports_Airport_airportRoutesOut_route:route]->(getAirports_Airport_airportRoutesOut:`airport`) " +
+            "OPTIONAL MATCH (getAirports_Airport)-[`getAirports_Airport_airportRoutesOut_route`:`route`]->(getAirports_Airport_airportRoutesOut:`airport`) " +
             "WHERE getAirports_Airport_airportRoutesOut.country STARTS WITH $getAirports_Airport_airportRoutesOut_country\n" +
             "WITH getAirports_Airport, " +
             "CASE WHEN getAirports_Airport_airportRoutesOut IS NULL THEN [] " +
@@ -252,7 +252,7 @@ test('should resolve app sync event with nested sort arguments', () => {
 
     expect(result).toEqual({
         query: 'MATCH (getAirports_Airport:`airport`) WITH getAirports_Airport ORDER BY getAirports_Airport.desc ASC, getAirports_Airport.code DESC\n' +
-            'OPTIONAL MATCH (getAirports_Airport)<-[getAirports_Airport_airportRoutesIn_route:route]-(getAirports_Airport_airportRoutesIn:`airport`) ' +
+            'OPTIONAL MATCH (getAirports_Airport)<-[`getAirports_Airport_airportRoutesIn_route`:`route`]-(getAirports_Airport_airportRoutesIn:`airport`) ' +
             'WITH getAirports_Airport, getAirports_Airport_airportRoutesIn, getAirports_Airport_airportRoutesIn_route ORDER BY getAirports_Airport_airportRoutesIn.country ASC, getAirports_Airport_airportRoutesIn.city DESC\n' +
             'WITH getAirports_Airport, CASE WHEN getAirports_Airport_airportRoutesIn IS NULL THEN [] ELSE COLLECT({country: getAirports_Airport_airportRoutesIn.`country`, city: getAirports_Airport_airportRoutesIn.`city`}) END AS getAirports_Airport_airportRoutesIn_collect\n' +
             'RETURN collect({desc: getAirports_Airport.`desc`, code: getAirports_Airport.`code`, airportRoutesIn: getAirports_Airport_airportRoutesIn_collect})',
@@ -286,7 +286,7 @@ test('should resolve app sync event with nested sort arguments and variables', (
 
     expect(result).toEqual({
         query: 'MATCH (getAirports_Airport:`airport`) WITH getAirports_Airport ORDER BY getAirports_Airport.country ASC, getAirports_Airport.city ASC LIMIT 1\n' +
-            'OPTIONAL MATCH (getAirports_Airport)<-[getAirports_Airport_airportRoutesIn_route:route]-(getAirports_Airport_airportRoutesIn:`airport`) ' +
+            'OPTIONAL MATCH (getAirports_Airport)<-[`getAirports_Airport_airportRoutesIn_route`:`route`]-(getAirports_Airport_airportRoutesIn:`airport`) ' +
             'WITH getAirports_Airport, getAirports_Airport_airportRoutesIn, getAirports_Airport_airportRoutesIn_route ORDER BY getAirports_Airport_airportRoutesIn.country DESC, getAirports_Airport_airportRoutesIn.code DESC\n' +
             'WITH getAirports_Airport, CASE WHEN getAirports_Airport_airportRoutesIn IS NULL THEN [] ELSE COLLECT({_id:ID(getAirports_Airport_airportRoutesIn), city: getAirports_Airport_airportRoutesIn.`city`, code: getAirports_Airport_airportRoutesIn.`code`, country: getAirports_Airport_airportRoutesIn.`country`})[..1] END AS getAirports_Airport_airportRoutesIn_collect\n' +
             'RETURN collect({_id:ID(getAirports_Airport), city: getAirports_Airport.`city`, code: getAirports_Airport.`code`, country: getAirports_Airport.`country`, airportRoutesIn: getAirports_Airport_airportRoutesIn_collect})[..1]',
@@ -316,7 +316,7 @@ test('should resolve app sync event with nested sort and nested selection', () =
 
     expect(result).toEqual({
         query: 'MATCH (getAirports_Airport:`airport`)\n' +
-            'OPTIONAL MATCH (getAirports_Airport)<-[getAirports_Airport_airportRoutesIn_route:route]-(getAirports_Airport_airportRoutesIn:`airport`) ' +
+            'OPTIONAL MATCH (getAirports_Airport)<-[`getAirports_Airport_airportRoutesIn_route`:`route`]-(getAirports_Airport_airportRoutesIn:`airport`) ' +
             'WITH getAirports_Airport, getAirports_Airport_airportRoutesIn, getAirports_Airport_airportRoutesIn_route ' +
             'ORDER BY getAirports_Airport_airportRoutesIn.country DESC\n' +
             'WITH getAirports_Airport, getAirports_Airport_airportRoutesIn, {dist: getAirports_Airport_airportRoutesIn_route.`dist`} AS getAirports_Airport_airportRoutesIn_route_one\n' +
@@ -347,7 +347,7 @@ test('should resolve app sync event with ID field as both top-level and nested s
 
     expect(result).toEqual({
         query: 'MATCH (getAirports_Airport:`airport`) WITH getAirports_Airport ORDER BY ID(getAirports_Airport) ASC\n' +
-            'OPTIONAL MATCH (getAirports_Airport)<-[getAirports_Airport_airportRoutesIn_route:route]-(getAirports_Airport_airportRoutesIn:`airport`) ' +
+            'OPTIONAL MATCH (getAirports_Airport)<-[`getAirports_Airport_airportRoutesIn_route`:`route`]-(getAirports_Airport_airportRoutesIn:`airport`) ' +
             'WITH getAirports_Airport, getAirports_Airport_airportRoutesIn, getAirports_Airport_airportRoutesIn_route ORDER BY ID(getAirports_Airport_airportRoutesIn) DESC\n' +
             'WITH getAirports_Airport, CASE WHEN getAirports_Airport_airportRoutesIn IS NULL THEN [] ELSE COLLECT({_id:ID(getAirports_Airport_airportRoutesIn)}) END AS getAirports_Airport_airportRoutesIn_collect\n' +
             'RETURN collect({_id:ID(getAirports_Airport), airportRoutesIn: getAirports_Airport_airportRoutesIn_collect})',
@@ -427,9 +427,9 @@ test('should inference query with nested types single and array, references in a
 
     expect(result).toMatchObject({
         query: "MATCH (getAirportByCode_Airport:`airport`{code:'YKM'})\n" +
-            'OPTIONAL MATCH (getAirportByCode_Airport)<-[getAirportByCode_Airport_continentContainsIn_contains:contains]-(getAirportByCode_Airport_continentContainsIn:`continent`)\n' +
-            'OPTIONAL MATCH (getAirportByCode_Airport)<-[getAirportByCode_Airport_countryContainsIn_contains:contains]-(getAirportByCode_Airport_countryContainsIn:`country`)\n' +
-            'OPTIONAL MATCH (getAirportByCode_Airport)-[getAirportByCode_Airport_airportRoutesOut_route:route]->(getAirportByCode_Airport_airportRoutesOut:`airport`)\n' +
+            'OPTIONAL MATCH (getAirportByCode_Airport)<-[`getAirportByCode_Airport_continentContainsIn_contains`:`contains`]-(getAirportByCode_Airport_continentContainsIn:`continent`)\n' +
+            'OPTIONAL MATCH (getAirportByCode_Airport)<-[`getAirportByCode_Airport_countryContainsIn_contains`:`contains`]-(getAirportByCode_Airport_countryContainsIn:`country`)\n' +
+            'OPTIONAL MATCH (getAirportByCode_Airport)-[`getAirportByCode_Airport_airportRoutesOut_route`:`route`]->(getAirportByCode_Airport_airportRoutesOut:`airport`)\n' +
             'WITH getAirportByCode_Airport, getAirportByCode_Airport_continentContainsIn, getAirportByCode_Airport_countryContainsIn, CASE WHEN getAirportByCode_Airport_airportRoutesOut IS NULL THEN [] ELSE COLLECT({code: getAirportByCode_Airport_airportRoutesOut.`code`}) END AS getAirportByCode_Airport_airportRoutesOut_collect\n' +
             'WITH getAirportByCode_Airport, getAirportByCode_Airport_continentContainsIn, getAirportByCode_Airport_airportRoutesOut_collect, {desc: getAirportByCode_Airport_countryContainsIn.`desc`} AS getAirportByCode_Airport_countryContainsIn_one\n' +
             'WITH getAirportByCode_Airport, getAirportByCode_Airport_countryContainsIn_one, getAirportByCode_Airport_airportRoutesOut_collect, {desc: getAirportByCode_Airport_continentContainsIn.`desc`} AS getAirportByCode_Airport_continentContainsIn_one\n' +
@@ -446,7 +446,7 @@ test('should get edge properties in nested array (Query0004)', () => {
 
     expect(result).toMatchObject({
         query: "MATCH (getAirportByCode_Airport:`airport`{code:'SEA'})\n" +
-            'OPTIONAL MATCH (getAirportByCode_Airport)-[getAirportByCode_Airport_airportRoutesOut_route:route]->(getAirportByCode_Airport_airportRoutesOut:`airport`)\n' +
+            'OPTIONAL MATCH (getAirportByCode_Airport)-[`getAirportByCode_Airport_airportRoutesOut_route`:`route`]->(getAirportByCode_Airport_airportRoutesOut:`airport`)\n' +
             'WITH getAirportByCode_Airport, getAirportByCode_Airport_airportRoutesOut, {dist: getAirportByCode_Airport_airportRoutesOut_route.`dist`} AS getAirportByCode_Airport_airportRoutesOut_route_one\n' +
             'WITH getAirportByCode_Airport, CASE WHEN getAirportByCode_Airport_airportRoutesOut IS NULL THEN [] ELSE COLLECT({code: getAirportByCode_Airport_airportRoutesOut.`code`, route: getAirportByCode_Airport_airportRoutesOut_route_one}) END AS getAirportByCode_Airport_airportRoutesOut_collect\n' +
             'RETURN {airportRoutesOut: getAirportByCode_Airport_airportRoutesOut_collect} LIMIT 1',
@@ -583,7 +583,7 @@ test('should apply limit to results returned from a nested edge (Query0012)', ()
 
     expect(result).toMatchObject({
         query: 'MATCH (getAirport_Airport:`airport`) WHERE getAirport_Airport.code = $getAirport_Airport_code\n' +
-            'OPTIONAL MATCH (getAirport_Airport)-[getAirport_Airport_airportRoutesOut_route:route]->(getAirport_Airport_airportRoutesOut:`airport`)\n' +
+            'OPTIONAL MATCH (getAirport_Airport)-[`getAirport_Airport_airportRoutesOut_route`:`route`]->(getAirport_Airport_airportRoutesOut:`airport`)\n' +
             'WITH getAirport_Airport, CASE WHEN getAirport_Airport_airportRoutesOut IS NULL THEN [] ELSE COLLECT({code: getAirport_Airport_airportRoutesOut.`code`})[..2] END AS getAirport_Airport_airportRoutesOut_collect\n' +
             'RETURN {airportRoutesOut: getAirport_Airport_airportRoutesOut_collect} LIMIT 1',
         parameters: { getAirport_Airport_code: 'SEA' },
@@ -598,7 +598,7 @@ test('should inference query with filter in nested edge (Query0013)', () => {
 
     expect(result).toMatchObject({
         query: 'MATCH (getAirport_Airport:`airport`) WHERE getAirport_Airport.code = $getAirport_Airport_code\n' +
-            'OPTIONAL MATCH (getAirport_Airport)-[getAirport_Airport_airportRoutesOut_route:route]->(getAirport_Airport_airportRoutesOut:`airport`) WHERE getAirport_Airport_airportRoutesOut.code = $getAirport_Airport_airportRoutesOut_code\n' +
+            'OPTIONAL MATCH (getAirport_Airport)-[`getAirport_Airport_airportRoutesOut_route`:`route`]->(getAirport_Airport_airportRoutesOut:`airport`) WHERE getAirport_Airport_airportRoutesOut.code = $getAirport_Airport_airportRoutesOut_code\n' +
             'WITH getAirport_Airport, CASE WHEN getAirport_Airport_airportRoutesOut IS NULL THEN [] ELSE COLLECT({city: getAirport_Airport_airportRoutesOut.`city`}) END AS getAirport_Airport_airportRoutesOut_collect\n' +
             'RETURN {airportRoutesOut: getAirport_Airport_airportRoutesOut_collect, city: getAirport_Airport.`city`} LIMIT 1',
         parameters: {
@@ -900,7 +900,7 @@ test('should resolve query with nested edge filter that uses string comparison o
         query: 'MATCH (getAirports_Airport:`airport`) ' +
             'WHERE getAirports_Airport.country = $getAirports_Airport_country ' +
             'WITH getAirports_Airport LIMIT 5\n' +
-            'OPTIONAL MATCH (getAirports_Airport)-[getAirports_Airport_airportRoutesOut_route:route]->(getAirports_Airport_airportRoutesOut:`airport`) ' +
+            'OPTIONAL MATCH (getAirports_Airport)-[`getAirports_Airport_airportRoutesOut_route`:`route`]->(getAirports_Airport_airportRoutesOut:`airport`) ' +
             'WHERE getAirports_Airport_airportRoutesOut.country STARTS WITH $getAirports_Airport_airportRoutesOut_country ' +
             'AND getAirports_Airport_airportRoutesOut.code CONTAINS $getAirports_Airport_airportRoutesOut_code\n' +
             'WITH getAirports_Airport, ' +
@@ -966,7 +966,7 @@ test('should resolve query with nested edge filter and variables', () => {
         query: 'MATCH (getAirports_Airport:`airport`) ' +
             'WHERE getAirports_Airport.country = $getAirports_Airport_country ' +
             'WITH getAirports_Airport LIMIT 6\n' +
-            'OPTIONAL MATCH (getAirports_Airport)-[getAirports_Airport_airportRoutesOut_route:route]->(getAirports_Airport_airportRoutesOut:`airport`) ' +
+            'OPTIONAL MATCH (getAirports_Airport)-[`getAirports_Airport_airportRoutesOut_route`:`route`]->(getAirports_Airport_airportRoutesOut:`airport`) ' +
             'WHERE getAirports_Airport_airportRoutesOut.country STARTS WITH $getAirports_Airport_airportRoutesOut_country\n' +
             'WITH getAirports_Airport, ' +
             'CASE WHEN getAirports_Airport_airportRoutesOut IS NULL THEN [] ' +
@@ -1010,7 +1010,7 @@ test('should resolve query with nested edge filter and nested scalar variables',
         query: 'MATCH (getAirports_Airport:`airport`) ' +
             'WHERE getAirports_Airport.country = $getAirports_Airport_country ' +
             'WITH getAirports_Airport LIMIT 6\n' +
-            'OPTIONAL MATCH (getAirports_Airport)-[getAirports_Airport_airportRoutesOut_route:route]->(getAirports_Airport_airportRoutesOut:`airport`) ' +
+            'OPTIONAL MATCH (getAirports_Airport)-[`getAirports_Airport_airportRoutesOut_route`:`route`]->(getAirports_Airport_airportRoutesOut:`airport`) ' +
             'WHERE getAirports_Airport_airportRoutesOut.country = $getAirports_Airport_airportRoutesOut_country\n' +
             'WITH getAirports_Airport, ' +
             'CASE WHEN getAirports_Airport_airportRoutesOut IS NULL THEN [] ' +
@@ -1168,6 +1168,24 @@ test('should resolve mutation to update connection between nodes with a prefix',
     });
 });
 
+test('should resolve query with special characters in edge label', () => {
+    const result = resolveGraphDBQueryFromAppSyncEvent({
+        field: 'getVersions',
+        arguments: {},
+        selectionSetGraphQL: '{ _id date desc dataSourcePulledFromOut { _id name type } }'
+    });
+
+    expect(result).toEqual({
+        query: 'MATCH (getVersions_Version:`version`)\n' +
+            'OPTIONAL MATCH (getVersions_Version)-[`getVersions_Version_dataSourcePulledFromOut_pulled:From`:`pulled:From`]->(getVersions_Version_dataSourcePulledFromOut:`dataSource`)\n' +
+            'WITH getVersions_Version, CASE WHEN getVersions_Version_dataSourcePulledFromOut IS NULL THEN [] ELSE COLLECT({_id:ID(getVersions_Version_dataSourcePulledFromOut), name: getVersions_Version_dataSourcePulledFromOut.`name`, type: getVersions_Version_dataSourcePulledFromOut.`type`}) END AS getVersions_Version_dataSourcePulledFromOut_collect\n' +
+            'RETURN collect({_id:ID(getVersions_Version), date: getVersions_Version.`date`, desc: getVersions_Version.`desc`, dataSourcePulledFromOut: getVersions_Version_dataSourcePulledFromOut_collect})',
+        parameters: {},
+        language: 'opencypher',
+        refactorOutput: null
+    });
+});
+
 test('should resolve query with limit and offset', () => {
     const result = resolveGraphDBQueryFromAppSyncEvent({
         field: 'getAirports',
@@ -1191,7 +1209,7 @@ test('should resolve query with nested edge limit and offset', () => {
     });
     expect(result).toEqual({
         query: 'MATCH (getAirports_Airport:`airport`) WITH getAirports_Airport SKIP 2 LIMIT 10\n' +
-            'OPTIONAL MATCH (getAirports_Airport)<-[getAirports_Airport_airportRoutesIn_route:route]-(getAirports_Airport_airportRoutesIn:`airport`)\n' +
+            'OPTIONAL MATCH (getAirports_Airport)<-[`getAirports_Airport_airportRoutesIn_route`:`route`]-(getAirports_Airport_airportRoutesIn:`airport`)\n' +
             'WITH getAirports_Airport, CASE WHEN getAirports_Airport_airportRoutesIn IS NULL THEN [] ' +
             'ELSE COLLECT({code: getAirports_Airport_airportRoutesIn.`code`})[5..8] ' +
             'END AS getAirports_Airport_airportRoutesIn_collect\n' +
@@ -1214,7 +1232,7 @@ test('should resolve query with nested edge limit and offset from variables', ()
     });
     expect(result).toEqual({
         query: 'MATCH (getAirports_Airport:`airport`) WITH getAirports_Airport SKIP 4 LIMIT 2\n' +
-            'OPTIONAL MATCH (getAirports_Airport)-[getAirports_Airport_airportRoutesOut_route:route]->(getAirports_Airport_airportRoutesOut:`airport`)\n' +
+            'OPTIONAL MATCH (getAirports_Airport)-[`getAirports_Airport_airportRoutesOut_route`:`route`]->(getAirports_Airport_airportRoutesOut:`airport`)\n' +
             'WITH getAirports_Airport, CASE WHEN getAirports_Airport_airportRoutesOut IS NULL THEN [] ' +
             'ELSE COLLECT({code: getAirports_Airport_airportRoutesOut.`code`})[6..9] ' +
             'END AS getAirports_Airport_airportRoutesOut_collect\n' +
@@ -1237,7 +1255,7 @@ test('should resolve query zero limit and offset', () => {
     });
     expect(result).toEqual({
         query: 'MATCH (getAirports_Airport:`airport`) WITH getAirports_Airport SKIP 0 LIMIT 0\n' +
-            'OPTIONAL MATCH (getAirports_Airport)<-[getAirports_Airport_airportRoutesIn_route:route]-(getAirports_Airport_airportRoutesIn:`airport`)\n' +
+            'OPTIONAL MATCH (getAirports_Airport)<-[`getAirports_Airport_airportRoutesIn_route`:`route`]-(getAirports_Airport_airportRoutesIn:`airport`)\n' +
             'WITH getAirports_Airport, CASE WHEN getAirports_Airport_airportRoutesIn IS NULL THEN [] ' +
             'ELSE COLLECT({code: getAirports_Airport_airportRoutesIn.`code`})[0..0] ' +
             'END AS getAirports_Airport_airportRoutesIn_collect\n' +
@@ -1312,7 +1330,7 @@ test('should resolve query with nested edge fragments', () => {
     expect(result).toEqual({
         query: 'MATCH (getAirport_Airport:`airport`) ' +
             'WHERE getAirport_Airport.code = $getAirport_Airport_code\n' +
-            'OPTIONAL MATCH (getAirport_Airport)<-[getAirport_Airport_airportRoutesIn_route:route]-(getAirport_Airport_airportRoutesIn:`airport`)\n' +
+            'OPTIONAL MATCH (getAirport_Airport)<-[`getAirport_Airport_airportRoutesIn_route`:`route`]-(getAirport_Airport_airportRoutesIn:`airport`)\n' +
             'WITH getAirport_Airport, ' +
             'CASE WHEN getAirport_Airport_airportRoutesIn IS NULL THEN [] ' +
             'ELSE COLLECT({' +
@@ -1480,7 +1498,7 @@ test('should resolve multiple app sync events with updated variable values', () 
     // first result should reflect initial variable values
     expect(firstResult).toEqual({
         query: 'MATCH (getAirports_Airport:`airport`) WITH getAirports_Airport LIMIT 3\n' +
-            'OPTIONAL MATCH (getAirports_Airport)-[getAirports_Airport_airportRoutesOut_route:route]->(getAirports_Airport_airportRoutesOut:`airport`) WHERE getAirports_Airport_airportRoutesOut.country = $getAirports_Airport_airportRoutesOut_country\n' +
+            'OPTIONAL MATCH (getAirports_Airport)-[`getAirports_Airport_airportRoutesOut_route`:`route`]->(getAirports_Airport_airportRoutesOut:`airport`) WHERE getAirports_Airport_airportRoutesOut.country = $getAirports_Airport_airportRoutesOut_country\n' +
             'WITH getAirports_Airport, CASE WHEN getAirports_Airport_airportRoutesOut IS NULL THEN [] ELSE COLLECT({code: getAirports_Airport_airportRoutesOut.`code`})[..2] END AS getAirports_Airport_airportRoutesOut_collect\n' +
             'RETURN collect({code: getAirports_Airport.`code`, airportRoutesOut: getAirports_Airport_airportRoutesOut_collect})[..3]',
         parameters: { getAirports_Airport_airportRoutesOut_country: 'CA'},
@@ -1499,7 +1517,7 @@ test('should resolve multiple app sync events with updated variable values', () 
     // second result should reflect updated variable values
     expect(secondResult).toEqual({
         query: 'MATCH (getAirports_Airport:`airport`) WITH getAirports_Airport LIMIT 3\n' +
-            'OPTIONAL MATCH (getAirports_Airport)-[getAirports_Airport_airportRoutesOut_route:route]->(getAirports_Airport_airportRoutesOut:`airport`) WHERE getAirports_Airport_airportRoutesOut.country = $getAirports_Airport_airportRoutesOut_country\n' +
+            'OPTIONAL MATCH (getAirports_Airport)-[`getAirports_Airport_airportRoutesOut_route`:`route`]->(getAirports_Airport_airportRoutesOut:`airport`) WHERE getAirports_Airport_airportRoutesOut.country = $getAirports_Airport_airportRoutesOut_country\n' +
             'WITH getAirports_Airport, CASE WHEN getAirports_Airport_airportRoutesOut IS NULL THEN [] ELSE COLLECT({code: getAirports_Airport_airportRoutesOut.`code`})[..1] END AS getAirports_Airport_airportRoutesOut_collect\n' +
             'RETURN collect({code: getAirports_Airport.`code`, airportRoutesOut: getAirports_Airport_airportRoutesOut_collect})[..3]',
         parameters: { getAirports_Airport_airportRoutesOut_country: 'MX'},

--- a/src/test/templates/JSResolverOCHTTPS.test.js
+++ b/src/test/templates/JSResolverOCHTTPS.test.js
@@ -1172,14 +1172,14 @@ test('should resolve query with special characters in edge label', () => {
     const result = resolveGraphDBQueryFromAppSyncEvent({
         field: 'getVersions',
         arguments: {},
-        selectionSetGraphQL: '{ _id date desc dataSourcePulledFromOut { _id name type } }'
+        selectionSetGraphQL: '{ _id date desc dataSourcePulled_cn_fromOut { _id name type } }'
     });
 
     expect(result).toEqual({
         query: 'MATCH (getVersions_Version:`version`)\n' +
-            'OPTIONAL MATCH (getVersions_Version)-[`getVersions_Version_dataSourcePulledFromOut_pulled:From`:`pulled:From`]->(getVersions_Version_dataSourcePulledFromOut:`dataSource`)\n' +
-            'WITH getVersions_Version, CASE WHEN getVersions_Version_dataSourcePulledFromOut IS NULL THEN [] ELSE COLLECT({_id:ID(getVersions_Version_dataSourcePulledFromOut), name: getVersions_Version_dataSourcePulledFromOut.`name`, type: getVersions_Version_dataSourcePulledFromOut.`type`}) END AS getVersions_Version_dataSourcePulledFromOut_collect\n' +
-            'RETURN collect({_id:ID(getVersions_Version), date: getVersions_Version.`date`, desc: getVersions_Version.`desc`, dataSourcePulledFromOut: getVersions_Version_dataSourcePulledFromOut_collect})',
+            'OPTIONAL MATCH (getVersions_Version)-[`getVersions_Version_dataSourcePulled_cn_fromOut_pulled:From`:`pulled:From`]->(getVersions_Version_dataSourcePulled_cn_fromOut:`dataSource`)\n' +
+            'WITH getVersions_Version, CASE WHEN getVersions_Version_dataSourcePulled_cn_fromOut IS NULL THEN [] ELSE COLLECT({_id:ID(getVersions_Version_dataSourcePulled_cn_fromOut), name: getVersions_Version_dataSourcePulled_cn_fromOut.`name`, type: getVersions_Version_dataSourcePulled_cn_fromOut.`type`}) END AS getVersions_Version_dataSourcePulled_cn_fromOut_collect\n' +
+            'RETURN collect({_id:ID(getVersions_Version), date: getVersions_Version.`date`, desc: getVersions_Version.`desc`, dataSourcePulled_cn_fromOut: getVersions_Version_dataSourcePulled_cn_fromOut_collect})',
         parameters: {},
         language: 'opencypher',
         refactorOutput: null

--- a/templates/JSResolverOCHTTPS.js
+++ b/templates/JSResolverOCHTTPS.js
@@ -709,7 +709,7 @@ function createTypeFieldStatementAndRecurse({selection, fieldSchemaInfo, lastNam
         if (schemaTypeInfo.relationship.direction !== 'IN') {
             arrows.shift();
         }
-        matchStatements.push(`OPTIONAL MATCH (${lastNamePath})${arrows[0]}[${schemaTypeInfo.pathName}_${schemaTypeInfo.relationship.edgeType}:${schemaTypeInfo.relationship.edgeType}]${arrows[1]}(${schemaTypeInfo.pathName}:\`${schemaTypeInfo.typeAlias}\`${queryArgs})${whereClause}${orderByClause}`);
+        matchStatements.push(`OPTIONAL MATCH (${lastNamePath})${arrows[0]}[\`${schemaTypeInfo.pathName}_${schemaTypeInfo.relationship.edgeType}\`:\`${schemaTypeInfo.relationship.edgeType}\`]${arrows[1]}(${schemaTypeInfo.pathName}:\`${schemaTypeInfo.typeAlias}\`${queryArgs})${whereClause}${orderByClause}`);
     }
 
     const thisWithId = withStatements.push({carryOver: schemaTypeInfo.pathName, inLevel: '', content: ''}) - 1;

--- a/templates/JSResolverOCHTTPS.js
+++ b/templates/JSResolverOCHTTPS.js
@@ -700,7 +700,7 @@ function createTypeFieldStatementAndRecurse({selection, fieldSchemaInfo, lastNam
     const argsAndWhereClauses = extractQueryArgsAndWhereClauses(selection.arguments, fieldSchemaInfo);
     const queryArgs = argsAndWhereClauses.queryArguments?.length > 0 ? `{${argsAndWhereClauses.queryArguments.join(',')}}` : '';
     const whereClause = argsAndWhereClauses.whereClauses?.length > 0 ? ` WHERE ${argsAndWhereClauses.whereClauses.join(' AND ')}` : '';
-    const edgePath = schemaTypeInfo.isRelationship ? `${schemaTypeInfo.pathName}_${schemaTypeInfo.relationship.edgeType}` : '';
+    const edgePath = schemaTypeInfo.isRelationship ? `\`${schemaTypeInfo.pathName}_${schemaTypeInfo.relationship.edgeType}\`` : '';
     const withClause = `${[lastNamePath, schemaTypeInfo.pathName, edgePath].filter(path => path !== '').join(', ')}`;
     const orderByClause = fieldSchemaInfo.argOrderBy?.length ? ` WITH ${withClause} ORDER BY ${fieldSchemaInfo.argOrderBy.map(orderBy => `${orderBy.field === fieldSchemaInfo.graphDBIdArgName ? `ID(${schemaTypeInfo.pathName})` : `${schemaTypeInfo.pathName}.${orderBy.field}`} ${orderBy.direction}`).join(', ')}` : '';
 


### PR DESCRIPTION
Queries would fail if an edge label contained a special character such as a colon, period, or space as it is invalid formatting for Cypher. Thus, back ticks were added to ensure that special characters could be included as label names without crashing from incorrect Cypher translations.

Added a unit test for the resolver to ensure backticks are added correctly in cypher translations from queries with special characters in edge labels. Also changed existing resolver unit tests to accommodate for this change.