### PR TITLE
Add CHANGELOG entry, bump project version, doc updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,31 @@ permissions and limitations under the License.
 
 # amazon-neptune-for-graphql CHANGELOG
 
+## Release v2.1.0
+
+### Features
+
+* Added `addType` action in schema changes file for custom type
+  definitions ([#163](https://github.com/aws/amazon-neptune-for-graphql/pull/163))
+
+### Improvements
+
+* Upgraded Lambda runtime to
+  nodejs22.x ([#164](https://github.com/aws/amazon-neptune-for-graphql/pull/164))
+* Upgraded dependencies: AWS SDK, Axios, Apollo
+  Server ([#144](https://github.com/aws/amazon-neptune-for-graphql/pull/144), [#160](https://github.com/aws/amazon-neptune-for-graphql/pull/160), [#161](https://github.com/aws/amazon-neptune-for-graphql/pull/161))
+* Added unit tests for pipeline creation/removal, CDK generation, and
+  schema changes ([#157](https://github.com/aws/amazon-neptune-for-graphql/pull/157), [#162](https://github.com/aws/amazon-neptune-for-graphql/pull/162), [#163](https://github.com/aws/amazon-neptune-for-graphql/pull/163))
+
+### Bug Fixes
+
+* Fixed Lambda missing VPC configuration when Neptune DB is used with
+  IAM auth ([#157](https://github.com/aws/amazon-neptune-for-graphql/pull/157))
+* Fixed `remove` action prefix matching — `desc` no longer removes
+  `desc2` ([#162](https://github.com/aws/amazon-neptune-for-graphql/pull/162))
+* Fixed missing error handling for malformed
+  `--input-schema-changes-file` ([#163](https://github.com/aws/amazon-neptune-for-graphql/pull/163))
+
 ## Release v2.0.0
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <br>
 <img src="https://github.com/aws/amazon-neptune-for-graphql/blob/main/doc/images/utilityRunning.gif" width="180" height="100">
 
-# **Amazon Neptune utility for GraphQL&trade; schemas and resolvers - v2.0.0**
+# **Amazon Neptune utility for GraphQL&trade; schemas and resolvers - v2.1.0**
 
 The Amazon Neptune utility for GraphQL&trade; is a Node.js command-line utility
 to help with the creation and maintenance of a GraphQL API for the Amazon

--- a/doc/cliReference.md
+++ b/doc/cliReference.md
@@ -1,4 +1,4 @@
-# Neptune GraphQL Utility Command Line options Reference - v2.0.0
+# Neptune GraphQL Utility Command Line options Reference - v2.1.0
 
 `--help, --h, -help, -h`
 <br>
@@ -32,10 +32,19 @@ format.
 ```json
 [
   {
+    "action": "add",
     "type": "graphQLTypeName",
     "field": "graphQLFieldName",
-    "action": "remove|add",
-    "value": "value"
+    "value": "fieldDefinition"
+  },
+  {
+    "action": "remove",
+    "type": "graphQLTypeName",
+    "field": "graphQLFieldName"
+  },
+  {
+    "action": "addType",
+    "value": "type NewType { field: String }"
   }
 ]
 ```

--- a/doc/resources.md
+++ b/doc/resources.md
@@ -1,4 +1,4 @@
-# Detailed AWS Resources - v2.0.0
+# Detailed AWS Resources - v2.1.0
 
 Steps:
 
@@ -68,13 +68,13 @@ AppSync. To create the Lambda you have two options:
 1. go to the Neptune documentation
    here https://docs.aws.amazon.com/neptune/latest/userguide/get-started-cfn-lambda.html,
    can run the CloudFormation template that creates the Lambda. Lambda runtime
-   is Node.js 18x.
+   is Node.js 22.x.
    (NOTE: the Neptune CloudFormation to create the Lambda is outdated, the
    nodejs12.x is no longer supported by Lambda)
 2. go to Lambda console
     1. Create a new function, author from scratch
     2. Name the function ( you will point AppSync to this fucntion)
-    3. Runtime: Node.js 18.x
+    3. Runtime: Node.js 22.x
     4. Open Advance settings, enable VPC, and select your Neptune DB VPC,
        Subnets and Security Group.
     5. Create the function

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/neptune-for-graphql",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/neptune-for-graphql",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/neptune-for-graphql",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "CLI utility to create and maintain a GraphQL API for Amazon Neptune",
   "keywords": [
     "Amazon Neptune",

--- a/templates/ApolloServer/package-lock.json
+++ b/templates/ApolloServer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neptune-apollo-server",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neptune-apollo-server",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@apollo/server": "^5.5.0",

--- a/templates/ApolloServer/package.json
+++ b/templates/ApolloServer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neptune-apollo-server",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "",
   "license": "Apache-2.0",
   "author": "",

--- a/templates/Lambda4AppSyncGraphSDK/package-lock.json
+++ b/templates/Lambda4AppSyncGraphSDK/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lambda4appsyncgraphsdk",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lambda4appsyncgraphsdk",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-neptune-graph": "^3.1030.0",

--- a/templates/Lambda4AppSyncGraphSDK/package.json
+++ b/templates/Lambda4AppSyncGraphSDK/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda4appsyncgraphsdk",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "AWS Lambda function to bridge AppSync to Neptune Analytics",
   "main": "index.mjs",
   "type": "module",

--- a/templates/Lambda4AppSyncHTTP/package-lock.json
+++ b/templates/Lambda4AppSyncHTTP/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lambda4appsynchttp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lambda4appsynchttp",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
         "aws4-axios": "3.3.0",

--- a/templates/Lambda4AppSyncHTTP/package.json
+++ b/templates/Lambda4AppSyncHTTP/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda4appsynchttp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "AWS Lambda function to bridge AppSync to Neptune or Neptune Analytics",
   "main": "index.mjs",
   "type": "module",

--- a/templates/Lambda4AppSyncSDK/package-lock.json
+++ b/templates/Lambda4AppSyncSDK/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lambda4appsyncsdk",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lambda4appsyncsdk",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-neptunedata": "^3.1030.0",

--- a/templates/Lambda4AppSyncSDK/package.json
+++ b/templates/Lambda4AppSyncSDK/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda4appsyncsdk",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "AWS Lambda function to bridge AppSync to Neptune",
   "main": "index.mjs",
   "type": "module",


### PR DESCRIPTION
Adds the `v2.1.0` CHANGELOG entry, bumps version to `2.1.0` in all `package.json` files, and updates the version string in README.md. Also updates docs with content changes from this release:

  - `doc/cliReference.md`: added `addType` action to the `--input-schema-changes-file` format example
  - `doc/resources.md`: updated Lambda runtime from Node.js 18.x to 22.x