### PR TITLE
Handle non-nullable IDs for input types in resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,3 +129,4 @@ permissions and limitations under the License.
   ([#126](https://github.com/aws/amazon-neptune-for-graphql/pull/126))
 * Accommodated for special characters in edge labels to ensure proper Cypher
   translation ([#127](https://github.com/aws/amazon-neptune-for-graphql/pull/127))
+* Accommodated for non-nullable IDs in resolver for input types ([#137](https://github.com/aws/amazon-neptune-for-graphql/pull/137))

--- a/src/test/templates/JSResolverOCHTTPS.test.js
+++ b/src/test/templates/JSResolverOCHTTPS.test.js
@@ -660,6 +660,27 @@ test('should inference query with mutation update node (Query0016)', () => {
     });
 });
 
+test('should inference query with mutation update node from event', () => {
+    const result = resolveGraphDBQueryFromEvent({
+        field: 'updateAirport',
+        arguments: {input: {_id: "22", city: "Seattle"}},
+        selectionSet: gql`{ city }`.definitions[0].selectionSet,
+        fragments: {}
+    });
+    expect(result).toMatchObject({
+        query: 'MATCH (updateAirport_Airport)\n' +
+            'WHERE ID(updateAirport_Airport) = $updateAirport_Airport__id\n' +
+            'SET updateAirport_Airport.city = $updateAirport_Airport_city\n' +
+            'RETURN {city: updateAirport_Airport.`city`}',
+        parameters: {
+            updateAirport_Airport_city: 'Seattle',
+            updateAirport_Airport__id: '22'
+        },
+        language: 'opencypher',
+        refactorOutput: null
+    });
+});
+
 test('should resolve mutation to connect nodes', () => {
     const query = 'mutation ConnectCountryToAirport {\n' +
         '  connectCountryToAirportThroughContains(from_id: \"ee71c547-ea32-4573-88bc-6ecb31942a1e\", to_id: \"99cb3321-9cda-41b6-b760-e88ead3e1ea1\") {\n' +
@@ -1375,7 +1396,7 @@ test('should resolve mutation to update node with fragment', () => {
             'elev: updateAirport_Airport.`elev`' +
             '}',
         parameters: {
-            updateAirport_Airport__id: 22,
+            updateAirport_Airport__id: '22',
             updateAirport_Airport_city: "Seattle",
         },
         language: 'opencypher',

--- a/templates/JSResolverOCHTTPS.js
+++ b/templates/JSResolverOCHTTPS.js
@@ -74,7 +74,7 @@ export function resolveGraphDBQueryFromEvent(event) {
                 // retrieve an ID field which may not necessarily be named 'id'
                 const idField = Object.values(inputType.getFields()).find(
                     // if field is of non-null type, check the underlying type as well
-                    field => field?.type?.name === GraphQLID.name || field?.type?.ofType?.name === GraphQLID.name);
+                    field => field.type?.name === GraphQLID.name || field.type?.ofType?.name === GraphQLID.name);
                 if (idField) {
                     // check if id was an input arg
                     const idValue = astValue.fields.find(f => f.name.value === idField.name);

--- a/templates/JSResolverOCHTTPS.js
+++ b/templates/JSResolverOCHTTPS.js
@@ -10,7 +10,7 @@ express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 */
 
-import { astFromValue, buildASTSchema, GraphQLError, GraphQLID, GraphQLInputObjectType, parse, typeFromAST } from 'graphql';
+import { astFromValue, buildASTSchema, GraphQLError, GraphQLID, GraphQLInputObjectType, GraphQLNonNull, parse, typeFromAST } from 'graphql';
 
 const useCallSubquery = false;
 
@@ -64,11 +64,17 @@ export function resolveGraphDBQueryFromEvent(event) {
         const value = event.arguments[inputDef.name.value];
 
         if (value) {
-            const inputType = typeFromAST(schema, inputDef.type);
+            let inputType = typeFromAST(schema, inputDef.type);
+            if (inputType instanceof GraphQLNonNull && inputType.ofType) {
+                // if non-null type, unwrap to the underlying type
+                inputType = inputType.ofType;
+            }
             const astValue = astFromValue(value, inputType);
             if (inputType instanceof GraphQLInputObjectType) {
                 // retrieve an ID field which may not necessarily be named 'id'
-                const idField = Object.values(inputType.getFields()).find(field => field.type.name === GraphQLID.name);
+                const idField = Object.values(inputType.getFields()).find(
+                    // if field is of non-null type, check the underlying type as well
+                    field => field?.type?.name === GraphQLID.name || field?.type?.ofType?.name === GraphQLID.name);
                 if (idField) {
                     // check if id was an input arg
                     const idValue = astValue.fields.find(f => f.name.value === idField.name);


### PR DESCRIPTION
Fixed issue where non-nullable id values were being passed as numbers in neptune query parameters by unwrapping non-nullable ID types for input types in resolver.
