### PR TITLE
Update Lambda runtime to nodejs22.x and improve test reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,3 +642,5 @@ Follow AWS open source practices.
 <br>
 [Code of conduct page.](/CODE_OF_CONDUCT.md)
 <br>
+[Testing guide.](/TESTING.md)
+<br>

--- a/TESTING.md
+++ b/TESTING.md
@@ -135,6 +135,17 @@ Both test suites use JSON files containing GraphQL queries and expected results:
   that the utility was executed with option
   `--input-schema-changes-file ./test/air-routes-changes.json`
 
+## Known Test Failures
+
+Some tests are expected to fail depending on the target environment:
+
+- **Gremlin queries** fail on Neptune Analytics, which only supports openCypher.
+- **Gremlin type query** returns a different data shape through Apollo Server on Neptune DB.
+- **`_id` field queries** fail on Neptune Analytics, which uses `id` instead of `_id`.
+- **Dataset differences** between Neptune DB (Gremlin load) and Neptune Analytics (openCypher load) cause mismatches in route counts and sort order.
+- **Fragment queries** fail on AppSync, which does not support fragments.
+- **Sort with variables** fails on Apollo Server (see README Known Limitations).
+
 ## Loading Airports Sample Data Into Neptune
 
 The easiest way to load the airports sample data into Neptune is using

