### PR TITLE
Enable integration tests to run against IAM-enabled Neptune endpoints

### DIFF
--- a/.jest.js
+++ b/.jest.js
@@ -12,6 +12,8 @@ export default {
         // ex. db-neptune-foo-bar.cluster-abc.us-west-2.neptune.amazonaws.com
         'AIR_ROUTES_DB_HOST': process.env.AIR_ROUTES_DB_HOST,
         // ex. 8182
-        'AIR_ROUTES_DB_PORT': process.env.AIR_ROUTES_DB_PORT
+        'AIR_ROUTES_DB_PORT': process.env.AIR_ROUTES_DB_PORT,
+        // enables IAM auth flags for pipeline/CDK integration tests
+        'NEPTUNE_IAM_AUTH': process.env.NEPTUNE_IAM_AUTH
     }
 };

--- a/TESTING.md
+++ b/TESTING.md
@@ -29,24 +29,33 @@ the following prerequisites to run:
 2. neptune db cluster or graph which is accessible from the machine running the
    tests and
    is [loaded with the airports sample dataset](#loading-airports-sample-data-into-neptune)
-   3, AWS credentials configured appropriately on the machine running the tests
+3. AWS credentials configured appropriately on the machine running the tests
    to allow query access to the neptune db or cluster
 4. AWS IAM configured to allow creation of AWS resources necessary to deploy an
    App Sync API
 5. environment variables `AIR_ROUTES_DB_HOST` and `AIR_ROUTES_DB_PORT` set to
    identify the neptune db cluster or graph, for example:
 
-```
-# neptune db cluster
-export AIR_ROUTES_DB_HOST=air-routes.cluster-123.us-west-2.neptune.amazonaws.com
-export AIR_ROUTES_DB_PORT=8182
-```
+   ```
+   # neptune db cluster
+   export AIR_ROUTES_DB_HOST=air-routes.cluster-123.us-west-2.neptune.amazonaws.com
+   export AIR_ROUTES_DB_PORT=8182
+   ```
 
-```
-# neptune analytics graph
-export AIR_ROUTES_DB_HOST=g-abc123.us-west-2.neptune-graph.amazonaws.com
-export AIR_ROUTES_DB_PORT=8182
-```
+   ```
+   # neptune analytics graph
+   export AIR_ROUTES_DB_HOST=g-abc123.us-west-2.neptune-graph.amazonaws.com
+   export AIR_ROUTES_DB_PORT=8182
+   ```
+
+6. if the neptune db cluster has IAM authentication enabled:
+
+   ```
+   export NEPTUNE_IAM_AUTH=true
+   ```
+
+   **Note:** Neptune Analytics (`neptune-graph`) endpoints automatically enable
+   IAM auth regardless of the `NEPTUNE_IAM_AUTH` variable.
 
 To execute the integration tests use the following command:
 

--- a/test/TestCases/Case05/Case05.01.test.js
+++ b/test/TestCases/Case05/Case05.01.test.js
@@ -1,12 +1,12 @@
 
 import { jest } from '@jest/globals';
-import { readJSONFile } from '../../testLib';
+import { readJSONFile, getTestArgv } from '../../testLib';
 import { main } from "../../../src/main";
 
 const casetest = readJSONFile('./test/TestCases/Case05/case01.json');
 
 async function executeUtility() {    
-    process.argv = casetest.argv;
+    process.argv = getTestArgv(casetest);
     await main();
 }
 

--- a/test/TestCases/Case05/Case05.04.test.js
+++ b/test/TestCases/Case05/Case05.04.test.js
@@ -1,12 +1,12 @@
 
 import { jest } from '@jest/globals';
-import { readJSONFile } from '../../testLib';
+import { readJSONFile, getTestArgv } from '../../testLib';
 import { main } from "../../../src/main";
 
 const casetest = readJSONFile('./test/TestCases/Case05/pipeline-with-prefixes.json');
 
 async function executeUtility() {    
-    process.argv = casetest.argv;
+    process.argv = getTestArgv(casetest);
     await main();
 }
 

--- a/test/TestCases/Case06/Case06.01.test.js
+++ b/test/TestCases/Case06/Case06.01.test.js
@@ -1,10 +1,10 @@
-import { readJSONFile } from '../../testLib';
+import { readJSONFile, getTestArgv } from '../../testLib';
 import { main } from "../../../src/main";
 
 const casetest = readJSONFile('./test/TestCases/Case06/cdk-pipeline-http-resolver.json');
 
 async function executeUtility() {    
-    process.argv = casetest.argv;
+    process.argv = getTestArgv(casetest);
     await main();
 }
 

--- a/test/TestCases/Case06/Case06.03.test.js
+++ b/test/TestCases/Case06/Case06.03.test.js
@@ -1,10 +1,10 @@
-import { readJSONFile } from '../../testLib';
+import { readJSONFile, getTestArgv } from '../../testLib';
 import { main } from "../../../src/main";
 
 const casetest = readJSONFile('./test/TestCases/Case06/cdk-pipeline-sdk-resolver.json');
 
 async function executeUtility() {    
-    process.argv = casetest.argv;
+    process.argv = getTestArgv(casetest);
     await main();
 }
 

--- a/test/TestCases/Case06/Case06.05.test.js
+++ b/test/TestCases/Case06/Case06.05.test.js
@@ -1,10 +1,10 @@
-import { readJSONFile } from '../../testLib';
+import { readJSONFile, getTestArgv } from '../../testLib';
 import { main } from "../../../src/main";
 
 const casetest = readJSONFile('./test/TestCases/Case06/cdk-pipeline-no-name.json');
 
 async function executeUtility() {    
-    process.argv = casetest.argv;
+    process.argv = getTestArgv(casetest);
     await main();
 }
 

--- a/test/TestCases/Case07/Case07.01.test.js
+++ b/test/TestCases/Case07/Case07.01.test.js
@@ -1,10 +1,10 @@
-import {readJSONFile} from '../../testLib';
+import {readJSONFile, getTestArgv} from '../../testLib';
 import {main} from "../../../src/main";
 
 const casetest = readJSONFile('./test/TestCases/Case07/case01.json');
 
 async function executeUtility() {
-    process.argv = casetest.argv;
+    process.argv = getTestArgv(casetest);
     await main();
 }
 

--- a/test/testLib.js
+++ b/test/testLib.js
@@ -376,6 +376,18 @@ function testApolloQueries(queryFilePath) {
     });
 }
 
