### PR TITLE
Improved error when selection or query field types cannot be determined

### DIFF
--- a/src/test/templates/JSResolverOCHTTPS.test.js
+++ b/src/test/templates/JSResolverOCHTTPS.test.js
@@ -4,6 +4,7 @@ import {schemaParser} from "../../schemaParser.js";
 import {validatedSchemaModel} from "../../schemaModelValidator.js";
 import {injectAwsScalarDefinitions} from "../../../templates/util.mjs";
 import { gql } from "graphql-tag";
+import { jest } from "@jest/globals";
 
 beforeAll(() => {
     // Initialize resolver
@@ -1524,4 +1525,26 @@ test('should resolve multiple app sync events with updated variable values', () 
         language: 'opencypher',
         refactorOutput: null
     });
+});
+
+test('should log detailed error when GraphQL selection set field type cannot be resolved', () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    
+    try {
+        resolveGraphDBQueryFromEvent({
+            field: 'getAirport',
+            arguments: {},
+            selectionSet: gql`{ invalid }`.definitions[0].selectionSet,
+            fragments: {}
+        });
+    } catch (error) {
+        // Expected to fail due to unhandled type
+        console.log(error);
+    }
+    
+    expect(consoleSpy).toHaveBeenCalledWith(
+        'GraphQL field type not found - field: invalid type: Airport path: getAirport_Airport.'
+    );
+    
+    consoleSpy.mockRestore();
 });

--- a/templates/JSResolverOCHTTPS.js
+++ b/templates/JSResolverOCHTTPS.js
@@ -299,9 +299,11 @@ function getSchemaQueryInfo(name) {
 
     });
 
-    if (r.returnType == '') {
-        console.error('GraphQL query not found.');
-
+    if (!r.returnType) {
+        // if we ended up here it means there's an unhandled field type
+        const message = `GraphQL query return type not found for ${name}`;
+        console.error(message);
+        throw new Error(message);
     }
 
     return r;
@@ -449,8 +451,10 @@ function getSchemaFieldInfo(typeName, fieldName, pathName) {
         }
     });
 
-    if (r.type == '') {
-        console.error('GraphQL field not found.');
+    if (!r.type) {
+        // not throwing error here as the type is not currently used to determine the cypher query
+        // but logging for troubleshooting purposes
+        console.log(`GraphQL field type not found - field: ${fieldName} type: ${typeName} path: ${pathName}.`);
     }
 
     return r;


### PR DESCRIPTION
Improved error details when a selection field type cannot be found. Throw error if query return type cannot be found as the return type is required to determine the cypher query.
