### PR TITLE
Fixed graphdb.js to process ONE-ONE edge types

### DIFF
--- a/src/graphdb.js
+++ b/src/graphdb.js
@@ -195,7 +195,7 @@ function graphDBInferenceSchema (graphdbSchema, { addMutations = true, queryPref
                     if (direction.relationship === 'ONE-MANY') {
                         r += `\t${toCase.toLocaleLowerCase() + edgeCase}sOut(filter: ${toCase}Input, options: Options, sort: [${toCase}Sort!]): [${toCase}] @relationship(edgeType:"${edge.label}", direction:OUT)\n`;
                     }
-                    if (direction.relationship === 'MANY-ONE') {
+                    if (direction.relationship === 'MANY-ONE' || direction.relationship === 'ONE-ONE') {
                         r += `\t${toCase.toLocaleLowerCase() + edgeCase}Out: ${toCase} @relationship(edgeType:"${edge.label}", direction:OUT)\n`;
                     }
                     if (!edgeTypes.includes(edge.label))
@@ -206,7 +206,7 @@ function graphDBInferenceSchema (graphdbSchema, { addMutations = true, queryPref
                     if (direction.relationship === 'MANY-MANY') {
                         r += `\t${fromCase.toLocaleLowerCase() + edgeCase}sIn(filter: ${fromCase}Input, options: Options, sort: [${fromCase}Sort!]): [${fromCase}] @relationship(edgeType:"${edge.label}", direction:IN)\n`
                     }
-                    if (direction.relationship === 'ONE-MANY') {
+                    if (direction.relationship === 'ONE-MANY' || direction.relationship === 'ONE-ONE') {
                         r += `\t${fromCase.toLocaleLowerCase() + edgeCase}In: ${fromCase} @relationship(edgeType:"${edge.label}", direction:IN)\n`;
                     }
                     if (direction.relationship === 'MANY-ONE') {

--- a/src/graphdb.js
+++ b/src/graphdb.js
@@ -176,41 +176,54 @@ function graphDBInferenceSchema (graphdbSchema, { addMutations = true, queryPref
                 let edgeCase = toPascalCase(cleanseLabel(edge.label));
 
                 if (direction.from === node.label && direction.to === node.label){
-                    if (direction.relationship === 'MANY-MANY') {
-                        r += `\t${nodeCase.toLocaleLowerCase() + edgeCase}sOut(filter: ${nodeCase}Input, options: Options, sort: [${nodeCase}Sort!]): [${nodeCase}] @relationship(edgeType:"${edge.label}", direction:OUT)\n`;
-                        r += `\t${nodeCase.toLocaleLowerCase() + edgeCase}sIn(filter: ${nodeCase}Input, options: Options, sort: [${nodeCase}Sort!]): [${nodeCase}] @relationship(edgeType:"${edge.label}", direction:IN)\n`;
-                    }
-                    if (direction.relationship === 'ONE-ONE') {
-                        r += `\t${nodeCase.toLocaleLowerCase() + edgeCase}Out: ${nodeCase} @relationship(edgeType:"${edge.label}", direction:OUT)\n`;
-                        r += `\t${nodeCase.toLocaleLowerCase() + edgeCase}In: ${nodeCase} @relationship(edgeType:"${edge.label}", direction:IN)\n`;
-                    }
-                    if (!edgeTypes.includes(edge.label))
-                        edgeTypes.push(edge.label);                                      
-                }
-                
-                if (direction.from === node.label && direction.to !== node.label){
-                    if (direction.relationship === 'MANY-MANY') {
-                        r += `\t${toCase.toLocaleLowerCase() + edgeCase}sOut(filter: ${toCase}Input, options: Options, sort: [${toCase}Sort!]): [${toCase}] @relationship(edgeType:"${edge.label}", direction:OUT)\n`;
-                    }
-                    if (direction.relationship === 'ONE-MANY') {
-                        r += `\t${toCase.toLocaleLowerCase() + edgeCase}sOut(filter: ${toCase}Input, options: Options, sort: [${toCase}Sort!]): [${toCase}] @relationship(edgeType:"${edge.label}", direction:OUT)\n`;
-                    }
-                    if (direction.relationship === 'MANY-ONE' || direction.relationship === 'ONE-ONE') {
-                        r += `\t${toCase.toLocaleLowerCase() + edgeCase}Out: ${toCase} @relationship(edgeType:"${edge.label}", direction:OUT)\n`;
+                    switch (direction.relationship) {
+                        case 'MANY-MANY':
+                            r += `\t${nodeCase.toLocaleLowerCase() + edgeCase}sOut(filter: ${nodeCase}Input, options: Options, sort: [${nodeCase}Sort!]): [${nodeCase}] @relationship(edgeType:"${edge.label}", direction:OUT)\n`;
+                            r += `\t${nodeCase.toLocaleLowerCase() + edgeCase}sIn(filter: ${nodeCase}Input, options: Options, sort: [${nodeCase}Sort!]): [${nodeCase}] @relationship(edgeType:"${edge.label}", direction:IN)\n`;
+                            break;
+                        case 'ONE-ONE':
+                            r += `\t${nodeCase.toLocaleLowerCase() + edgeCase}Out: ${nodeCase} @relationship(edgeType:"${edge.label}", direction:OUT)\n`;
+                            r += `\t${nodeCase.toLocaleLowerCase() + edgeCase}In: ${nodeCase} @relationship(edgeType:"${edge.label}", direction:IN)\n`;
+                            break;
+                        default:
+                            loggerInfo(`Unknown relationship type for edge from ${direction.from} to ${direction.to}: ${direction.relationship}`, {toConsole: true});
+                            break;
                     }
                     if (!edgeTypes.includes(edge.label))
                         edgeTypes.push(edge.label);                                      
                 }
-                
-                if (direction.from !== node.label && direction.to === node.label){
-                    if (direction.relationship === 'MANY-MANY') {
-                        r += `\t${fromCase.toLocaleLowerCase() + edgeCase}sIn(filter: ${fromCase}Input, options: Options, sort: [${fromCase}Sort!]): [${fromCase}] @relationship(edgeType:"${edge.label}", direction:IN)\n`
+
+                if (direction.from === node.label && direction.to !== node.label) {
+                    switch (direction.relationship) {
+                        case 'MANY-MANY':
+                        case 'ONE-MANY':
+                            r += `\t${toCase.toLocaleLowerCase() + edgeCase}sOut(filter: ${toCase}Input, options: Options, sort: [${toCase}Sort!]): [${toCase}] @relationship(edgeType:"${edge.label}", direction:OUT)\n`;
+                            break;
+                        case 'MANY-ONE':
+                        case 'ONE-ONE':
+                            r += `\t${toCase.toLocaleLowerCase() + edgeCase}Out: ${toCase} @relationship(edgeType:"${edge.label}", direction:OUT)\n`;
+                            break;
+                        default:
+                            loggerInfo(`Unknown relationship type for edge from ${direction.from} to ${direction.to}: ${direction.relationship}`, {toConsole: true});
+                            break;
                     }
-                    if (direction.relationship === 'ONE-MANY' || direction.relationship === 'ONE-ONE') {
-                        r += `\t${fromCase.toLocaleLowerCase() + edgeCase}In: ${fromCase} @relationship(edgeType:"${edge.label}", direction:IN)\n`;
-                    }
-                    if (direction.relationship === 'MANY-ONE') {
-                        r += `\t${fromCase.toLocaleLowerCase() + edgeCase}sIn(filter: ${fromCase}Input, options: Options, sort: [${fromCase}Sort!]): [${fromCase}] @relationship(edgeType:"${edge.label}", direction:IN)\n`;
+                    if (!edgeTypes.includes(edge.label))
+                        edgeTypes.push(edge.label);
+                }
+
+                if (direction.from !== node.label && direction.to === node.label) {
+                    switch (direction.relationship) {
+                        case 'MANY-MANY':
+                        case 'MANY-ONE':
+                            r += `\t${fromCase.toLocaleLowerCase() + edgeCase}sIn(filter: ${fromCase}Input, options: Options, sort: [${fromCase}Sort!]): [${fromCase}] @relationship(edgeType:"${edge.label}", direction:IN)\n`
+                            break;
+                        case 'ONE-MANY':
+                        case 'ONE-ONE':
+                            r += `\t${fromCase.toLocaleLowerCase() + edgeCase}In: ${fromCase} @relationship(edgeType:"${edge.label}", direction:IN)\n`;
+                            break;
+                        default:
+                            loggerInfo(`Unknown relationship type for edge from ${direction.from} to ${direction.to}: ${direction.relationship}`, {toConsole: true});
+                            break;
                     }
                     if (!edgeTypes.includes(edge.label))
                         edgeTypes.push(edge.label);                                      

--- a/src/test/dining.graphql
+++ b/src/test/dining.graphql
@@ -7,6 +7,7 @@ type City @alias(property: "city") {
     _id: ID! @id
     name: String
     personLivessIn(filter: PersonInput, options: Options, sort: [PersonSort!]): [Person] @relationship(edgeType: "lives", direction: IN)
+    stateWithinOut: State @relationship(edgeType: "within", direction: OUT)
     restaurantWithinsIn(filter: RestaurantInput, options: Options, sort: [RestaurantSort!]): [Restaurant] @relationship(edgeType: "within", direction: IN)
     lives: Lives
     within: Within
@@ -122,6 +123,7 @@ input CuisineSort {
 type State @alias(property: "state") {
     _id: ID! @id
     name: String
+    cityWithinIn: City @relationship(edgeType: "within", direction: IN)
     within: Within
 }
 

--- a/src/test/epl.graphql
+++ b/src/test/epl.graphql
@@ -9,6 +9,7 @@ type Stadium {
     capacity: Int
     name: String
     cityCity_edgeOut: City @relationship(edgeType: "CITY_EDGE", direction: OUT)
+    teamStadium_edgeIn: Team @relationship(edgeType: "STADIUM_EDGE", direction: IN)
     CITY_EDGE: City_edge
     STADIUM_EDGE: Stadium_edge
 }
@@ -54,6 +55,7 @@ type Team {
     fullName: String
     founded: Int
     leagueCurrent_leagueOut: League @relationship(edgeType: "CURRENT_LEAGUE", direction: OUT)
+    stadiumStadium_edgeOut: Stadium @relationship(edgeType: "STADIUM_EDGE", direction: OUT)
     CURRENT_LEAGUE: Current_league
     STADIUM_EDGE: Stadium_edge
 }

--- a/src/test/graphdb.test.js
+++ b/src/test/graphdb.test.js
@@ -96,6 +96,13 @@ test('should alias edge with same label as node', async () => {
     expect(actual).toBe(expected);
 });
 
+test('should handle single one-to-one edge', async () => {
+    loggerInit('./src/test/output', false, 'info');
+    const actual = await inferGraphQLSchema('./src/test/single-edge-neptune-schema.json', {addMutations: false});
+    const expected = await loadGraphQLSchema('./src/test/single-edge.graphql');
+    expect(actual).toBe(expected);
+});
+
 async function inferGraphQLSchema(neptuneSchemaFilePath, { addMutations = false, queryPrefix = '', mutationPrefix = ''} = {}) {
     let neptuneSchema = readFile(neptuneSchemaFilePath);
     let inferredSchema = graphDBInferenceSchema(neptuneSchema, {addMutations, queryPrefix, mutationPrefix});

--- a/src/test/node-edge-same-label.graphql
+++ b/src/test/node-edge-same-label.graphql
@@ -6,6 +6,7 @@ enum SortingDirection {
 type post {
     _id: ID! @id
     text: String
+    authorauthorOut: author @relationship(edgeType: "author", direction: OUT)
     author: author
 }
 
@@ -22,6 +23,7 @@ input postSort {
 type author {
     _id: ID! @id
     username: String
+    postauthorIn: post @relationship(edgeType: "author", direction: IN)
     author: author
 }
 

--- a/src/test/security.graphql
+++ b/src/test/security.graphql
@@ -65,7 +65,10 @@ type Ec2_cn_vpc @alias(property: "ec2:vpc") {
     cidr_block: String
     ec2_cn_network_hy_interfaceResource_linksIn(filter: Ec2_cn_network_hy_interfaceInput, options: Options, sort: [Ec2_cn_network_hy_interfaceSort!]): [Ec2_cn_network_hy_interface] @relationship(edgeType: "resource_link", direction: IN)
     ec2_cn_subnetResource_linksIn(filter: Ec2_cn_subnetInput, options: Options, sort: [Ec2_cn_subnetSort!]): [Ec2_cn_subnet] @relationship(edgeType: "resource_link", direction: IN)
+    ec2_cn_internet_hy_gatewayResource_linkIn: Ec2_cn_internet_hy_gateway @relationship(edgeType: "resource_link", direction: IN)
     ec2_cn_instanceResource_linksIn(filter: Ec2_cn_instanceInput, options: Options, sort: [Ec2_cn_instanceSort!]): [Ec2_cn_instance] @relationship(edgeType: "resource_link", direction: IN)
+    ec2_cn_route_hy_tableResource_linkIn: Ec2_cn_route_hy_table @relationship(edgeType: "resource_link", direction: IN)
+    rds_cn_dbTransient_resource_linkIn: Rds_cn_db @relationship(edgeType: "transient_resource_link", direction: IN)
     resource_link: Resource_link
     transient_resource_link: Transient_resource_link
 }
@@ -100,6 +103,7 @@ type Iam_cn_role @alias(property: "iam:role") {
     scan_id: String
     assume_role_policy_document_dot_version: String @alias(property: "assume_role_policy_document.version")
     iam_cn_policyResource_linksOut(filter: Iam_cn_policyInput, options: Options, sort: [Iam_cn_policySort!]): [Iam_cn_policy] @relationship(edgeType: "resource_link", direction: OUT)
+    iam_cn_instance_hy_profileResource_linkIn: Iam_cn_instance_hy_profile @relationship(edgeType: "resource_link", direction: IN)
     resource_link: Resource_link
 }
 
@@ -195,6 +199,9 @@ type Rds_cn_db @alias(property: "rds:db") {
     endpoint_port: String
     instance_create_time: String
     engine: String
+    ec2_cn_security_hy_groupTransient_resource_linkOut: Ec2_cn_security_hy_group @relationship(edgeType: "transient_resource_link", direction: OUT)
+    ec2_cn_vpcTransient_resource_linkOut: Ec2_cn_vpc @relationship(edgeType: "transient_resource_link", direction: OUT)
+    kms_cn_keyTransient_resource_linkOut: Kms_cn_key @relationship(edgeType: "transient_resource_link", direction: OUT)
     transient_resource_link: Transient_resource_link
 }
 
@@ -258,6 +265,9 @@ type Ec2_cn_instance @alias(property: "ec2:instance") {
     ec2_cn_security_hy_groupResource_linkOut: Ec2_cn_security_hy_group @relationship(edgeType: "resource_link", direction: OUT)
     ec2_cn_subnetResource_linkOut: Ec2_cn_subnet @relationship(edgeType: "resource_link", direction: OUT)
     ec2_cn_vpcResource_linkOut: Ec2_cn_vpc @relationship(edgeType: "resource_link", direction: OUT)
+    ec2_cn_volumeResource_linkIn: Ec2_cn_volume @relationship(edgeType: "resource_link", direction: IN)
+    tagTaggedOut: Tag @relationship(edgeType: "tagged", direction: OUT)
+    iam_cn_instance_hy_profileTransient_resource_linkOut: Iam_cn_instance_hy_profile @relationship(edgeType: "transient_resource_link", direction: OUT)
     imageTransient_resource_linkOut: Image @relationship(edgeType: "transient_resource_link", direction: OUT)
     resource_link: Resource_link
     tagged: Tagged
@@ -353,6 +363,7 @@ type Ec2_cn_security_hy_group @alias(property: "ec2:security-group") {
     ec2_cn_security_hy_groupResource_linkOut: Ec2_cn_security_hy_group @relationship(edgeType: "resource_link", direction: OUT)
     ec2_cn_security_hy_groupResource_linkIn: Ec2_cn_security_hy_group @relationship(edgeType: "resource_link", direction: IN)
     tagTaggedsOut(filter: TagInput, options: Options, sort: [TagSort!]): [Tag] @relationship(edgeType: "tagged", direction: OUT)
+    rds_cn_dbTransient_resource_linkIn: Rds_cn_db @relationship(edgeType: "transient_resource_link", direction: IN)
     resource_link: Resource_link
     tagged: Tagged
     transient_resource_link: Transient_resource_link
@@ -398,6 +409,7 @@ type Ec2_cn_internet_hy_gateway @alias(property: "ec2:internet-gateway") {
     scan_id: String
     owner_id: String
     attachment_dot_state: String @alias(property: "attachment.state")
+    ec2_cn_vpcResource_linkOut: Ec2_cn_vpc @relationship(edgeType: "resource_link", direction: OUT)
     resource_link: Resource_link
 }
 
@@ -488,6 +500,8 @@ type Iam_cn_instance_hy_profile @alias(property: "iam:instance-profile") {
     arn: String
     name: String
     scan_id: String
+    iam_cn_roleResource_linkOut: Iam_cn_role @relationship(edgeType: "resource_link", direction: OUT)
+    ec2_cn_instanceTransient_resource_linkIn: Ec2_cn_instance @relationship(edgeType: "transient_resource_link", direction: IN)
     resource_link: Resource_link
     transient_resource_link: Transient_resource_link
 }
@@ -570,6 +584,7 @@ type Tag @alias(property: "tag") {
     scan_id: String
     Name: String
     ec2_cn_security_hy_groupTaggedIn: Ec2_cn_security_hy_group @relationship(edgeType: "tagged", direction: IN)
+    ec2_cn_instanceTaggedIn: Ec2_cn_instance @relationship(edgeType: "tagged", direction: IN)
     tagged: Tagged
 }
 
@@ -590,6 +605,7 @@ type Kms_cn_key @alias(property: "kms:key") {
     arn: String
     scan_id: String
     key_id: String
+    rds_cn_dbTransient_resource_linkIn: Rds_cn_db @relationship(edgeType: "transient_resource_link", direction: IN)
     transient_resource_link: Transient_resource_link
 }
 
@@ -620,6 +636,7 @@ type Ec2_cn_volume @alias(property: "ec2:volume") {
     size: String
     create_time: String
     attachment_dot_delete_on_termination: String @alias(property: "attachment.delete_on_termination")
+    ec2_cn_instanceResource_linkOut: Ec2_cn_instance @relationship(edgeType: "resource_link", direction: OUT)
     resource_link: Resource_link
 }
 
@@ -666,6 +683,7 @@ type Ec2_cn_route_hy_table @alias(property: "ec2:route-table") {
     association_dot_main: String @alias(property: "association.main")
     route_dot_state: String @alias(property: "route.state")
     association_dot_route_table_association_id: String @alias(property: "association.route_table_association_id")
+    ec2_cn_vpcResource_linkOut: Ec2_cn_vpc @relationship(edgeType: "resource_link", direction: OUT)
     resource_link: Resource_link
 }
 

--- a/src/test/single-edge-neptune-schema.json
+++ b/src/test/single-edge-neptune-schema.json
@@ -1,0 +1,39 @@
+{
+  "nodeStructures": [
+    {
+      "label": "aws:lambda:function",
+      "properties": [
+        {
+          "name": "arn",
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "label": "tag",
+      "properties": [
+        {
+          "name": "value",
+          "type": "String"
+        },
+        {
+          "name": "key",
+          "type": "String"
+        }
+      ]
+    }
+  ],
+  "edgeStructures": [
+    {
+      "label": "tagged_aws:lambda:function",
+      "properties": [],
+      "directions": [
+        {
+          "from": "aws:lambda:function",
+          "to": "tag",
+          "relationship": "ONE-ONE"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/single-edge.graphql
+++ b/src/test/single-edge.graphql
@@ -1,0 +1,68 @@
+enum SortingDirection {
+    ASC
+    DESC
+}
+
+type aws_cn_lambda_cn_function @alias(property: "aws:lambda:function") {
+    _id: ID! @id
+    arn: String
+    tagtagged_aws_cn_lambda_cn_functionOut: tag @relationship(edgeType: "tagged_aws:lambda:function", direction: OUT)
+    tagged_aws_cn_lambda_cn_function: tagged_aws_cn_lambda_cn_function
+}
+
+input aws_cn_lambda_cn_functionInput {
+    _id: ID @id
+    arn: StringScalarFilters
+}
+
+input aws_cn_lambda_cn_functionSort {
+    _id: SortingDirection
+    arn: SortingDirection
+}
+
+type tag {
+    _id: ID! @id
+    value: String
+    key: String
+    aws_cn_lambda_cn_functiontagged_aws_cn_lambda_cn_functionIn: aws_cn_lambda_cn_function @relationship(edgeType: "tagged_aws:lambda:function", direction: IN)
+    tagged_aws_cn_lambda_cn_function: tagged_aws_cn_lambda_cn_function
+}
+
+input tagInput {
+    _id: ID @id
+    value: StringScalarFilters
+    key: StringScalarFilters
+}
+
+input tagSort {
+    _id: SortingDirection
+    value: SortingDirection
+    key: SortingDirection
+}
+
+type tagged_aws_cn_lambda_cn_function @alias(property: "tagged_aws:lambda:function") {
+    _id: ID! @id
+}
+
+input Options {
+    limit: Int
+    offset: Int
+}
+
+input StringScalarFilters {
+    eq: String
+    contains: String
+    endsWith: String
+    startsWith: String
+}
+
+type Query {
+    getaws_cn_lambda_cn_function(filter: aws_cn_lambda_cn_functionInput): aws_cn_lambda_cn_function
+    getaws_cn_lambda_cn_functions(filter: aws_cn_lambda_cn_functionInput, options: Options, sort: [aws_cn_lambda_cn_functionSort!]): [aws_cn_lambda_cn_function]
+    gettag(filter: tagInput): tag
+    gettags(filter: tagInput, options: Options, sort: [tagSort!]): [tag]
+}
+
+schema {
+    query: Query
+}


### PR DESCRIPTION
Fixed graphdb.js to process ONE-ONE edge types by adding appropriate `@relationship` directives, allowing resulting graphQL schema to traverse along these edges.
