### PR TITLE
Upgrade axios to fix security warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@aws-sdk/credential-providers": "3.414.0",
         "archiver": "7.0.1",
         "aws4-axios": "3.3.0",
-        "axios": "^1.9.0",
+        "axios": "^1.12.0",
         "graphql": "^16.8.1",
         "graphql-tag": "2.12.6",
         "ora": "7.0.1",
@@ -6793,13 +6793,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
+      "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@aws-sdk/credential-providers": "3.414.0",
     "archiver": "7.0.1",
     "aws4-axios": "3.3.0",
-    "axios": "^1.9.0",
+    "axios": "^1.12.0",
     "graphql": "^16.8.1",
     "graphql-tag": "2.12.6",
     "ora": "7.0.1",

--- a/templates/ApolloServer/package-lock.json
+++ b/templates/ApolloServer/package-lock.json
@@ -13,7 +13,7 @@
         "@apollo/subgraph": "^2.9.3",
         "@aws-sdk/credential-providers": "^3.729.0",
         "aws4-axios": "^3.3.14",
-        "axios": "^1.7.9",
+        "axios": "^1.12.0",
         "dotenv": "^16.4.7",
         "graphql": "^16.8.1",
         "retry-axios": "^3.1.3"
@@ -1902,13 +1902,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
+      "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },

--- a/templates/ApolloServer/package.json
+++ b/templates/ApolloServer/package.json
@@ -14,7 +14,7 @@
     "@apollo/subgraph": "^2.9.3",
     "@aws-sdk/credential-providers": "^3.729.0",
     "aws4-axios": "^3.3.14",
-    "axios": "^1.7.9",
+    "axios": "^1.12.0",
     "graphql": "^16.8.1",
     "retry-axios": "^3.1.3",
     "dotenv": "^16.4.7"

--- a/templates/Lambda4AppSyncHTTP/package-lock.json
+++ b/templates/Lambda4AppSyncHTTP/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "aws4-axios": "3.3.0",
-        "axios": "^1.9.0",
+        "axios": "^1.12.0",
         "graphql": "^16.8.1",
         "retry-axios": "3.1.0"
       }
@@ -1205,13 +1205,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
+      "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },

--- a/templates/Lambda4AppSyncHTTP/package.json
+++ b/templates/Lambda4AppSyncHTTP/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "aws4-axios": "3.3.0",
-    "axios": "^1.9.0",
+    "axios": "^1.12.0",
     "graphql": "^16.8.1",
     "retry-axios": "3.1.0"
   }

--- a/test/package.json
+++ b/test/package.json
@@ -13,6 +13,6 @@
     "graphql-tag": "2.12.6",
     "adm-zip": "0.5.16",
     "@aws-sdk/client-appsync": "^3.445.0",
-    "axios": "^1.9.0"
+    "axios": "^1.12.0"
   }
 }


### PR DESCRIPTION
Upgrade axios to 1.12.0 to fix security warning.