+function getTestArgv(caseConfig) {
+    const argv = [...caseConfig.argv];
+    if (process.env.NEPTUNE_IAM_AUTH === 'true') {
+        if (argv.includes('--create-update-aws-pipeline') || argv.includes('-p')) {
+            argv.push('--create-update-aws-pipeline-neptune-IAM');
+        } else if (argv.includes('--output-aws-pipeline-cdk') || argv.includes('-c')) {
+            argv.push('--output-aws-pipeline-cdk-neptune-IAM');
+        }
+    }
+    return argv;
+}
+
 export {
     checkFileContains,
     checkFolderContainsFiles,
@@ -384,6 +396,7 @@ export {
     createAppSyncApiKey,
     executeAppSyncQuery,
     executeGraphQLQuery,
+    getTestArgv,
     loadResolver,
     readJSONFile,
     testApolloArtifacts,


### PR DESCRIPTION
   ### Description
  
   Integration tests for pipeline and CDK creation (Case05, Case06, Case07) fail against IAM-enabled Neptune databases because the test arguments don't include the required IAM flags. This PR introduces a shared helper and environment variable so the same test suite works against both IAM and non-IAM Neptune endpoints without changes to test configs.

   ### Changes

   - Add `getTestArgv()` helper in `testLib.js` that conditionally appends `--create-update-aws-pipeline-neptune-IAM` or `--output-aws-pipeline-cdk-neptune-IAM` when `NEPTUNE_IAM_AUTH=true` is set
   - Update 6 test files (Case05.01, Case05.04, Case06.01, Case06.03, Case06.05, Case07.01) to use `getTestArgv()` instead of raw `casetest.argv`
   - Expose `NEPTUNE_IAM_AUTH` in `.jest.js` globals
   - Document the new env var in `TESTING.md` (also fixes pre-existing numbered list formatting)

   When `NEPTUNE_IAM_AUTH` is not set, behavior is identical to before — the helper returns argv unchanged.