--- a/src/pipelineResources.js
+++ b/src/pipelineResources.js
@@ -420,7 +420,7 @@ async function createLambdaFunction() {
         FunctionName: lambdaName,
         Handler: 'index.handler',
         Role: LAMBDA_ROLE,
-        Runtime: 'nodejs18.x',
+        Runtime: 'nodejs22.x',
         Description: 'Neptune GraphQL Resolver for AppSync',
         Timeout: 15,
         MemorySize: 128,

--- a/src/test/CDKTemplate.test.js
+++ b/src/test/CDKTemplate.test.js
@@ -43,7 +43,7 @@ function evaluateTemplate({ neptuneType, neptuneIAMAuth }) {
         const lambda_role = { addManagedPolicy: (p) => managedPolicies.push(p) };
         const managedPolicies = [];
         const Duration = { seconds: (s) => s };
-        const lambda = { Code: { fromAsset: (f) => f }, Runtime: { NODEJS_18_X: 'nodejs18.x' } };
+        const lambda = { Code: { fromAsset: (f) => f }, Runtime: { NODEJS_22_X: 'nodejs22.x' } };
         const self = { parseNeptuneDomainFromHost: () => 'neptune.amazonaws.com' };
         const LAMBDA_FUNCTION_NAME = 'testFn';
         const LAMBDA_ZIP_FILE = 'test.zip';

--- a/templates/CDKTemplate.js
+++ b/templates/CDKTemplate.js
@@ -77,7 +77,7 @@ class AppSyncNeptuneStack extends Stack {
                 description: 'Neptune GraphQL Resolver for AppSync',
                 code: lambda.Code.fromAsset(LAMBDA_ZIP_FILE),
                 handler: 'index.handler',
-                runtime: lambda.Runtime.NODEJS_18_X,
+                runtime: lambda.Runtime.NODEJS_22_X,
                 timeout: Duration.seconds(15),
                 memorySize: 128,
                 environment: env,

--- a/templates/Lambda4AppSyncGraphSDK/package-lock.json
+++ b/templates/Lambda4AppSyncGraphSDK/package-lock.json
@@ -139,51 +139,51 @@
       }
     },
     "node_modules/@aws-sdk/client-neptune-graph": {
-      "version": "3.1030.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-neptune-graph/-/client-neptune-graph-3.1030.0.tgz",
-      "integrity": "sha512-IaEW8TY4bOp5cIV51m9toBTejorELUgrZ55SxAgfFQyelvPfEEUKBp/U34QJYkK3W0fs/kIbX5HKxFT1Oinzlw==",
+      "version": "3.1038.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-neptune-graph/-/client-neptune-graph-3.1038.0.tgz",
+      "integrity": "sha512-p2hGP97syv+RopfFKACrh6Q/qMa14aJGU0Lk+TQSAkYLZilNriUsnGTYPSanl5SdsmDupoGUT2xbbXXQazPjOQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/credential-provider-node": "^3.972.30",
-        "@aws-sdk/middleware-host-header": "^3.972.9",
-        "@aws-sdk/middleware-logger": "^3.972.9",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
-        "@aws-sdk/middleware-user-agent": "^3.972.29",
-        "@aws-sdk/region-config-resolver": "^3.972.11",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-endpoints": "^3.996.6",
-        "@aws-sdk/util-user-agent-browser": "^3.972.9",
-        "@aws-sdk/util-user-agent-node": "^3.973.15",
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/core": "^3.23.14",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/hash-node": "^4.2.13",
-        "@smithy/invalid-dependency": "^4.2.13",
-        "@smithy/middleware-content-length": "^4.2.13",
-        "@smithy/middleware-endpoint": "^4.4.29",
-        "@smithy/middleware-retry": "^4.5.0",
-        "@smithy/middleware-serde": "^4.2.17",
-        "@smithy/middleware-stack": "^4.2.13",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/credential-provider-node": "^3.972.37",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.45",
-        "@smithy/util-defaults-mode-node": "^4.2.49",
-        "@smithy/util-endpoints": "^3.3.4",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-retry": "^4.3.0",
-        "@smithy/util-stream": "^4.5.22",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.2.15",
+        "@smithy/util-waiter": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -191,22 +191,23 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.27.tgz",
-      "integrity": "sha512-CUZ5m8hwMCH6OYI4Li/WgMfIEx10Q2PLI9Y3XOUTPGZJ53aZ0007jCv+X/ywsaERyKPdw5MRZWk877roQksQ4A==",
+      "version": "3.974.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.6.tgz",
+      "integrity": "sha512-8Vu7zGxu+39ChR/s5J7nXBw3a2kMHAi0OfKT8ohgTVjX0qYed/8mIfdBb638oBmKrWCwwKjYAM5J/4gMJ8nAJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/xml-builder": "^3.972.17",
-        "@smithy/core": "^3.23.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/signature-v4": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.20",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.5",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -215,15 +216,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.25.tgz",
-      "integrity": "sha512-6QfI0wv4jpG5CrdO/AO0JfZ2ux+tKwJPrUwmvxXF50vI5KIypKVGNF6b4vlkYEnKumDTI1NX2zUBi8JoU5QU3A==",
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.32.tgz",
+      "integrity": "sha512-7vA4GHg8NSmQxquJHSBcSM3RgB4ZaaRi6u4+zGFKOmOH6aqlgr2Sda46clkZDYzlirgfY96w15Zj0jh6PT48ng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -231,20 +232,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.27.tgz",
-      "integrity": "sha512-3V3Usj9Gs93h865DqN4M2NWJhC5kXU9BvZskfN3+69omuYlE3TZxOEcVQtBGLOloJB7BVfJKXVLqeNhOzHqSlQ==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.34.tgz",
+      "integrity": "sha512-vBrhWujFCLp1u8ptJRWYlipMutzPptb8pDQ00rKVH9q67T7rGd3VTWIj63aKrlLuY6qSsw1Rt5F/D/7wnNgryA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-stream": "^4.5.22",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -252,24 +253,24 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.29.tgz",
-      "integrity": "sha512-SiBuAnXecCbT/OpAf3vqyI/AVE3mTaYr9ShXLybxZiPLBiPCCOIWSGAtYYGQWMRvobBTiqOewaB+wcgMMZI2Aw==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.36.tgz",
+      "integrity": "sha512-FBHyCmV8EB0gUvh1d+CZm87zt2PrdC7OyWexLRoH3I5zWSOUGa+9t58Y5jbxRfwUp3AWpHAFvKY6YzgR845sVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/credential-provider-env": "^3.972.25",
-        "@aws-sdk/credential-provider-http": "^3.972.27",
-        "@aws-sdk/credential-provider-login": "^3.972.29",
-        "@aws-sdk/credential-provider-process": "^3.972.25",
-        "@aws-sdk/credential-provider-sso": "^3.972.29",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/credential-provider-env": "^3.972.32",
+        "@aws-sdk/credential-provider-http": "^3.972.34",
+        "@aws-sdk/credential-provider-login": "^3.972.36",
+        "@aws-sdk/credential-provider-process": "^3.972.32",
+        "@aws-sdk/credential-provider-sso": "^3.972.36",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.36",
+        "@aws-sdk/nested-clients": "^3.997.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -277,18 +278,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.29.tgz",
-      "integrity": "sha512-OGOslTbOlxXexKMqhxCEbBQbUIfuhGxU5UXw3Fm56ypXHvrXH4aTt/xb5Y884LOoteP1QST1lVZzHfcTnWhiPQ==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.36.tgz",
+      "integrity": "sha512-IFap01lJKxQc0C/OHmZwZQr/cKq0DhrcmKedRrdnnl42D+P0SImnnnWQjv07uIPqpEdtqmkPXb9TiPYTU+prxQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/nested-clients": "^3.997.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -296,22 +297,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.30.tgz",
-      "integrity": "sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.37.tgz",
+      "integrity": "sha512-/WFixFAAiw8WpmjZcI0l4t3DerXLmVinOIfuotmRZnu2qmsFPoqqmstASz0z8bi1pGdFXzeLzf6bwucM3mZcUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.25",
-        "@aws-sdk/credential-provider-http": "^3.972.27",
-        "@aws-sdk/credential-provider-ini": "^3.972.29",
-        "@aws-sdk/credential-provider-process": "^3.972.25",
-        "@aws-sdk/credential-provider-sso": "^3.972.29",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/credential-provider-env": "^3.972.32",
+        "@aws-sdk/credential-provider-http": "^3.972.34",
+        "@aws-sdk/credential-provider-ini": "^3.972.36",
+        "@aws-sdk/credential-provider-process": "^3.972.32",
+        "@aws-sdk/credential-provider-sso": "^3.972.36",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.36",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -319,16 +320,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.25.tgz",
-      "integrity": "sha512-HR7ynNRdNhNsdVCOCegy1HsfsRzozCOPtD3RzzT1JouuaHobWyRfJzCBue/3jP7gECHt+kQyZUvwg/cYLWurNQ==",
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.32.tgz",
+      "integrity": "sha512-uZp4tlGbpczV8QxmtIwOpSkcyGtBRR8/T4BAumRKfAt1nwCig3FSCZvrKl6ARDIDVRYn5p2oRcAsfFR01EgMGA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -336,18 +337,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.29.tgz",
-      "integrity": "sha512-HWv4SEq3jZDYPlwryZVef97+U8CxxRos5mK8sgGO1dQaFZpV5giZLzqGE5hkDmh2csYcBO2uf5XHjPTpZcJlig==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.36.tgz",
+      "integrity": "sha512-DsLr0UHMyKzRJKe2bjlwU8q1cfoXg8TIJKV/xwvnalAemiZLOZunFzj/whGnFDZIBVLdnbLiwv5SvRf1+CSwkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/token-providers": "3.1026.0",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/nested-clients": "^3.997.4",
+        "@aws-sdk/token-providers": "3.1038.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -355,17 +356,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.29.tgz",
-      "integrity": "sha512-PdMBza1WEKEUPFEmMGCfnU2RYCz9MskU2e8JxjyUOsMKku7j9YaDKvbDi2dzC0ihFoM6ods2SbhfAAro+Gwlew==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.36.tgz",
+      "integrity": "sha512-uzrURO7frJhHQVVNR5zBJcCYeMYflmXcWBK1+MiBym2Dfjh6nXATrMixrmGZi+97Q7ETZ+y/4lUwAy0Nfnznjw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/nested-clients": "^3.997.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -373,14 +374,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.9.tgz",
-      "integrity": "sha512-je5vRdNw4SkuTnmRbFZLdye4sQ0faLt8kwka5wnnSU30q1mHO4X+idGEJOOE+Tn1ME7Oryn05xxkDvIb3UaLaQ==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -388,13 +389,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.9.tgz",
-      "integrity": "sha512-HsVgDrruhqI28RkaXALm8grJ7Agc1wF6Et0xh6pom8NdO2VdO/SD9U/tPwUjewwK/pVoka+EShBxyCvgsPCtog==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -402,15 +403,40 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.10.tgz",
-      "integrity": "sha512-RVQQbq5orQ/GHUnXvqEOj2HHPBJm+mM+ySwZKS5UaLBwra5ugRtiH09PLUoOZRl7a1YzaOzXSuGbn9iD5j60WQ==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/types": "^3.973.8",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.35.tgz",
+      "integrity": "sha512-lLppaNTAz+wNgLdi4FtHzrlwrGF0ODTnBWHBaFg85SKs0eJ+M+tP5ifrA8f/0lNd+Ak3MC1NGC6RavV3ny4HTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -418,18 +444,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.29.tgz",
-      "integrity": "sha512-f/sIRzuTfEjg6NsbMYvye2VsmnQoNgntntleQyx5uGacUYzszbfIlO3GcI6G6daWUmTm0IDZc11qMHWwF0o0mQ==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.36.tgz",
+      "integrity": "sha512-O2beToxguBvrZFFZ+fFgPbbae8MvyIBjQ6lImee4APHEXXNAD5ZJ2ayLF1mb7rsKw86TM81y5czg82bZncjSjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-endpoints": "^3.996.6",
-        "@smithy/core": "^3.23.14",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-retry": "^4.3.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-retry": "^4.3.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -437,47 +463,48 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.19.tgz",
-      "integrity": "sha512-uFkmCDXvmQYLanlYdOFS0+MQWkrj9wPMt/ZCc/0J0fjPim6F5jBVBmEomvGY/j77ILW6GTPwN22Jc174Mhkw6Q==",
+      "version": "3.997.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.4.tgz",
+      "integrity": "sha512-4Sf+WY1lMJzXlw5MiyCMe/UzdILCwvuaHThbqMXS6dfh9gZy3No360I42RXquOI/ULUOhWy2HCyU0Fp20fQGPQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/middleware-host-header": "^3.972.9",
-        "@aws-sdk/middleware-logger": "^3.972.9",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
-        "@aws-sdk/middleware-user-agent": "^3.972.29",
-        "@aws-sdk/region-config-resolver": "^3.972.11",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-endpoints": "^3.996.6",
-        "@aws-sdk/util-user-agent-browser": "^3.972.9",
-        "@aws-sdk/util-user-agent-node": "^3.973.15",
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/core": "^3.23.14",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/hash-node": "^4.2.13",
-        "@smithy/invalid-dependency": "^4.2.13",
-        "@smithy/middleware-content-length": "^4.2.13",
-        "@smithy/middleware-endpoint": "^4.4.29",
-        "@smithy/middleware-retry": "^4.5.0",
-        "@smithy/middleware-serde": "^4.2.17",
-        "@smithy/middleware-stack": "^4.2.13",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.23",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.45",
-        "@smithy/util-defaults-mode-node": "^4.2.49",
-        "@smithy/util-endpoints": "^3.3.4",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-retry": "^4.3.0",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.5",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -486,15 +513,32 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.11.tgz",
-      "integrity": "sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.23.tgz",
+      "integrity": "sha512-wBbys3Y53Ikly556vyADurKpYQHXS7Jjaskbz+Ga9PZCz7PB/9f3VdKbDlz7dqIzn+xwz7L/a6TR4iXcOi8IRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.35",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -502,17 +546,17 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1026.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1026.0.tgz",
-      "integrity": "sha512-Ieq/HiRrbEtrYP387Nes0XlR7H1pJiJOZKv+QyQzMYpvTiDs0VKy2ZB3E2Zf+aFovWmeE7lRE4lXyF7dYM6GgA==",
+      "version": "3.1038.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1038.0.tgz",
+      "integrity": "sha512-Qniru+9oGGb/HNK/gGZWbV3jsD0k71ngE7qMQ/x6gYNYLd2EOwHCS6E2E6jfkaqO4i0d+nNKmfRy8bNcshKdGQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/nested-clients": "^3.997.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -520,12 +564,24 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.7.tgz",
-      "integrity": "sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+      "license": "Apache-2.0",
+      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -533,15 +589,15 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.6.tgz",
-      "integrity": "sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg==",
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
-        "@smithy/util-endpoints": "^3.3.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -561,27 +617,27 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.9.tgz",
-      "integrity": "sha512-sn/LMzTbGjYqCCF24390WxPd6hkpoSptiUn5DzVp4cD71yqw+yGEGm1YCxyEoPXyc8qciM8UzLJcZBFslxo5Uw==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.15.tgz",
-      "integrity": "sha512-fYn3s9PtKdgQkczGZCFMgkNEe8aq1JCVbnRqjqN9RSVW43xn2RV9xdcZ3z01a48Jpkuh/xCmBKJxdLOo4Ozg7w==",
+      "version": "3.973.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.22.tgz",
+      "integrity": "sha512-YTYqTmOUrwbm1h99Ee4y/mVYpFRl0oSO/amtP5cc1BZZWdaAVWs9zj3TkyRHWvR9aI/ZS8m3mS6awXtYUlWyaw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.29",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -598,13 +654,14 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.17.tgz",
-      "integrity": "sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==",
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.21.tgz",
+      "integrity": "sha512-qxNiHUtlrsjTeSlrPWiFkWps7uD6YB4eKzg7eLAFH8jbiHTlt0ePNlo2Xu+WlftP38JIcMaIX4jTUjOlE2ySWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "fast-xml-parser": "5.5.8",
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -620,17 +677,29 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.15",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.15.tgz",
-      "integrity": "sha512-BJdMBY5YO9iHh+lPLYdHv6LbX+J8IcPCYMl1IJdBt2KDWNHwONHrPVHk3ttYBqJd9wxv84wlbN0f7GlQzcQtNQ==",
+      "version": "4.4.17",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
+      "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-endpoints": "^3.4.0",
-        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -638,18 +707,18 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.14",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.14.tgz",
-      "integrity": "sha512-vJ0IhpZxZAkFYOegMKSrxw7ujhhT2pass/1UEcZ4kfl5srTAqtPU5I7MdYQoreVas3204ykCiNhY1o7Xlz6Yyg==",
+      "version": "3.23.17",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-stream": "^4.5.22",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
@@ -659,15 +728,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.13.tgz",
-      "integrity": "sha512-wboCPijzf6RJKLOvnjDAiBxGSmSnGXj35o5ZAWKDaHa/cvQ5U3ZJ13D4tMCE8JG4dxVAZFy/P0x/V9CwwdfULQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -675,14 +744,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.16.tgz",
-      "integrity": "sha512-nYDRUIvNd4mFmuXraRWt6w5UsZTNqtj4hXJA/iiOD4tuseIdLP9Lq38teH/SZTcIFCa2f+27o7hYpIsWktJKEQ==",
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/querystring-builder": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
@@ -691,12 +760,12 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.13.tgz",
-      "integrity": "sha512-4/oy9h0jjmY80a2gOIo75iLl8TOPhmtx4E2Hz+PfMjvx/vLtGY4TMU/35WRyH2JHPfT5CVB38u4JRow7gnmzJA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-buffer-from": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -706,12 +775,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.13.tgz",
-      "integrity": "sha512-jvC0RB/8BLj2SMIkY0Npl425IdnxZJxInpZJbu563zIRnVjpDMXevU3VMCRSabaLB0kf/eFIOusdGstrLJ8IDg==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+      "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -731,13 +800,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.13.tgz",
-      "integrity": "sha512-IPMLm/LE4AZwu6qiE8Rr8vJsWhs9AtOdySRXrOM7xnvclp77Tyh7hMs/FRrMf26kgIe67vFJXXOSmVxS7oKeig==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+      "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -745,18 +814,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.29",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.29.tgz",
-      "integrity": "sha512-R9Q/58U+qBiSARGWbAbFLczECg/RmysRksX6Q8BaQEpt75I7LI6WGDZnjuC9GXSGKljEbA7N118LhGaMbfrTXw==",
+      "version": "4.4.32",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
+      "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.14",
-        "@smithy/middleware-serde": "^4.2.17",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
-        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -764,19 +833,19 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.1.tgz",
-      "integrity": "sha512-/zY+Gp7Qj2D2hVm3irkCyONER7E9MiX3cUUm/k2ZmhkzZkrPgwVS4aJ5NriZUEN/M0D1hhjrgjUmX04HhRwdWA==",
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.7.tgz",
+      "integrity": "sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/service-error-classification": "^4.2.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-retry": "^4.3.1",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
@@ -785,14 +854,14 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.17",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.17.tgz",
-      "integrity": "sha512-0T2mcaM6v9W1xku86Dk0bEW7aEseG6KenFkPK98XNw0ZhOqOiD1MrMsdnQw9QsL3/Oa85T53iSMlm0SZdSuIEQ==",
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
+      "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.14",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -800,12 +869,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.13.tgz",
-      "integrity": "sha512-g72jN/sGDLyTanrCLH9fhg3oysO3f7tQa6eWWsMyn2BiYNCgjF24n4/I9wff/5XidFvjj9ilipAoQrurTUrLvw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+      "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -813,14 +882,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.13.tgz",
-      "integrity": "sha512-iGxQ04DsKXLckbgnX4ipElrOTk+IHgTyu0q0WssZfYhDm9CQWHmu6cOeI5wmWRxpXbBDhIIfXMWz5tPEtcVqbw==",
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+      "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -828,14 +897,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.2.tgz",
-      "integrity": "sha512-/oD7u8M0oj2ZTFw7GkuuHWpIxtWdLlnyNkbrWcyVYhd5RJNDuczdkb0wfnQICyNFrVPlr8YHOhamjNy3zidhmA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
+      "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/querystring-builder": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -843,12 +912,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.13.tgz",
-      "integrity": "sha512-bGzUCthxRmezuxkbu9wD33wWg9KX3hJpCXpQ93vVkPrHn9ZW6KNNdY5xAUWNuRCwQ+VyboFuWirG1lZhhkcyRQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+      "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -856,12 +925,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
-      "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -869,12 +938,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.13.tgz",
-      "integrity": "sha512-tG4aOYFCZdPMjbgfhnIQ322H//ojujldp1SrHPHpBSb3NqgUp3dwiUGRJzie87hS1DYwWGqDuPaowoDF+rYCbQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -883,12 +952,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.13.tgz",
-      "integrity": "sha512-hqW3Q4P+CDzUyQ87GrboGMeD7XYNMOF+CuTwu936UQRB/zeYn3jys8C3w+wMkDfY7CyyyVwZQ5cNFoG0x1pYmA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+      "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -896,24 +965,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.13.tgz",
-      "integrity": "sha512-a0s8XZMfOC/qpqq7RCPvJlk93rWFrElH6O++8WJKz0FqnA4Y7fkNi/0mnGgSH1C4x6MFsuBA8VKu4zxFrMe5Vw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.1.tgz",
+      "integrity": "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0"
+        "@smithy/types": "^4.14.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.8.tgz",
-      "integrity": "sha512-VZCZx2bZasxdqxVgEAhREvDSlkatTPnkdWy1+Kiy8w7kYPBosW0V5IeDwzDUMvWBt56zpK658rx1cOBFOYaPaw==",
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+      "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -921,16 +990,16 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.13.tgz",
-      "integrity": "sha512-YpYSyM0vMDwKbHD/JA7bVOF6kToVRpa+FM5ateEVRpsTNu564g1muBlkTubXhSKKYXInhpADF46FPyrZcTLpXg==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-middleware": "^4.2.14",
         "@smithy/util-uri-escape": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -940,17 +1009,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.9.tgz",
-      "integrity": "sha512-ovaLEcTU5olSeHcRXcxV6viaKtpkHZumn6Ps0yn7dRf2rRSfy794vpjOtrWDO0d1auDSvAqxO+lyhERSXQ03EQ==",
+      "version": "4.12.13",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
+      "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.14",
-        "@smithy/middleware-endpoint": "^4.4.29",
-        "@smithy/middleware-stack": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-stream": "^4.5.22",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -958,9 +1027,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.0.tgz",
-      "integrity": "sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -970,13 +1039,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.13.tgz",
-      "integrity": "sha512-2G03yoboIRZlZze2+PT4GZEjgwQsJjUgn6iTsvxA02bVceHR6vp4Cuk7TUnPFWKF+ffNUk3kj4COwkENS2K3vw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1047,14 +1116,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.45",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.45.tgz",
-      "integrity": "sha512-ag9sWc6/nWZAuK3Wm9KlFJUnRkXLrXn33RFjIAmCTFThqLHY+7wCst10BGq56FxslsDrjhSie46c8OULS+BiIw==",
+      "version": "4.3.49",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+      "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1062,17 +1131,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.50",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.50.tgz",
-      "integrity": "sha512-xpjncL5XozFA3No7WypTsPU1du0fFS8flIyO+Wh2nhCy7bpEapvU7BR55Bg+wrfw+1cRA+8G8UsTjaxgzrMzXg==",
+      "version": "4.2.54",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+      "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.15",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1080,13 +1149,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.0.tgz",
-      "integrity": "sha512-QQHGPKkw6NPcU6TJ1rNEEa201srPtZiX4k61xL163vvs9sTqW/XKz+UEuJ00uvPqoN+5Rs4Ka1UJ7+Mp03IXJw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+      "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1106,12 +1175,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.13.tgz",
-      "integrity": "sha512-GTooyrlmRTqvUen4eK7/K1p6kryF7bnDfq6XsAbIsf2mo51B/utaH+XThY6dKgNCWzMAaH/+OLmqaBuLhLWRow==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1119,13 +1188,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.1.tgz",
-      "integrity": "sha512-FwmicpgWOkP5kZUjN3y+3JIom8NLGqSAJBeoIgK0rIToI817TEBHCrd0A2qGeKQlgDeP+Jzn4i0H/NLAXGy9uQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.6.tgz",
+      "integrity": "sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1133,14 +1202,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.22",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.22.tgz",
-      "integrity": "sha512-3H8iq/0BfQjUs2/4fbHZ9aG9yNzcuZs24LPkcX1Q7Z+qpqaGM8+qbGmE8zo9m2nCRgamyvS98cHdcWvR6YUsew==",
+      "version": "4.5.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
+      "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/types": "^4.14.0",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-buffer-from": "^4.2.2",
         "@smithy/util-hex-encoding": "^4.2.2",
@@ -1177,12 +1246,12 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "4.2.15",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.15.tgz",
-      "integrity": "sha512-oUt9o7n8hBv3BL56sLSneL0XeigZSuem0Hr78JaoK33D9oKieyCvVP8eTSe3j7g2mm/S1DvzxKieG7JEWNJUNg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.3.0.tgz",
+      "integrity": "sha512-JyjYmLAfS+pdxF92o4yLgEoy0zhayKTw73FU1aofLWwLcJw7iSqIY2exGmMTrl/lmZugP5p/zxdFSippJDfKWA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1208,9 +1277,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -1223,9 +1292,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
       "funding": [
         {
           "type": "github",
@@ -1234,18 +1303,19 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/graphql": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
-      "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==",
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"

--- a/test/TestCases/Case05/Case05.02.test.js
+++ b/test/TestCases/Case05/Case05.02.test.js
@@ -41,6 +41,7 @@ describe('Validate pipeline with http resolver output content', () => {
         const apiId = awsResources.AppSyncAPI;
         const region = awsResources.region;
         const results = await executeAppSyncQuery(apiId, 'query {getContinents {code}}', {}, region);
+        expect(results.errors).toBeUndefined();
         const codes = results.data.getContinents.map(continent => continent.code).sort();
         expect(codes).toEqual(['AF', 'AN', 'AS', 'EU', 'NA', 'OC', 'SA']);
     }, 600000);

--- a/test/TestCases/Case05/Case05.05.test.js
+++ b/test/TestCases/Case05/Case05.05.test.js
@@ -37,6 +37,7 @@ describe('Validate pipeline with prefixes content', () => {
         const apiId = awsResources.AppSyncAPI;
         const region = awsResources.region;
         const results = await executeAppSyncQuery(apiId, 'query {airportsQueryPrefix_getContinents {code}}', {}, region);
+        expect(results.errors).toBeUndefined();
         const codes = results.data.airportsQueryPrefix_getContinents.map(continent => continent.code).sort();
         expect(codes).toEqual(['AF', 'AN', 'AS', 'EU', 'NA', 'OC', 'SA']);
     }, 600000);
@@ -56,11 +57,13 @@ describe('Validate pipeline with prefixes content', () => {
         }`;
 
         const results = await executeAppSyncQuery(apiId, mutation, {}, region);
+        expect(results.errors).toBeUndefined();
         const createdCode = results.data.airportsMutationPrefix_createAirport.code;
         expect(createdCode).toBe("TEST");
 
         const deleteMutation = `mutation {airportsMutationPrefix_deleteAirport(_id: "${results.data.airportsMutationPrefix_createAirport._id}")}`;
         const deleteResults = await executeAppSyncQuery(apiId, deleteMutation, {}, region);
+        expect(deleteResults.errors).toBeUndefined();
         const deleteResult = deleteResults.data.airportsMutationPrefix_deleteAirport;
         expect(deleteResult).toBe(true);
     }, 600000);

--- a/test/TestCases/Case07/Case07.02.test.js
+++ b/test/TestCases/Case07/Case07.02.test.js
@@ -49,6 +49,7 @@ describe('Validate pipeline with sdk resolver output content', () => {
         const apiId = awsResources.AppSyncAPI;
         const region = awsResources.region;
         const results = await executeAppSyncQuery(apiId, 'query {getContinents {code}}', {}, region);
+        expect(results.errors).toBeUndefined();
         const codes = results.data.getContinents.map(continent => continent.code).sort();
         expect(codes).toEqual(['AF', 'AN', 'AS', 'EU', 'NA', 'OC', 'SA']);
     }, 600000);

--- a/test/testLib.js
+++ b/test/testLib.js
@@ -31,13 +31,14 @@ async function queryNeptune(q, language, host, port, param) {
     try {
         let response = null;
         if (language == 'opencypher')
-            response = await axios.post(`https://${host}:${port}/opencypher`, `query=${encodeURIComponent(q)}&parameters=${encodeURIComponent(JSON.stringify(param))}`);
+            response = await axios.post(`https://${host}:${port}/opencypher`, { query: q, parameters: JSON.stringify(param) });
         else             
-            response = await axios.post(`https://${host}:${port}/gremlin`, `{"gremlin":"${q}"}`)
+            response = await axios.post(`https://${host}:${port}/gremlin`, { gremlin: q })
 
         return response.data;    
     } catch (error) {
-        console.error("Http query request failed: ", error.message);            
+        console.error("Http query request failed: ", error.message);
+        throw error;
     }
 }
 
@@ -154,15 +155,21 @@ async function testResolverQueriesResults(resolverFile, queriesReferenceFolder, 
                 continue;
             }
             console.log(`Executing query: ${queryFile} ${query.graphql}`);
-            const result = resolverModule.resolveGraphDBQuery({queryObjOrStr: gql(query.graphql)});
-            const httpResult = await queryNeptune(result.query, result.language, host, port, result.parameters);
-                
             let data = null;
-            if (result.language === 'opencypher')
-                data = httpResult.results[0][Object.keys(httpResult.results[0])[0]];
-            else {
-                const input = httpResult.result.data;
-                data = JSON.parse(resolverModule.refactorGremlinqueryOutput(input, result.fieldsAlias));                                            
+            try {
+                const result = resolverModule.resolveGraphDBQuery({queryObjOrStr: gql(query.graphql)});
+                const httpResult = await queryNeptune(result.query, result.language, host, port, result.parameters);
+                if (result.language === 'opencypher')
+                    data = httpResult.results[0][Object.keys(httpResult.results[0])[0]];
+                else {
+                    const input = httpResult.result.data;
+                    data = JSON.parse(resolverModule.refactorGremlinqueryOutput(input, result.fieldsAlias));
+                }
+            } catch (queryError) {
+                test(`Resolver Neptune result, ${queryFile}: ${query.name}`, async () => {
+                    throw new Error(`Neptune query failed: ${queryError.message}`, { cause: queryError });
+                });
+                continue;
             }
 
             if (JSON.stringify(data, null, 2) !== JSON.stringify(query.result, null, 2))


### PR DESCRIPTION
### Description:

  Update Lambda runtime from nodejs18.x to nodejs22.x (Node 18 is EOL and AWS SDK v3 has dropped support for it). Applies to pipeline deployer, CDK template, and CDK test.

  Fix test error handling in `testLib.js`:

  - `queryNeptune` now throws on failure instead of silently returning undefined
  - OpenCypher and Gremlin request bodies sent as JSON objects instead of string concatenation, matching production code in `queryHttpNeptune.mjs`
  - Gremlin request body sent as JSON object instead of template string
  -  `testResolverQueriesResults` wraps both `resolveGraphDBQuery()` and Neptune HTTP calls in try/catch, catching per-query failures instead of crashing the suite

  Add `expect(results.errors).toBeUndefined()` to Case05.02, Case05.05, and Case07.02 for clearer failure reporting when Lambda returns errors.

  Regenerate `Lambda4AppSyncGraphSDK/package-lock.json` for latest AWS SDK patches.

  Document known test failures in `TESTING.md` and link it from `README.md`.