### PR TITLE
Fix Lambda VPC config missing for Neptune DB with IAM auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.vscode/launch.json
+.vscode/
+.kiro/
 **/node_modules/
 coverage/**
 **/output/

--- a/src/CDKPipelineApp.js
+++ b/src/CDKPipelineApp.js
@@ -110,13 +110,13 @@ async function createAWSpipelineCDK({
             if (!quiet) spinner.succeed('Got Neptune Cluster Info');
             if (isNeptuneIAMAuth) {
                 if (!neptuneClusterInfo.isIAMauth) {
-                    loggerError("The Neptune database authentication is set to VPC.");
+                    loggerError("Neptune database has IAM authentication disabled, but --neptune-IAM flag was provided.");
                     loggerError("Remove the --output-aws-pipeline-cdk-neptune-IAM option.");
                     process.exit(1);
                 }
             } else {
                 if (neptuneClusterInfo.isIAMauth) {
-                    loggerError("The Neptune database authentication is set to IAM.");
+                    loggerError("Neptune database has IAM authentication enabled, but --neptune-IAM flag was not provided.");
                     loggerError("Add the --output-aws-pipeline-cdk-neptune-IAM option.");
                     process.exit(1);
                 } else {
@@ -140,15 +140,11 @@ async function createAWSpipelineCDK({
             NEPTUNE_IAM_POLICY_RESOURCE = neptuneClusterInfo.iamPolicyResource;
 
         } catch (error) {
+            // VPC data is required for all Neptune DB deployments regardless of auth method
             loggerError('Error getting Neptune Cluster Info', error);
-            if (!quiet) spinner.fail("Error getting Neptune Cluster Info.");
-            if (!isNeptuneIAMAuth) {
-                spinner.clear();
-                loggerError("VPC data is not available to proceed.");
-                process.exit(1);
-            } else {
-                loggerInfo("Proceeding without getting Neptune Cluster info.", {toConsole: true});
-            }
+            if (spinner) spinner.fail('Error getting Neptune Cluster Info.');
+            loggerError("VPC data is not available to proceed.");
+            process.exit(1);
         }
     }
          
@@ -171,13 +167,17 @@ async function createAWSpipelineCDK({
     CDKFile = CDKFile.replace( "const NEPTUNE_PORT = '';",                   `const NEPTUNE_PORT = '${NEPTUNE_PORT}';` );
     CDKFile = CDKFile.replace( "const NEPTUNE_DB_NAME = '';",                `const NEPTUNE_DB_NAME = '${NEPTUNE_DB_NAME}';` );
     CDKFile = CDKFile.replace( "const NEPTUNE_TYPE = '';",                   `const NEPTUNE_TYPE = '${NEPTUNE_TYPE}';` );
-    CDKFile = CDKFile.replace( "const NEPTUNE_DBSubnetGroup = null;",        `const NEPTUNE_DBSubnetGroup = '${NEPTUNE_DBSubnetGroup}';` );
     if (neptuneClusterInfo) {
+        CDKFile = CDKFile.replace("const NEPTUNE_DBSubnetGroup = null;",     `const NEPTUNE_DBSubnetGroup = '${neptuneClusterInfo.dbSubnetGroup}';`);
         CDKFile = CDKFile.replace("const NEPTUNE_DBSubnetIds = null;",       `const NEPTUNE_DBSubnetIds = '${neptuneClusterInfo.dbSubnetIds}';`);
         CDKFile = CDKFile.replace("const NEPTUNE_VpcSecurityGroupId = null;",`const NEPTUNE_VpcSecurityGroupId = '${neptuneClusterInfo.vpcSecurityGroupId}';`);
     }
     CDKFile = CDKFile.replace( "const NEPTUNE_IAM_AUTH = false;",            `const NEPTUNE_IAM_AUTH = ${isNeptuneIAMAuth};` );    
     CDKFile = CDKFile.replace( "const NEPTUNE_IAM_POLICY_RESOURCE = '*';",   `const NEPTUNE_IAM_POLICY_RESOURCE = '${NEPTUNE_IAM_POLICY_RESOURCE}';` );
+
+    if (isNeptuneIAMAuth && NEPTUNE_IAM_POLICY_RESOURCE === '*') {
+        loggerInfo("WARNING: NEPTUNE_IAM_POLICY_RESOURCE is set to '*'. Consider restricting to a specific Neptune cluster ARN.", {toConsole: true});
+    }
 
     CDKFile = CDKFile.replace( "const LAMBDA_FUNCTION_NAME = '';",           `const LAMBDA_FUNCTION_NAME = '${NAME + 'LambdaFunction'}';` );
     CDKFile = CDKFile.replace( "const LAMBDA_ZIP_FILE = '';",                `const LAMBDA_ZIP_FILE = '${NAME}.zip';` );

--- a/src/pipelineResources.js
+++ b/src/pipelineResources.js
@@ -372,16 +372,18 @@ async function createLambdaRole() {
         storeResource({LambdaExecutionPolicy2: input.PolicyArn});    
         await sleep(10000);
         succeedSpinner(`Attached ${yellow('Neptune Query Policy')} policies to Lambda Role`, {logLevel: 'info'});
-        
-    } else {
+    }
+
+    if (NEPTUNE_TYPE === NEPTUNE_DB) {
         startSpinner('Attaching policy for Neptune VPC to Lambda role ...', true);
+        const vpcPolicyKey = NEPTUNE_IAM_AUTH ? 'LambdaExecutionPolicy3' : 'LambdaExecutionPolicy2';
         input = {
             RoleName: roleName,
             PolicyArn: "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
         };
         command = new AttachRolePolicyCommand(input);
         await iamClient.send(command);    
-        storeResource({LambdaExecutionPolicy2: input.PolicyArn});    
+        storeResource({[vpcPolicyKey]: input.PolicyArn});    
         await sleep(10000);
         succeedSpinner(`Attached ${yellow('AWSLambdaVPCAccessExecutionRole')} policies to role`, {logLevel: 'info'});
     }
@@ -436,7 +438,7 @@ async function createLambdaFunction() {
         },
     };
 
-    if (!NEPTUNE_IAM_AUTH) {
+    if (NEPTUNE_TYPE === NEPTUNE_DB) {
         params.VpcConfig = {
             SubnetIds: NEPTUNE_DBSubnetIds,
             SecurityGroupIds: [NEPTUNE_VpcSecurityGroupId]
@@ -770,37 +772,24 @@ async function removeAWSpipelineResources(resources, quietI) {
         loggerError(message, error);
     }    
     
-    // Lambda execution role
-    startSpinner('Detaching first IAM policy from role ...', true);
-    try {
-        let input = { 
-            PolicyArn: resources.LambdaExecutionPolicy1,
-            RoleName: resources.LambdaExecutionRole
-        };
-        let command = new DetachRolePolicyCommand(input);        
-        await iamClient.send(command);
-        succeedSpinner('Detached policy: ' + yellow(resources.LambdaExecutionPolicy1) + " from role: " + yellow(resources.LambdaExecutionRole), {logLevel: 'debug'});
-        loggerInfo('Detached first IAM policy from role');
-    } catch (error) {
-        let message = 'Detach first policy failed';
-        failSpinner(message);
-        loggerError(message, error);
-    }
-
-    startSpinner('Detaching second IAM policy from role ...', true);
-    try {
-        let input = { 
-            PolicyArn: resources.LambdaExecutionPolicy2,
-            RoleName: resources.LambdaExecutionRole
-        };
-        let command = new DetachRolePolicyCommand(input);        
-        await iamClient.send(command);
-        succeedSpinner('Detached IAM policy: ' + yellow(resources.LambdaExecutionPolicy2) + " from role: " + yellow(resources.LambdaExecutionRole), {logLevel: 'debug'});
-        loggerInfo('Detached second IAM policy from role');
-    } catch (error) {
-        const message = 'Detach second IAM policy failed';
-        failSpinner(message);
-        loggerError(message, error);
+    // Lambda execution role - detach all execution policies
+    const policyKeys = Object.keys(resources).filter(k => k.startsWith('LambdaExecutionPolicy'));
+    for (const key of policyKeys) {
+        startSpinner(`Detaching IAM policy ${key} from role ...`, true);
+        try {
+            const input = { 
+                PolicyArn: resources[key],
+                RoleName: resources.LambdaExecutionRole
+            };
+            const command = new DetachRolePolicyCommand(input);        
+            await iamClient.send(command);
+            succeedSpinner('Detached policy: ' + yellow(resources[key]) + " from role: " + yellow(resources.LambdaExecutionRole), {logLevel: 'debug'});
+            loggerInfo(`Detached ${key} from role`);
+        } catch (error) {
+            const message = `Detach ${key} failed`;
+            failSpinner(message);
+            loggerError(message, error);
+        }
     }
     
     // Delete Neptune query Policy
@@ -971,13 +960,13 @@ async function createUpdateAWSpipeline({
                     succeedSpinner('Retrieved Neptune Cluster Info', {logLevel: 'info'});
                     if (isNeptuneIAMAuth) {
                         if (!NEPTUNE_CURRENT_IAM) {
-                            loggerError('The Neptune database authentication is set to VPC.');
+                            loggerError('Neptune database has IAM authentication disabled, but --neptune-IAM flag was provided.');
                             loggerError('Remove the --create-update-aws-pipeline-neptune-IAM option.');
                             exit(1);
                         }
                     } else {
                         if (NEPTUNE_CURRENT_IAM) {
-                            loggerError('The Neptune database authentication is set to IAM.');
+                            loggerError('Neptune database has IAM authentication enabled, but --neptune-IAM flag was not provided.');
                             loggerError('Add the --create-update-aws-pipeline-neptune-IAM option.');
                             exit(1);
                         } else {
@@ -999,13 +988,9 @@ async function createUpdateAWSpipeline({
                     let message = 'Error getting Neptune Cluster Info.';
                     failSpinner(message);
                     loggerError(message, error);
-                    if (!isNeptuneIAMAuth) {
-                        loggerError("VPC data is not available to proceed.");
-                        exit(1);
-                    } else {
-                        loggerInfo("Could not read the database ARN to restrict the Lambda permissions. To increase security change the resource in the Neptune Query policy.", {toConsole: true});
-                        loggerInfo("Proceeding without getting Neptune Cluster info.", {toConsole: true});
-                    }
+                    loggerInfo("Could not read the database ARN to restrict the Lambda permissions. To increase security change the resource in the Neptune Query policy.", {toConsole: true});
+                    loggerError("VPC data is not available to proceed.");
+                    exit(1);
                 }
             }
 

--- a/src/test/CDKPipelineApp.test.js
+++ b/src/test/CDKPipelineApp.test.js
@@ -1,0 +1,96 @@
+import { jest } from '@jest/globals';
+import { readFileSync } from 'fs';
+import { ExitCalled } from './helpers/pipelineMocks.js';
+
+const cdkTemplateContent = readFileSync('./templates/CDKTemplate.js', 'utf8');
+
+const mockGetNeptuneClusterDbInfoBy = jest.fn();
+const mockWriteFile = jest.fn();
+const mockReadFile = jest.fn();
+
+jest.unstable_mockModule('../pipelineResources.js', () => ({
+    getNeptuneClusterDbInfoBy: mockGetNeptuneClusterDbInfoBy,
+}));
+
+jest.unstable_mockModule('fs/promises', () => ({
+    readFile: mockReadFile,
+    writeFile: mockWriteFile,
+}));
+
+jest.unstable_mockModule('ora', () => ({
+    default: jest.fn(() => ({ start: jest.fn().mockReturnThis(), succeed: jest.fn(), fail: jest.fn(), warn: jest.fn() })),
+}));
+
+jest.unstable_mockModule('../zipPackage.js', () => ({
+    createLambdaDeploymentPackage: jest.fn(),
+}));
+
+jest.unstable_mockModule('../logger.js', () => ({
+    loggerDebug: jest.fn(), loggerError: jest.fn(), loggerInfo: jest.fn(), yellow: jest.fn(s => s),
+}));
+
+// CDKPipelineApp.js calls process.exit() directly (global), so spyOn is needed here
+const mockProcessExit = jest.spyOn(process, 'exit').mockImplementation((code) => { throw new ExitCalled(code); });
+
+let createAWSpipelineCDK;
+
+beforeAll(async () => {
+    ({ createAWSpipelineCDK } = await import('../CDKPipelineApp.js'));
+});
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockReadFile.mockImplementation(async (path, enc) => {
+        if (path.includes('CDKTemplate')) return cdkTemplateContent;
+        return '';
+    });
+    mockWriteFile.mockResolvedValue(undefined);
+});
+
+const clusterInfo = {
+    host: 'db.cluster.us-east-1.neptune.amazonaws.com', port: '8182',
+    isIAMauth: true, version: '1.3.0.0', dbSubnetGroup: 'default-vpc-123',
+    dbSubnetIds: ['subnet-1', 'subnet-2'], vpcSecurityGroupId: 'sg-123',
+    iamPolicyResource: 'arn:aws:neptune-db:us-east-1:123:cluster-abc/*',
+};
+
+const baseParams = {
+    pipelineName: 'test', neptuneDBName: 'mydb', neptuneDBregion: 'us-east-1',
+    appSyncSchema: 'type Query { get: String }', lambdaFilesPath: '/tmp/lambda',
+    outputFile: '/tmp/output/cdk.js', __dirname: '.', quiet: true,
+    neptuneHost: 'db.cluster.us-east-1.neptune.amazonaws.com', neptunePort: '8182',
+    outputFolderPath: '/tmp/output', resolverFilePath: '/tmp/r.js', resolverSchemaFilePath: '/tmp/s.json',
+    schemaModel: { definitions: [{ kind: 'ObjectTypeDefinition', name: { value: 'Query' }, fields: [{ name: { value: 'get' } }] }] },
+};
+
+test('should exit on cluster info failure for neptune-db with IAM', async () => {
+    mockGetNeptuneClusterDbInfoBy.mockRejectedValue(new Error('cluster not found'));
+
+    try { await createAWSpipelineCDK({ ...baseParams, isNeptuneIAMAuth: true, neptuneType: 'neptune-db' }); } catch (e) { if (!(e instanceof ExitCalled)) throw e; }
+
+    expect(mockProcessExit).toHaveBeenCalledWith(1);
+});
+
+test('should exit on cluster info failure for neptune-db without IAM', async () => {
+    mockGetNeptuneClusterDbInfoBy.mockRejectedValue(new Error('cluster not found'));
+
+    try { await createAWSpipelineCDK({ ...baseParams, isNeptuneIAMAuth: false, neptuneType: 'neptune-db' }); } catch (e) { if (!(e instanceof ExitCalled)) throw e; }
+
+    expect(mockProcessExit).toHaveBeenCalledWith(1);
+});
+
+test('should generate CDK file for neptune-graph without calling cluster info', async () => {
+    await createAWSpipelineCDK({ ...baseParams, isNeptuneIAMAuth: true, neptuneType: 'neptune-graph' });
+
+    expect(mockGetNeptuneClusterDbInfoBy).not.toHaveBeenCalled();
+    expect(mockWriteFile).toHaveBeenCalled();
+    const writtenContent = mockWriteFile.mock.calls[0][1];
+    expect(writtenContent).toContain('NEPTUNE_IAM_AUTH = true');
+    expect(writtenContent).toContain('NEPTUNE_DBSubnetGroup = null');
+    expect(writtenContent).toContain('NEPTUNE_DBSubnetIds = null');
+    expect(writtenContent).toContain('NEPTUNE_VpcSecurityGroupId = null');
+});
+
+afterAll(() => {
+    mockProcessExit.mockRestore();
+});

--- a/src/test/CDKPipelineApp.test.js
+++ b/src/test/CDKPipelineApp.test.js
@@ -91,6 +91,30 @@ test('should generate CDK file for neptune-graph without calling cluster info', 
     expect(writtenContent).toContain('NEPTUNE_VpcSecurityGroupId = null');
 });
 
+test('should generate CDK file with VPC config for neptune-db with IAM', async () => {
+    mockGetNeptuneClusterDbInfoBy.mockResolvedValue(clusterInfo);
+    await createAWSpipelineCDK({ ...baseParams, isNeptuneIAMAuth: true, neptuneType: 'neptune-db' });
+    expect(mockWriteFile).toHaveBeenCalled();
+    const writtenContent = mockWriteFile.mock.calls[0][1];
+    expect(writtenContent).toContain("NEPTUNE_IAM_AUTH = true");
+    expect(writtenContent).toContain("NEPTUNE_DBSubnetGroup = 'default-vpc-123'");
+    expect(writtenContent).toContain("NEPTUNE_DBSubnetIds = 'subnet-1,subnet-2'");
+    expect(writtenContent).toContain("NEPTUNE_VpcSecurityGroupId = 'sg-123'");
+    expect(writtenContent).toContain("NEPTUNE_IAM_POLICY_RESOURCE = 'arn:aws:neptune-db:us-east-1:123:cluster-abc/*'");
+});
+
+test('should exit when neptune-db has IAM disabled but IAM flag was provided', async () => {
+    mockGetNeptuneClusterDbInfoBy.mockResolvedValue({ ...clusterInfo, isIAMauth: false });
+    try { await createAWSpipelineCDK({ ...baseParams, isNeptuneIAMAuth: true, neptuneType: 'neptune-db' }); } catch (e) { if (!(e instanceof ExitCalled)) throw e; }
+    expect(mockProcessExit).toHaveBeenCalledWith(1);
+});
+
+test('should exit when neptune-db has IAM enabled but IAM flag was not provided', async () => {
+    mockGetNeptuneClusterDbInfoBy.mockResolvedValue(clusterInfo);
+    try { await createAWSpipelineCDK({ ...baseParams, isNeptuneIAMAuth: false, neptuneType: 'neptune-db' }); } catch (e) { if (!(e instanceof ExitCalled)) throw e; }
+    expect(mockProcessExit).toHaveBeenCalledWith(1);
+});
+
 afterAll(() => {
     mockProcessExit.mockRestore();
 });

--- a/src/test/CDKTemplate.test.js
+++ b/src/test/CDKTemplate.test.js
@@ -1,0 +1,104 @@
+import { readFileSync } from 'fs';
+
+const templateSource = readFileSync('./templates/CDKTemplate.js', 'utf8');
+
+function renderTemplate({ neptuneType, neptuneIAMAuth }) {
+    return templateSource
+        .replace("const NEPTUNE_TYPE = '';", `const NEPTUNE_TYPE = '${neptuneType}';`)
+        .replace("const NEPTUNE_IAM_AUTH = false;", `const NEPTUNE_IAM_AUTH = ${neptuneIAMAuth};`)
+        .replace("const NEPTUNE_DBSubnetGroup = null;", "const NEPTUNE_DBSubnetGroup = 'vpc-123';")
+        .replace("const NEPTUNE_DBSubnetIds = null;", "const NEPTUNE_DBSubnetIds = 'subnet-1,subnet-2';")
+        .replace("const NEPTUNE_VpcSecurityGroupId = null;", "const NEPTUNE_VpcSecurityGroupId = 'sg-123';")
+        .replace("const NEPTUNE_HOST = '';", "const NEPTUNE_HOST = 'db.cluster.us-east-1.neptune.amazonaws.com';")
+        .replace("const NEPTUNE_IAM_POLICY_RESOURCE = '*';", "const NEPTUNE_IAM_POLICY_RESOURCE = 'arn:aws:neptune-db:us-east-1:123:cluster-abc/*';");
+}
+
+function evaluateTemplate({ neptuneType, neptuneIAMAuth }) {
+    const code = renderTemplate({ neptuneType, neptuneIAMAuth });
+    // Extract from "const lambdaProps = {" up to "echoLambda = new lambda.Function"
+    const match = code.match(/const lambdaProps = \{[\s\S]*?(?=\n\s*echoLambda = new lambda\.Function)/);
+    if (!match) throw new Error('Could not extract lambdaProps block from CDKTemplate.js — check that "const lambdaProps = {" and "echoLambda = new lambda.Function" markers still exist in the template');
+
+    const managedPolicies = [];
+    const fn = new Function('NEPTUNE_TYPE', 'NEPTUNE_IAM_AUTH', 'NEPTUNE_DBSubnetGroup', 'NEPTUNE_DBSubnetIds', 'NEPTUNE_VpcSecurityGroupId', 'NEPTUNE_IAM_POLICY_RESOURCE', 'NAME', `
+        const ec2 = {
+            Vpc: { fromLookup: (_, __, o) => 'vpc-stub' },
+            Subnet: { fromSubnetId: (_, __, id) => id },
+            SecurityGroup: { fromSecurityGroupId: (_, __, id) => 'sg-stub' }
+        };
+        const iam = {
+            ManagedPolicy: { fromAwsManagedPolicyName: (n) => n },
+            PolicyStatement: class { constructor(o) { Object.assign(this, o); } },
+            Effect: { ALLOW: 'Allow' }
+        };
+        const lambda_role = { addManagedPolicy: (p) => managedPolicies.push(p) };
+        const managedPolicies = [];
+        const Duration = { seconds: (s) => s };
+        const lambda = { Code: { fromAsset: (f) => f }, Runtime: { NODEJS_18_X: 'nodejs18.x' } };
+        const self = { parseNeptuneDomainFromHost: () => 'neptune.amazonaws.com' };
+        const LAMBDA_FUNCTION_NAME = 'testFn';
+        const LAMBDA_ZIP_FILE = 'test.zip';
+        const REGION = 'us-east-1';
+        const NEPTUNE_HOST_LOCAL = 'db.cluster.us-east-1.neptune.amazonaws.com';
+        const NEPTUNE_PORT = '8182';
+        const NEPTUNE_DB_NAME = 'testdb';
+        let env = {
+            NEPTUNE_HOST: NEPTUNE_HOST_LOCAL,
+            NEPTUNE_PORT: NEPTUNE_PORT,
+            NEPTUNE_IAM_AUTH_ENABLED: NEPTUNE_IAM_AUTH.toString(),
+            LOGGING_ENABLED: 'false',
+            NEPTUNE_DB_NAME: NEPTUNE_DB_NAME,
+            NEPTUNE_REGION: REGION,
+            NEPTUNE_DOMAIN: 'neptune.amazonaws.com',
+            NEPTUNE_TYPE: NEPTUNE_TYPE,
+        };
+        ${match[0]}
+        return { lambdaProps, managedPolicies };
+    `);
+
+    return fn(neptuneType, neptuneIAMAuth, 'vpc-123', 'subnet-1,subnet-2', 'sg-123', 'arn:aws:neptune-db:us-east-1:123:cluster-abc/*', 'Test');
+}
+
+test('neptune-db without IAM: VPC config, no IAM policy', () => {
+    const { lambdaProps, managedPolicies } = evaluateTemplate({ neptuneType: 'neptune-db', neptuneIAMAuth: false });
+    expect(lambdaProps.vpc).toBeDefined();
+    expect(lambdaProps.vpcSubnets).toBeDefined();
+    expect(lambdaProps.securityGroups).toBeDefined();
+    expect(lambdaProps.initialPolicy).toBeUndefined();
+    expect(managedPolicies).toContain('service-role/AWSLambdaVPCAccessExecutionRole');
+});
+
+test('neptune-db with IAM: VPC config and IAM policy', () => {
+    const { lambdaProps, managedPolicies } = evaluateTemplate({ neptuneType: 'neptune-db', neptuneIAMAuth: true });
+    expect(lambdaProps.vpc).toBeDefined();
+    expect(lambdaProps.vpcSubnets).toBeDefined();
+    expect(lambdaProps.securityGroups).toBeDefined();
+    expect(lambdaProps.initialPolicy).toBeDefined();
+    expect(lambdaProps.initialPolicy[0].actions).toEqual(expect.arrayContaining([
+        'neptune-db:connect',
+        'neptune-db:ReadDataViaQuery',
+    ]));
+    expect(managedPolicies).toContain('service-role/AWSLambdaVPCAccessExecutionRole');
+});
+
+test('neptune-graph with IAM: IAM policy, no VPC config', () => {
+    const { lambdaProps } = evaluateTemplate({ neptuneType: 'neptune-graph', neptuneIAMAuth: true });
+    expect(lambdaProps.vpc).toBeUndefined();
+    expect(lambdaProps.vpcSubnets).toBeUndefined();
+    expect(lambdaProps.securityGroups).toBeUndefined();
+    expect(lambdaProps.initialPolicy).toBeDefined();
+    expect(lambdaProps.initialPolicy[0].actions).toContain('neptune-graph:connect');
+});
+
+test('neptune-graph without IAM: no VPC, no IAM policy', () => {
+    const { lambdaProps } = evaluateTemplate({ neptuneType: 'neptune-graph', neptuneIAMAuth: false });
+    expect(lambdaProps.vpc).toBeUndefined();
+    expect(lambdaProps.vpcSubnets).toBeUndefined();
+    expect(lambdaProps.securityGroups).toBeUndefined();
+    expect(lambdaProps.initialPolicy).toBeUndefined();
+});
+
+test('should guard VPC config by NEPTUNE_TYPE not NEPTUNE_IAM_AUTH', () => {
+    const code = renderTemplate({ neptuneType: 'neptune-db', neptuneIAMAuth: true });
+    expect(code).not.toMatch(/if\s*\(\s*!NEPTUNE_IAM_AUTH\s*\)/);
+});

--- a/src/test/CDKTemplate.test.js
+++ b/src/test/CDKTemplate.test.js
@@ -2,15 +2,25 @@ import { readFileSync } from 'fs';
 
 const templateSource = readFileSync('./templates/CDKTemplate.js', 'utf8');
 
+function safeReplace(source, searchStr, replaceStr) {
+    if (!source.includes(searchStr)) {
+        throw new Error(
+            `CDKTemplate.js no longer contains expected placeholder: ${searchStr}. Update renderTemplate in CDKTemplate.test.js.`
+        );
+    }
+    return source.replace(searchStr, replaceStr);
+}
+
 function renderTemplate({ neptuneType, neptuneIAMAuth }) {
-    return templateSource
-        .replace("const NEPTUNE_TYPE = '';", `const NEPTUNE_TYPE = '${neptuneType}';`)
-        .replace("const NEPTUNE_IAM_AUTH = false;", `const NEPTUNE_IAM_AUTH = ${neptuneIAMAuth};`)
-        .replace("const NEPTUNE_DBSubnetGroup = null;", "const NEPTUNE_DBSubnetGroup = 'vpc-123';")
-        .replace("const NEPTUNE_DBSubnetIds = null;", "const NEPTUNE_DBSubnetIds = 'subnet-1,subnet-2';")
-        .replace("const NEPTUNE_VpcSecurityGroupId = null;", "const NEPTUNE_VpcSecurityGroupId = 'sg-123';")
-        .replace("const NEPTUNE_HOST = '';", "const NEPTUNE_HOST = 'db.cluster.us-east-1.neptune.amazonaws.com';")
-        .replace("const NEPTUNE_IAM_POLICY_RESOURCE = '*';", "const NEPTUNE_IAM_POLICY_RESOURCE = 'arn:aws:neptune-db:us-east-1:123:cluster-abc/*';");
+    let code = templateSource;
+    code = safeReplace(code, "const NEPTUNE_TYPE = '';", `const NEPTUNE_TYPE = '${neptuneType}';`);
+    code = safeReplace(code, "const NEPTUNE_IAM_AUTH = false;", `const NEPTUNE_IAM_AUTH = ${neptuneIAMAuth};`);
+    code = safeReplace(code, "const NEPTUNE_DBSubnetGroup = null;", "const NEPTUNE_DBSubnetGroup = 'vpc-123';");
+    code = safeReplace(code, "const NEPTUNE_DBSubnetIds = null;", "const NEPTUNE_DBSubnetIds = 'subnet-1,subnet-2';");
+    code = safeReplace(code, "const NEPTUNE_VpcSecurityGroupId = null;", "const NEPTUNE_VpcSecurityGroupId = 'sg-123';");
+    code = safeReplace(code, "const NEPTUNE_HOST = '';", "const NEPTUNE_HOST = 'db.cluster.us-east-1.neptune.amazonaws.com';");
+    code = safeReplace(code, "const NEPTUNE_IAM_POLICY_RESOURCE = '*';", "const NEPTUNE_IAM_POLICY_RESOURCE = 'arn:aws:neptune-db:us-east-1:123:cluster-abc/*';");
+    return code;
 }
 
 function evaluateTemplate({ neptuneType, neptuneIAMAuth }) {
@@ -19,7 +29,6 @@ function evaluateTemplate({ neptuneType, neptuneIAMAuth }) {
     const match = code.match(/const lambdaProps = \{[\s\S]*?(?=\n\s*echoLambda = new lambda\.Function)/);
     if (!match) throw new Error('Could not extract lambdaProps block from CDKTemplate.js — check that "const lambdaProps = {" and "echoLambda = new lambda.Function" markers still exist in the template');
 
-    const managedPolicies = [];
     const fn = new Function('NEPTUNE_TYPE', 'NEPTUNE_IAM_AUTH', 'NEPTUNE_DBSubnetGroup', 'NEPTUNE_DBSubnetIds', 'NEPTUNE_VpcSecurityGroupId', 'NEPTUNE_IAM_POLICY_RESOURCE', 'NAME', `
         const ec2 = {
             Vpc: { fromLookup: (_, __, o) => 'vpc-stub' },
@@ -74,10 +83,12 @@ test('neptune-db with IAM: VPC config and IAM policy', () => {
     expect(lambdaProps.vpcSubnets).toBeDefined();
     expect(lambdaProps.securityGroups).toBeDefined();
     expect(lambdaProps.initialPolicy).toBeDefined();
-    expect(lambdaProps.initialPolicy[0].actions).toEqual(expect.arrayContaining([
+    expect(lambdaProps.initialPolicy[0].actions).toEqual([
         'neptune-db:connect',
+        'neptune-db:DeleteDataViaQuery',
         'neptune-db:ReadDataViaQuery',
-    ]));
+        'neptune-db:WriteDataViaQuery',
+    ]);
     expect(managedPolicies).toContain('service-role/AWSLambdaVPCAccessExecutionRole');
 });
 
@@ -87,15 +98,12 @@ test('neptune-graph with IAM: IAM policy, no VPC config', () => {
     expect(lambdaProps.vpcSubnets).toBeUndefined();
     expect(lambdaProps.securityGroups).toBeUndefined();
     expect(lambdaProps.initialPolicy).toBeDefined();
-    expect(lambdaProps.initialPolicy[0].actions).toContain('neptune-graph:connect');
-});
-
-test('neptune-graph without IAM: no VPC, no IAM policy', () => {
-    const { lambdaProps } = evaluateTemplate({ neptuneType: 'neptune-graph', neptuneIAMAuth: false });
-    expect(lambdaProps.vpc).toBeUndefined();
-    expect(lambdaProps.vpcSubnets).toBeUndefined();
-    expect(lambdaProps.securityGroups).toBeUndefined();
-    expect(lambdaProps.initialPolicy).toBeUndefined();
+    expect(lambdaProps.initialPolicy[0].actions).toEqual([
+        'neptune-graph:connect',
+        'neptune-graph:DeleteDataViaQuery',
+        'neptune-graph:ReadDataViaQuery',
+        'neptune-graph:WriteDataViaQuery',
+    ]);
 });
 
 test('should guard VPC config by NEPTUNE_TYPE not NEPTUNE_IAM_AUTH', () => {

--- a/src/test/createPipeline.test.js
+++ b/src/test/createPipeline.test.js
@@ -1,0 +1,164 @@
+import { jest } from '@jest/globals';
+import { mockIAMSend, mockLambdaSend, mockAppSyncSend, mockNeptuneSend, mockWriteFileSync, mockReadFileSync, mockExit, ExitCalled, registerPipelineMocks, mockNeptuneClusterResponse } from './helpers/pipelineMocks.js';
+
+registerPipelineMocks();
+
+const originalSetTimeout = globalThis.setTimeout;
+
+let createUpdateAWSpipeline;
+
+beforeEach(async () => {
+    globalThis.setTimeout = (fn) => originalSetTimeout(fn, 0);
+
+    ({ createUpdateAWSpipeline } = await import('../pipelineResources.js?t=' + Date.now()));
+    jest.clearAllMocks();
+
+    mockIAMSend.mockImplementation(async (cmd) => {
+        if (cmd._type === 'GetRole') throw new Error('not found');
+        if (cmd._type === 'CreateRole') return { Role: { Arn: 'arn:aws:iam::123:role/testRole' } };
+        if (cmd._type === 'CreatePolicy') return { Policy: { Arn: 'arn:aws:iam::123:policy/testPolicy' } };
+        return {};
+    });
+    mockLambdaSend.mockImplementation(async (cmd) => {
+        if (cmd._type === 'GetFunction') throw new Error('not found');
+        if (cmd._type === 'CreateFunction') return { FunctionArn: 'arn:aws:lambda:us-east-1:123:function:test' };
+        return {};
+    });
+    mockAppSyncSend.mockImplementation(async (cmd) => {
+        if (cmd._type === 'ListGraphqlApis') return { graphqlApis: [] };
+        return { graphqlApi: { apiId: 'api-123' }, apiKey: { id: 'key-1' }, functionConfiguration: { functionId: 'fn-1' }, resolvers: [] };
+    });
+    mockNeptuneSend.mockImplementation(mockNeptuneClusterResponse({ iamEnabled: true }));
+    mockWriteFileSync.mockReturnValue(undefined);
+    mockReadFileSync.mockReturnValue(Buffer.from('zip'));
+});
+
+const baseParams = {
+    pipelineName: 'test', neptuneDBName: 'mydb', neptuneDBregion: 'us-east-1',
+    appSyncSchema: 'type Query { get: String }', lambdaFilesPath: '/tmp/lambda',
+    addMutations: false, quietI: true, __dirname: '/tmp',
+    neptuneHost: 'db.cluster.us-east-1.neptune.amazonaws.com', neptunePort: '8182',
+    outputFolderPath: '/tmp/output', resolverFilePath: '/tmp/r.js', resolverSchemaFilePath: '/tmp/s.json',
+    schemaModel: { definitions: [{ kind: 'ObjectTypeDefinition', name: { value: 'Query' }, fields: [{ name: { value: 'get' } }] }] },
+};
+
+describe('createLambdaRole via createUpdateAWSpipeline', () => {
+    test('should attach VPC role as Policy2 for neptune-db without IAM', async () => {
+        mockNeptuneSend.mockImplementation(mockNeptuneClusterResponse({ iamEnabled: false }));
+
+        await createUpdateAWSpipeline({ ...baseParams, isNeptuneIAMAuth: false, neptuneType: 'neptune-db' });
+
+        const attachCalls = mockIAMSend.mock.calls.filter(([c]) => c._type === 'AttachRolePolicy').map(([c]) => c.input.PolicyArn);
+        expect(attachCalls).toContain('arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole');
+        expect(attachCalls).toContain('arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole');
+        const createPolicyCalls = mockIAMSend.mock.calls.filter(([c]) => c._type === 'CreatePolicy');
+        const neptuneQueryPolicies = createPolicyCalls.filter(([c]) => c.input.PolicyName?.includes('NeptuneQuery'));
+        expect(neptuneQueryPolicies).toHaveLength(0);
+
+        const writes = mockWriteFileSync.mock.calls.map(([, json]) => JSON.parse(json));
+        const merged = Object.assign({}, ...writes);
+        expect(merged.LambdaExecutionPolicy2).toBe('arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole');
+        expect(merged.LambdaExecutionPolicy3).toBeUndefined();
+    });
+
+    test('should attach IAM query as Policy2 and VPC as Policy3 for neptune-db with IAM', async () => {
+        await createUpdateAWSpipeline({ ...baseParams, isNeptuneIAMAuth: true, neptuneType: 'neptune-db' });
+
+        const attachCalls = mockIAMSend.mock.calls.filter(([c]) => c._type === 'AttachRolePolicy').map(([c]) => c.input.PolicyArn);
+        expect(attachCalls).toContain('arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole');
+        expect(attachCalls).toContain('arn:aws:iam::123:policy/testPolicy');
+        expect(attachCalls).toContain('arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole');
+
+        const writes = mockWriteFileSync.mock.calls.map(([, json]) => JSON.parse(json));
+        const merged = Object.assign({}, ...writes);
+        expect(merged.LambdaExecutionPolicy2).toBe('arn:aws:iam::123:policy/testPolicy');
+        expect(merged.LambdaExecutionPolicy3).toBe('arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole');
+        expect(merged.NeptuneQueryPolicy).toBe('arn:aws:iam::123:policy/testPolicy');
+
+        const createPolicyCall = mockIAMSend.mock.calls.find(([c]) => c._type === 'CreatePolicy');
+        const policyDoc = JSON.parse(createPolicyCall[0].input.PolicyDocument);
+        expect(policyDoc.Statement[0].Action).toContain('neptune-db:connect');
+    });
+
+    test('should attach IAM query as Policy2 with no VPC for neptune-graph with IAM', async () => {
+        await createUpdateAWSpipeline({ ...baseParams, isNeptuneIAMAuth: true, neptuneType: 'neptune-graph' });
+
+        const attachCalls = mockIAMSend.mock.calls.filter(([c]) => c._type === 'AttachRolePolicy').map(([c]) => c.input.PolicyArn);
+        expect(attachCalls).toContain('arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole');
+        expect(attachCalls).toContain('arn:aws:iam::123:policy/testPolicy');
+        expect(attachCalls).not.toContain('arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole');
+
+        const createPolicyCall = mockIAMSend.mock.calls.find(([c]) => c._type === 'CreatePolicy');
+        const policyDoc = JSON.parse(createPolicyCall[0].input.PolicyDocument);
+        expect(policyDoc.Statement[0].Action).toContain('neptune-graph:connect');
+    });
+
+    test('should attach only basic execution role for neptune-graph without IAM', async () => {
+        await createUpdateAWSpipeline({ ...baseParams, isNeptuneIAMAuth: false, neptuneType: 'neptune-graph' });
+
+        const attachCalls = mockIAMSend.mock.calls.filter(([c]) => c._type === 'AttachRolePolicy').map(([c]) => c.input.PolicyArn);
+        expect(attachCalls).toContain('arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole');
+        expect(attachCalls).toHaveLength(2); // basic + invoke policy
+        expect(attachCalls).not.toContain('arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole');
+    });
+});
+
+describe('createLambdaFunction VpcConfig via createUpdateAWSpipeline', () => {
+    test('should include VpcConfig for neptune-db without IAM', async () => {
+        mockNeptuneSend.mockImplementation(mockNeptuneClusterResponse({ iamEnabled: false }));
+
+        await createUpdateAWSpipeline({ ...baseParams, isNeptuneIAMAuth: false, neptuneType: 'neptune-db' });
+
+        const createFnCall = mockLambdaSend.mock.calls.find(([c]) => c._type === 'CreateFunction');
+        expect(createFnCall).toBeDefined();
+        expect(createFnCall[0].input.VpcConfig).toBeDefined();
+        expect(createFnCall[0].input.VpcConfig.SecurityGroupIds).toEqual(['sg-123']);
+        expect(createFnCall[0].input.VpcConfig.SubnetIds).toEqual(['subnet-1', 'subnet-2']);
+    });
+
+    test('should include VpcConfig for neptune-db with IAM', async () => {
+        await createUpdateAWSpipeline({ ...baseParams, isNeptuneIAMAuth: true, neptuneType: 'neptune-db' });
+
+        const createFnCall = mockLambdaSend.mock.calls.find(([c]) => c._type === 'CreateFunction');
+        expect(createFnCall[0].input.VpcConfig).toBeDefined();
+        expect(createFnCall[0].input.VpcConfig.SubnetIds).toEqual(['subnet-1', 'subnet-2']);
+    });
+
+    test('should not include VpcConfig for neptune-graph with IAM', async () => {
+        await createUpdateAWSpipeline({ ...baseParams, isNeptuneIAMAuth: true, neptuneType: 'neptune-graph' });
+
+        const createFnCall = mockLambdaSend.mock.calls.find(([c]) => c._type === 'CreateFunction');
+        expect(createFnCall[0].input.VpcConfig).toBeUndefined();
+    });
+
+    test('should not include VpcConfig for neptune-graph without IAM', async () => {
+        await createUpdateAWSpipeline({ ...baseParams, isNeptuneIAMAuth: false, neptuneType: 'neptune-graph' });
+
+        const createFnCall = mockLambdaSend.mock.calls.find(([c]) => c._type === 'CreateFunction');
+        expect(createFnCall[0].input.VpcConfig).toBeUndefined();
+    });
+});
+
+describe('createUpdateAWSpipeline error handling', () => {
+    test('should exit on cluster info failure for neptune-db with IAM', async () => {
+        mockNeptuneSend.mockRejectedValue(new Error('cluster not found'));
+
+        try { await createUpdateAWSpipeline({ ...baseParams, isNeptuneIAMAuth: true, neptuneType: 'neptune-db' }); } catch (e) { if (!(e instanceof ExitCalled)) throw e; }
+
+        expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    test('should exit when neptune-db has IAM disabled but flag was provided', async () => {
+        mockNeptuneSend.mockImplementation(mockNeptuneClusterResponse({ iamEnabled: false }));
+
+        try { await createUpdateAWSpipeline({ ...baseParams, isNeptuneIAMAuth: true, neptuneType: 'neptune-db' }); } catch (e) { if (!(e instanceof ExitCalled)) throw e; }
+
+        expect(mockExit).toHaveBeenCalledWith(1);
+    });
+});
+
+afterEach(() => {
+    globalThis.setTimeout = originalSetTimeout;
+});
+
+

--- a/src/test/createPipeline.test.js
+++ b/src/test/createPipeline.test.js
@@ -3,12 +3,11 @@ import { mockIAMSend, mockLambdaSend, mockAppSyncSend, mockNeptuneSend, mockWrit
 
 registerPipelineMocks();
 
-const originalSetTimeout = globalThis.setTimeout;
-
 let createUpdateAWSpipeline;
 
 beforeEach(async () => {
-    globalThis.setTimeout = (fn) => originalSetTimeout(fn, 0);
+    // doNotFake: ['Date'] keeps Date.now() real so each re-import gets a unique query string, forcing a fresh module instance
+    jest.useFakeTimers({ doNotFake: ['Date'] });
 
     // Re-import with unique query string to reset module-level mutable state between tests
     ({ createUpdateAWSpipeline } = await import('../pipelineResources.js?t=' + Date.now()));
@@ -43,11 +42,17 @@ const baseParams = {
     schemaModel: { definitions: [{ kind: 'ObjectTypeDefinition', name: { value: 'Query' }, fields: [{ name: { value: 'get' } }] }] },
 };
 
+async function runPipeline(overrides) {
+    const p = createUpdateAWSpipeline({ ...baseParams, ...overrides });
+    await jest.runAllTimersAsync();
+    return p;
+}
+
 describe('createLambdaRole via createUpdateAWSpipeline', () => {
     test('should attach VPC role as Policy2 for neptune-db without IAM', async () => {
         mockNeptuneSend.mockImplementation(mockNeptuneClusterResponse({ iamEnabled: false }));
 
-        await createUpdateAWSpipeline({ ...baseParams, isNeptuneIAMAuth: false, neptuneType: 'neptune-db' });
+        await runPipeline({ isNeptuneIAMAuth: false, neptuneType: 'neptune-db' });
 
         const attachCalls = mockIAMSend.mock.calls.filter(([c]) => c._type === 'AttachRolePolicy').map(([c]) => c.input.PolicyArn);
         expect(attachCalls).toContain('arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole');
@@ -63,7 +68,7 @@ describe('createLambdaRole via createUpdateAWSpipeline', () => {
     });
 
     test('should attach IAM query as Policy2 and VPC as Policy3 for neptune-db with IAM', async () => {
-        await createUpdateAWSpipeline({ ...baseParams, isNeptuneIAMAuth: true, neptuneType: 'neptune-db' });
+        await runPipeline({ isNeptuneIAMAuth: true, neptuneType: 'neptune-db' });
 
         const attachCalls = mockIAMSend.mock.calls.filter(([c]) => c._type === 'AttachRolePolicy').map(([c]) => c.input.PolicyArn);
         expect(attachCalls).toContain('arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole');
@@ -82,7 +87,7 @@ describe('createLambdaRole via createUpdateAWSpipeline', () => {
     });
 
     test('should attach IAM query as Policy2 with no VPC for neptune-graph with IAM', async () => {
-        await createUpdateAWSpipeline({ ...baseParams, isNeptuneIAMAuth: true, neptuneType: 'neptune-graph' });
+        await runPipeline({ isNeptuneIAMAuth: true, neptuneType: 'neptune-graph' });
 
         const attachCalls = mockIAMSend.mock.calls.filter(([c]) => c._type === 'AttachRolePolicy').map(([c]) => c.input.PolicyArn);
         expect(attachCalls).toContain('arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole');
@@ -94,21 +99,13 @@ describe('createLambdaRole via createUpdateAWSpipeline', () => {
         expect(policyDoc.Statement[0].Action).toContain('neptune-graph:connect');
     });
 
-    test('should attach only basic execution role for neptune-graph without IAM', async () => {
-        await createUpdateAWSpipeline({ ...baseParams, isNeptuneIAMAuth: false, neptuneType: 'neptune-graph' });
-
-        const attachCalls = mockIAMSend.mock.calls.filter(([c]) => c._type === 'AttachRolePolicy').map(([c]) => c.input.PolicyArn);
-        expect(attachCalls).toContain('arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole');
-        expect(attachCalls).not.toContain('arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole');
-        expect(attachCalls).toHaveLength(2); // basic + invoke policy
-    });
 });
 
 describe('createLambdaFunction VpcConfig via createUpdateAWSpipeline', () => {
     test('should include VpcConfig for neptune-db without IAM', async () => {
         mockNeptuneSend.mockImplementation(mockNeptuneClusterResponse({ iamEnabled: false }));
 
-        await createUpdateAWSpipeline({ ...baseParams, isNeptuneIAMAuth: false, neptuneType: 'neptune-db' });
+        await runPipeline({ isNeptuneIAMAuth: false, neptuneType: 'neptune-db' });
 
         const createFnCall = mockLambdaSend.mock.calls.find(([c]) => c._type === 'CreateFunction');
         expect(createFnCall).toBeDefined();
@@ -118,7 +115,7 @@ describe('createLambdaFunction VpcConfig via createUpdateAWSpipeline', () => {
     });
 
     test('should include VpcConfig for neptune-db with IAM', async () => {
-        await createUpdateAWSpipeline({ ...baseParams, isNeptuneIAMAuth: true, neptuneType: 'neptune-db' });
+        await runPipeline({ isNeptuneIAMAuth: true, neptuneType: 'neptune-db' });
 
         const createFnCall = mockLambdaSend.mock.calls.find(([c]) => c._type === 'CreateFunction');
         expect(createFnCall[0].input.VpcConfig).toBeDefined();
@@ -126,25 +123,22 @@ describe('createLambdaFunction VpcConfig via createUpdateAWSpipeline', () => {
     });
 
     test('should not include VpcConfig for neptune-graph with IAM', async () => {
-        await createUpdateAWSpipeline({ ...baseParams, isNeptuneIAMAuth: true, neptuneType: 'neptune-graph' });
+        await runPipeline({ isNeptuneIAMAuth: true, neptuneType: 'neptune-graph' });
 
         const createFnCall = mockLambdaSend.mock.calls.find(([c]) => c._type === 'CreateFunction');
         expect(createFnCall[0].input.VpcConfig).toBeUndefined();
     });
 
-    test('should not include VpcConfig for neptune-graph without IAM', async () => {
-        await createUpdateAWSpipeline({ ...baseParams, isNeptuneIAMAuth: false, neptuneType: 'neptune-graph' });
-
-        const createFnCall = mockLambdaSend.mock.calls.find(([c]) => c._type === 'CreateFunction');
-        expect(createFnCall[0].input.VpcConfig).toBeUndefined();
-    });
 });
 
 describe('createUpdateAWSpipeline error handling', () => {
     test('should exit on cluster info failure for neptune-db with IAM', async () => {
         mockNeptuneSend.mockRejectedValue(new Error('cluster not found'));
 
-        try { await createUpdateAWSpipeline({ ...baseParams, isNeptuneIAMAuth: true, neptuneType: 'neptune-db' }); } catch (e) { if (!(e instanceof ExitCalled)) throw e; }
+        // swallow expected ExitCalled, rethrow anything else
+        try {
+            await runPipeline({ isNeptuneIAMAuth: true, neptuneType: 'neptune-db' });
+        } catch (e) { if (!(e instanceof ExitCalled)) throw e; }
 
         expect(mockExit).toHaveBeenCalledWith(1);
     });
@@ -152,14 +146,17 @@ describe('createUpdateAWSpipeline error handling', () => {
     test('should exit when neptune-db has IAM disabled but flag was provided', async () => {
         mockNeptuneSend.mockImplementation(mockNeptuneClusterResponse({ iamEnabled: false }));
 
-        try { await createUpdateAWSpipeline({ ...baseParams, isNeptuneIAMAuth: true, neptuneType: 'neptune-db' }); } catch (e) { if (!(e instanceof ExitCalled)) throw e; }
+        // swallow expected ExitCalled, rethrow anything else
+        try {
+            await runPipeline({ isNeptuneIAMAuth: true, neptuneType: 'neptune-db' });
+        } catch (e) { if (!(e instanceof ExitCalled)) throw e; }
 
         expect(mockExit).toHaveBeenCalledWith(1);
     });
 });
 
 afterEach(() => {
-    globalThis.setTimeout = originalSetTimeout;
+    jest.useRealTimers();
 });
 
 

--- a/src/test/createPipeline.test.js
+++ b/src/test/createPipeline.test.js
@@ -98,8 +98,8 @@ describe('createLambdaRole via createUpdateAWSpipeline', () => {
 
         const attachCalls = mockIAMSend.mock.calls.filter(([c]) => c._type === 'AttachRolePolicy').map(([c]) => c.input.PolicyArn);
         expect(attachCalls).toContain('arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole');
-        expect(attachCalls).toHaveLength(2); // basic + invoke policy
         expect(attachCalls).not.toContain('arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole');
+        expect(attachCalls).toHaveLength(2); // basic + invoke policy
     });
 });
 

--- a/src/test/createPipeline.test.js
+++ b/src/test/createPipeline.test.js
@@ -10,6 +10,7 @@ let createUpdateAWSpipeline;
 beforeEach(async () => {
     globalThis.setTimeout = (fn) => originalSetTimeout(fn, 0);
 
+    // Re-import with unique query string to reset module-level mutable state between tests
     ({ createUpdateAWSpipeline } = await import('../pipelineResources.js?t=' + Date.now()));
     jest.clearAllMocks();
 

--- a/src/test/helpers/pipelineMocks.js
+++ b/src/test/helpers/pipelineMocks.js
@@ -1,0 +1,85 @@
+import { jest } from '@jest/globals';
+
+export const mockIAMSend = jest.fn();
+export const mockLambdaSend = jest.fn();
+export const mockAppSyncSend = jest.fn();
+export const mockNeptuneSend = jest.fn();
+export const mockWriteFileSync = jest.fn();
+export const mockReadFileSync = jest.fn();
+export class ExitCalled extends Error {
+    constructor(code) { super(`process.exit(${code})`); this.code = code; }
+}
+export const mockExit = jest.fn((code) => { throw new ExitCalled(code); });
+
+export function registerPipelineMocks() {
+    jest.unstable_mockModule('@aws-sdk/client-iam', () => ({
+        IAMClient: jest.fn(() => ({ send: mockIAMSend })),
+        CreateRoleCommand: jest.fn(input => ({ _type: 'CreateRole', input })),
+        AttachRolePolicyCommand: jest.fn(input => ({ _type: 'AttachRolePolicy', input })),
+        GetRoleCommand: jest.fn(input => ({ _type: 'GetRole', input })),
+        CreatePolicyCommand: jest.fn(input => ({ _type: 'CreatePolicy', input })),
+        DetachRolePolicyCommand: jest.fn(input => ({ _type: 'DetachRolePolicy', input })),
+        DeleteRoleCommand: jest.fn(input => ({ _type: 'DeleteRole', input })),
+        DeletePolicyCommand: jest.fn(input => ({ _type: 'DeletePolicy', input })),
+    }));
+
+    jest.unstable_mockModule('@aws-sdk/client-lambda', () => ({
+        LambdaClient: jest.fn(() => ({ send: mockLambdaSend })),
+        CreateFunctionCommand: jest.fn(input => ({ _type: 'CreateFunction', input })),
+        GetFunctionCommand: jest.fn(input => ({ _type: 'GetFunction', input })),
+        DeleteFunctionCommand: jest.fn(input => ({ _type: 'DeleteFunction', input })),
+        UpdateFunctionCodeCommand: jest.fn(input => ({ _type: 'UpdateFunctionCode', input })),
+    }));
+
+    jest.unstable_mockModule('@aws-sdk/client-appsync', () => ({
+        AppSyncClient: jest.fn(() => ({ send: mockAppSyncSend })),
+        CreateGraphqlApiCommand: jest.fn(input => ({ _type: 'CreateGraphqlApi', input })),
+        StartSchemaCreationCommand: jest.fn(input => input),
+        CreateDataSourceCommand: jest.fn(input => input),
+        CreateFunctionCommand: jest.fn(input => input),
+        CreateResolverCommand: jest.fn(input => input),
+        CreateApiKeyCommand: jest.fn(input => input),
+        ListGraphqlApisCommand: jest.fn(input => ({ _type: 'ListGraphqlApis', input })),
+        DeleteGraphqlApiCommand: jest.fn(input => ({ _type: 'DeleteGraphqlApi', input })),
+        ListResolversCommand: jest.fn(input => input),
+    }));
+
+    jest.unstable_mockModule('@aws-sdk/client-neptune', () => ({
+        NeptuneClient: jest.fn(() => ({ send: mockNeptuneSend })),
+        DescribeDBClustersCommand: jest.fn(input => ({ _type: 'DescribeDBClusters', input })),
+        DescribeDBSubnetGroupsCommand: jest.fn(input => ({ _type: 'DescribeDBSubnetGroups', input })),
+    }));
+
+    jest.unstable_mockModule('ora', () => ({
+        default: jest.fn(() => ({ start: jest.fn().mockReturnThis(), succeed: jest.fn().mockReturnThis(), fail: jest.fn().mockReturnThis(), warn: jest.fn().mockReturnThis() })),
+    }));
+
+    jest.unstable_mockModule('fs', () => ({
+        default: { writeFileSync: mockWriteFileSync, readFileSync: mockReadFileSync },
+    }));
+
+    jest.unstable_mockModule('../zipPackage.js', () => ({
+        createLambdaDeploymentPackage: jest.fn(),
+    }));
+
+    jest.unstable_mockModule('../logger.js', () => ({
+        loggerDebug: jest.fn(), loggerError: jest.fn(), loggerInfo: jest.fn(), yellow: jest.fn(s => s),
+    }));
+
+    jest.unstable_mockModule('process', () => ({ exit: mockExit }));
+}
+
+export function mockNeptuneClusterResponse({ iamEnabled }) {
+    return async (cmd) => {
+        if (cmd._type === 'DescribeDBClusters') return {
+            DBClusters: [{ Endpoint: 'db.cluster.us-east-1.neptune.amazonaws.com', Port: 8182,
+                DBSubnetGroup: 'default', VpcSecurityGroups: [{ VpcSecurityGroupId: 'sg-123' }],
+                IAMDatabaseAuthenticationEnabled: iamEnabled, EngineVersion: '1.3.0.0',
+                DBClusterArn: 'arn:aws:rds:us-east-1:123:cluster:mydb', DbClusterResourceId: 'cluster-abc' }]
+        };
+        if (cmd._type === 'DescribeDBSubnetGroups') return {
+            DBSubnetGroups: [{ Subnets: [{ SubnetIdentifier: 'subnet-1' }, { SubnetIdentifier: 'subnet-2' }] }]
+        };
+        return {};
+    };
+}

--- a/src/test/removePipeline.test.js
+++ b/src/test/removePipeline.test.js
@@ -1,0 +1,169 @@
+import { jest } from '@jest/globals';
+import { mockIAMSend, mockLambdaSend, mockAppSyncSend, registerPipelineMocks } from './helpers/pipelineMocks.js';
+
+registerPipelineMocks();
+
+let removeAWSpipelineResources;
+
+describe('removeAWSpipelineResources', () => {
+
+beforeEach(async () => {
+    ({ removeAWSpipelineResources } = await import('../pipelineResources.js?t=' + Date.now()));
+    jest.clearAllMocks();
+    mockIAMSend.mockResolvedValue({});
+    mockLambdaSend.mockResolvedValue({});
+    mockAppSyncSend.mockResolvedValue({});
+});
+
+test('should detach Policy1 and Policy2 for neptune-db without IAM', async () => {
+    const resources = {
+        region: 'us-east-1',
+        AppSyncAPI: 'api-id',
+        LambdaFunction: 'testLambdaFunction',
+        LambdaExecutionRole: 'testLambdaExecutionRole',
+        LambdaExecutionPolicy1: 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole',
+        LambdaExecutionPolicy2: 'arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole',
+        LambdaInvokePolicy: 'arn:invoke-policy',
+        LambdaInvokeRole: 'invokeRole',
+    };
+
+    await removeAWSpipelineResources(resources, true);
+
+    const detachCalls = mockIAMSend.mock.calls
+        .filter(([cmd]) => cmd._type === 'DetachRolePolicy')
+        .map(([cmd]) => cmd.input.PolicyArn);
+
+    expect(detachCalls).toContain(resources.LambdaExecutionPolicy1);
+    expect(detachCalls).toContain(resources.LambdaExecutionPolicy2);
+    expect(detachCalls).not.toContain(undefined);
+});
+
+test('should detach all three policies for neptune-db with IAM', async () => {
+    const resources = {
+        region: 'us-east-1',
+        AppSyncAPI: 'api-id',
+        LambdaFunction: 'testLambdaFunction',
+        LambdaExecutionRole: 'testLambdaExecutionRole',
+        LambdaExecutionPolicy1: 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole',
+        LambdaExecutionPolicy2: 'arn:neptune-query-policy',
+        LambdaExecutionPolicy3: 'arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole',
+        NeptuneQueryPolicy: 'arn:neptune-query-policy',
+        LambdaInvokePolicy: 'arn:invoke-policy',
+        LambdaInvokeRole: 'invokeRole',
+    };
+
+    await removeAWSpipelineResources(resources, true);
+
+    const detachCalls = mockIAMSend.mock.calls
+        .filter(([cmd]) => cmd._type === 'DetachRolePolicy')
+        .map(([cmd]) => cmd.input.PolicyArn);
+
+    expect(detachCalls).toContain(resources.LambdaExecutionPolicy1);
+    expect(detachCalls).toContain(resources.LambdaExecutionPolicy2);
+    expect(detachCalls).toContain(resources.LambdaExecutionPolicy3);
+
+    const deletePolicyCalls = mockIAMSend.mock.calls
+        .filter(([cmd]) => cmd._type === 'DeletePolicy')
+        .map(([cmd]) => cmd.input.PolicyArn);
+    expect(deletePolicyCalls).toContain(resources.NeptuneQueryPolicy);
+});
+
+test('should detach Policy1 and Policy2 for neptune-graph with IAM', async () => {
+    const resources = {
+        region: 'us-east-1',
+        AppSyncAPI: 'api-id',
+        LambdaFunction: 'testLambdaFunction',
+        LambdaExecutionRole: 'testLambdaExecutionRole',
+        LambdaExecutionPolicy1: 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole',
+        LambdaExecutionPolicy2: 'arn:neptune-query-policy',
+        NeptuneQueryPolicy: 'arn:neptune-query-policy',
+        LambdaInvokePolicy: 'arn:invoke-policy',
+        LambdaInvokeRole: 'invokeRole',
+    };
+
+    await removeAWSpipelineResources(resources, true);
+
+    const detachCalls = mockIAMSend.mock.calls
+        .filter(([cmd]) => cmd._type === 'DetachRolePolicy')
+        .map(([cmd]) => cmd.input.PolicyArn);
+
+    expect(detachCalls).toContain(resources.LambdaExecutionPolicy1);
+    expect(detachCalls).toContain(resources.LambdaExecutionPolicy2);
+    expect(detachCalls).toHaveLength(3); // Policy1 + Policy2 + InvokePolicy detach
+});
+
+test('should detach only Policy1 for neptune-graph without IAM', async () => {
+    const resources = {
+        region: 'us-east-1',
+        AppSyncAPI: 'api-id',
+        LambdaFunction: 'testLambdaFunction',
+        LambdaExecutionRole: 'testLambdaExecutionRole',
+        LambdaExecutionPolicy1: 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole',
+        LambdaInvokePolicy: 'arn:invoke-policy',
+        LambdaInvokeRole: 'invokeRole',
+    };
+
+    await removeAWSpipelineResources(resources, true);
+
+    const detachCalls = mockIAMSend.mock.calls
+        .filter(([cmd]) => cmd._type === 'DetachRolePolicy')
+        .map(([cmd]) => cmd.input.PolicyArn);
+
+    expect(detachCalls).toContain(resources.LambdaExecutionPolicy1);
+    expect(detachCalls).toHaveLength(2); // Policy1 + InvokePolicy detach
+});
+
+test('should handle old resources.json format without Policy3', async () => {
+    const resources = {
+        region: 'us-east-1',
+        AppSyncAPI: 'api-id',
+        LambdaFunction: 'testLambdaFunction',
+        LambdaExecutionRole: 'testLambdaExecutionRole',
+        LambdaExecutionPolicy1: 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole',
+        LambdaExecutionPolicy2: 'arn:neptune-query-policy',
+        NeptuneQueryPolicy: 'arn:neptune-query-policy',
+        LambdaInvokePolicy: 'arn:invoke-policy',
+        LambdaInvokeRole: 'invokeRole',
+    };
+
+    await expect(removeAWSpipelineResources(resources, true)).resolves.not.toThrow();
+
+    const detachCalls = mockIAMSend.mock.calls
+        .filter(([cmd]) => cmd._type === 'DetachRolePolicy')
+        .map(([cmd]) => cmd.input.PolicyArn);
+
+    expect(detachCalls).toContain(resources.LambdaExecutionPolicy1);
+    expect(detachCalls).toContain(resources.LambdaExecutionPolicy2);
+    expect(detachCalls).not.toContain(undefined);
+});
+
+test('should continue detaching remaining policies when one fails', async () => {
+    mockIAMSend.mockImplementation(async (cmd) => {
+        if (cmd._type === 'DetachRolePolicy' && cmd.input.PolicyArn === 'arn:policy-that-fails') {
+            throw new Error('Detach failed');
+        }
+        return {};
+    });
+
+    const resources = {
+        region: 'us-east-1',
+        AppSyncAPI: 'api-id',
+        LambdaFunction: 'testLambdaFunction',
+        LambdaExecutionRole: 'testLambdaExecutionRole',
+        LambdaExecutionPolicy1: 'arn:policy-that-fails',
+        LambdaExecutionPolicy2: 'arn:policy-that-succeeds',
+        LambdaInvokePolicy: 'arn:invoke-policy',
+        LambdaInvokeRole: 'invokeRole',
+    };
+
+    await expect(removeAWSpipelineResources(resources, true)).resolves.not.toThrow();
+
+    const detachCalls = mockIAMSend.mock.calls
+        .filter(([cmd]) => cmd._type === 'DetachRolePolicy')
+        .map(([cmd]) => cmd.input.PolicyArn);
+
+    expect(detachCalls).toContain('arn:policy-that-fails');
+    expect(detachCalls).toContain('arn:policy-that-succeeds');
+});
+
+}); // describe

--- a/src/test/removePipeline.test.js
+++ b/src/test/removePipeline.test.js
@@ -93,27 +93,6 @@ test('should detach Policy1 and Policy2 for neptune-graph with IAM', async () =>
     expect(detachCalls).toHaveLength(3); // Policy1 + Policy2 + InvokePolicy detach
 });
 
-test('should detach only Policy1 for neptune-graph without IAM', async () => {
-    const resources = {
-        region: 'us-east-1',
-        AppSyncAPI: 'api-id',
-        LambdaFunction: 'testLambdaFunction',
-        LambdaExecutionRole: 'testLambdaExecutionRole',
-        LambdaExecutionPolicy1: 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole',
-        LambdaInvokePolicy: 'arn:invoke-policy',
-        LambdaInvokeRole: 'invokeRole',
-    };
-
-    await removeAWSpipelineResources(resources, true);
-
-    const detachCalls = mockIAMSend.mock.calls
-        .filter(([cmd]) => cmd._type === 'DetachRolePolicy')
-        .map(([cmd]) => cmd.input.PolicyArn);
-
-    expect(detachCalls).toContain(resources.LambdaExecutionPolicy1);
-    expect(detachCalls).toHaveLength(2); // Policy1 + InvokePolicy detach
-});
-
 test('should handle old resources.json format without Policy3', async () => {
     const resources = {
         region: 'us-east-1',

--- a/src/test/removePipeline.test.js
+++ b/src/test/removePipeline.test.js
@@ -8,6 +8,7 @@ let removeAWSpipelineResources;
 describe('removeAWSpipelineResources', () => {
 
 beforeEach(async () => {
+    // Re-import with unique query string to reset module-level mutable state between tests
     ({ removeAWSpipelineResources } = await import('../pipelineResources.js?t=' + Date.now()));
     jest.clearAllMocks();
     mockIAMSend.mockResolvedValue({});

--- a/templates/CDKTemplate.js
+++ b/templates/CDKTemplate.js
@@ -72,42 +72,7 @@ class AppSyncNeptuneStack extends Stack {
            NEPTUNE_DOMAIN: this.parseNeptuneDomainFromHost(NEPTUNE_HOST),
            NEPTUNE_TYPE: NEPTUNE_TYPE,
        };
-       if (NEPTUNE_IAM_AUTH) {
-            // is IAM auth
-            echoLambda = new lambda.Function(this, LAMBDA_FUNCTION_NAME, {
-                functionName: LAMBDA_FUNCTION_NAME,
-                description: 'Neptune GraphQL Resolver for AppSync',
-                code: lambda.Code.fromAsset(LAMBDA_ZIP_FILE), 
-                handler: 'index.handler',
-                runtime: lambda.Runtime.NODEJS_18_X,
-                timeout: Duration.seconds(15), 
-                memorySize: 128, 
-                environment: env,
-                initialPolicy: [new iam.PolicyStatement({
-                    sid: NAME + "NeptuneQueryPolicy",
-                    effect: iam.Effect.ALLOW,
-                    actions: [
-                        NEPTUNE_TYPE + ':connect',
-                        NEPTUNE_TYPE + ':DeleteDataViaQuery',
-                        NEPTUNE_TYPE + ':ReadDataViaQuery',
-                        NEPTUNE_TYPE + ':WriteDataViaQuery'
-                    ],
-                    resources: [NEPTUNE_IAM_POLICY_RESOURCE]
-                })],
-                roleArn: lambda_role.roleArn
-            });
-                        
-        } else {
-            // is VPC auth
-            const neptune_vpc = ec2.Vpc.fromLookup(this, 'Neptune_VPC', {
-                vpcId: NEPTUNE_DBSubnetGroup
-            });
-            
-            lambda_role.addManagedPolicy( iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole'));
-
-           let subnets = NEPTUNE_DBSubnetIds.split(',').map((subnetId) => ec2.Subnet.fromSubnetId(this, 'neptuneSubnet-' + subnetId, subnetId));
-
-            echoLambda = new lambda.Function(this, LAMBDA_FUNCTION_NAME, {
+        const lambdaProps = {
                 functionName: LAMBDA_FUNCTION_NAME,
                 description: 'Neptune GraphQL Resolver for AppSync',
                 code: lambda.Code.fromAsset(LAMBDA_ZIP_FILE),
@@ -116,18 +81,42 @@ class AppSyncNeptuneStack extends Stack {
                 timeout: Duration.seconds(15),
                 memorySize: 128,
                 environment: env,
-                vpc: neptune_vpc,
-                vpcSubnets: {
-                    subnets: subnets
-                },
-                securityGroups: [
-                    ec2.SecurityGroup.fromSecurityGroupId(this, 'neptuneSecurityGroup', NEPTUNE_VpcSecurityGroupId)
-                ],
-                allowPublicSubnet: 'true',
                 roleArn: lambda_role.roleArn
-            });
+        };
+
+        if (NEPTUNE_IAM_AUTH) {
+            lambdaProps.initialPolicy = [new iam.PolicyStatement({
+                sid: NAME + "NeptuneQueryPolicy",
+                effect: iam.Effect.ALLOW,
+                actions: [
+                    NEPTUNE_TYPE + ':connect',
+                    NEPTUNE_TYPE + ':DeleteDataViaQuery',
+                    NEPTUNE_TYPE + ':ReadDataViaQuery',
+                    NEPTUNE_TYPE + ':WriteDataViaQuery'
+                ],
+                resources: [NEPTUNE_IAM_POLICY_RESOURCE]
+            })];
         }
-        
+
+        if (NEPTUNE_TYPE === 'neptune-db') {
+            const neptune_vpc = ec2.Vpc.fromLookup(this, 'Neptune_VPC', {
+                vpcId: NEPTUNE_DBSubnetGroup
+            });
+
+            lambda_role.addManagedPolicy( iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole'));
+
+            let subnets = NEPTUNE_DBSubnetIds.split(',').map((subnetId) => ec2.Subnet.fromSubnetId(this, 'neptuneSubnet-' + subnetId, subnetId));
+
+            lambdaProps.vpc = neptune_vpc;
+            lambdaProps.vpcSubnets = { subnets: subnets };
+            lambdaProps.securityGroups = [
+                ec2.SecurityGroup.fromSecurityGroupId(this, 'neptuneSecurityGroup', NEPTUNE_VpcSecurityGroupId)
+            ];
+            lambdaProps.allowPublicSubnet = 'true';
+        }
+
+        echoLambda = new lambda.Function(this, LAMBDA_FUNCTION_NAME, lambdaProps);
+
         echoLambda.node.addDependency(lambda_role);
         LAMBDA_ARN = echoLambda.functionArn;        
 


### PR DESCRIPTION
   ### Description

   Neptune DB clusters always run inside a VPC, but the Lambda resolver was created without VPC configuration when IAM authentication was enabled. The Lambda could not reach the Neptune endpoint, making the `neptune-db + IAM` deployment combination non-functional.

   ### Root Cause

VPC configuration was conditionally applied based on the authentication method (`!NEPTUNE_IAM_AUTH`) rather than the database type (`NEPTUNE_TYPE === NEPTUNE_DB`). This incorrectly treated VPC and IAM as mutually exclusive, when in practice Neptune DB requires VPC connectivity regardless of how authentication is configured.

   ### Changes

   **Pipeline creation** (`src/pipelineResources.js`)
   - `createLambdaRole()`: split if/else into two independent blocks; neptune-db + IAM now gets all three policies (BasicExecution, NeptuneQuery, VPCAccess)
   - `createLambdaFunction()`: gate `VpcConfig` on `NEPTUNE_TYPE === NEPTUNE_DB` instead of `!NEPTUNE_IAM_AUTH`

   **CDK generation** (`src/CDKPipelineApp.js`, `templates/CDKTemplate.js`)
   - Restructure template from two separate `lambda.Function` calls to incremental props building with a single instantiation
   - Gate VPC config on `NEPTUNE_TYPE`, not auth method
   - Move `NEPTUNE_DBSubnetGroup` replacement inside the `neptuneClusterInfo` guard (previously produced string `'null'` for neptune-graph)

   **Cleanup** (`src/pipelineResources.js`)
   - Replace hardcoded policy detach blocks with dynamic loop over `LambdaExecutionPolicy*` keys

   **Error handling** (`src/pipelineResources.js`, `src/CDKPipelineApp.js`)
   - Always `exit(1)` when cluster info fetch fails for neptune-db, regardless of IAM flag (previously silently continued for IAM)
   - Improve error messages: "IAM authentication enabled/disabled" instead of "authentication is set to VPC/IAM"

   **Tests** (5 new files, 24 test cases)
   - Full 4-combination matrix (neptune-db/graph × IAM/no-IAM) for role creation, Lambda VpcConfig, policy cleanup, and CDK template output
   - Edge cases: partial cleanup failures, old resources.json format without Policy3, cluster info fetch failures