### PR TITLE
Fix Case08 test writing artifacts to repository root

### DIFF
--- a/test/TestCases/Case08/case02.json
+++ b/test/TestCases/Case08/case02.json
@@ -6,8 +6,8 @@
             "--output-folder-path", "./test/TestCases/Case08/case08-02-output",
             "--create-update-apollo-server",
             "--output-resolver-query-https",
-            "--output-lambda-resolver-file", "case08-02-resolver.js",
-            "--output-schema-file", "case08-02.schema.graphql"],
+            "--output-lambda-resolver-file", "./test/TestCases/Case08/case08-02-output/case08-02-resolver.js",
+            "--output-schema-file", "./test/TestCases/Case08/case08-02-output/case08-02.schema.graphql"],
     "host": "<AIR_ROUTES_DB_HOST>",
     "port": "<AIR_ROUTES_DB_PORT>"
 }


### PR DESCRIPTION
### Description

Integration tests for Case08-02 were generating `case08-02-resolver.js` and `case08-02.schema.graphql` in the repository root, polluting the working tree. Updated the test config to write output files into the test's own output directory instead, which is getting cleaned up by the test's `afterAll` hook